### PR TITLE
Fix #22 - Reject non-ending multiline comments.

### DIFF
--- a/rust/generated_parser/src/error.rs
+++ b/rust/generated_parser/src/error.rs
@@ -11,6 +11,7 @@ pub enum ParseError<'alloc> {
     InvalidEscapeSequence,
     UnterminatedString,
     UnterminatedRegExp,
+    UnterminatedMultiLineComment,
     LexerError,
 
     // Generic syntax errors
@@ -41,6 +42,7 @@ impl<'alloc> ParseError<'alloc> {
             ParseError::InvalidEscapeSequence => format!("invalid escape sequence"),
             ParseError::UnterminatedString => format!("unterminated string literal"),
             ParseError::UnterminatedRegExp => format!("unterminated regexp literal"),
+            ParseError::UnterminatedMultiLineComment => format!("unterminated multiline comment"),
             ParseError::LexerError => format!("lexical error"),
             ParseError::NotImplemented(message) => format!("not implemented: {}", message),
             ParseError::SyntaxError(token) => format!("syntax error on: {:?}", token),

--- a/rust/parser/src/lexer.rs
+++ b/rust/parser/src/lexer.rs
@@ -146,13 +146,13 @@ impl<'alloc> Lexer<'alloc> {
     /// that a SingleLineHTMLCloseComment must occur at the start of a line. We
     /// use `is_on_new_line` for that.)
     ///
-    fn skip_multi_line_comment(&mut self, builder: &mut AutoCow<'alloc>) {
+    fn skip_multi_line_comment(&mut self, builder: &mut AutoCow<'alloc>) -> Result<'alloc, ()> {
         while let Some(ch) = self.chars.next() {
             match ch {
                 '*' if self.peek() == Some('/') => {
                     self.chars.next();
                     *builder = AutoCow::new(&self);
-                    return;
+                    return Ok(());
                 }
                 CR | LF | PS | LS => {
                     self.is_on_new_line = true;
@@ -160,6 +160,7 @@ impl<'alloc> Lexer<'alloc> {
                 _ => {}
             }
         }
+        Err(ParseError::UnterminatedMultiLineComment)
     }
 
     /// Skip a *SingleLineComment* and the following *LineTerminatorSequence*,
@@ -1130,7 +1131,7 @@ impl<'alloc> Lexer<'alloc> {
                     }
                     Some('*') => {
                         self.chars.next();
-                        self.skip_multi_line_comment(&mut builder);
+                        self.skip_multi_line_comment(&mut builder)?;
                         start = self.offset();
                         continue;
                     }


### PR DESCRIPTION
Tested and works locally.
Do we have a place for adding non-parsing test cases?