### PR TITLE
Fix #44 - Return NotImplemented errors for missing initializers in lexical declarations.

### DIFF
--- a/rust/generated_parser/src/ast_builder.rs
+++ b/rust/generated_parser/src/ast_builder.rs
@@ -1627,13 +1627,24 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         kind: arena::Box<'alloc, VariableDeclarationKind>,
         declarators: arena::Box<'alloc, arena::Vec<'alloc, VariableDeclarator<'alloc>>>,
-    ) -> arena::Box<'alloc, Statement<'alloc>> {
-        self.alloc(Statement::VariableDeclarationStatement(
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
+        // 13.3.1.1 Static Semantics: Early Errors
+        // TODO: missing check for binding identifiers named `let`.
+        // TODO: missing check for duplicated let bindings.
+        if *kind == VariableDeclarationKind::Const {
+            for v in declarators.iter() {
+                if v.init == None {
+                   return Err(ParseError::NotImplemented("Missing initializer in a lexical binding."));
+                }
+            }
+        }
+
+        Ok(self.alloc(Statement::VariableDeclarationStatement(
             VariableDeclaration {
                 kind: kind.unbox(),
                 declarators: declarators.unbox(),
             },
-        ))
+        )))
     }
 
     // ForLexicalDeclaration : LetOrConst BindingList `;`
@@ -1641,13 +1652,24 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         kind: arena::Box<'alloc, VariableDeclarationKind>,
         declarators: arena::Box<'alloc, arena::Vec<'alloc, VariableDeclarator<'alloc>>>,
-    ) -> arena::Box<'alloc, VariableDeclarationOrExpression<'alloc>> {
-        self.alloc(VariableDeclarationOrExpression::VariableDeclaration(
+    ) -> Result<'alloc, arena::Box<'alloc, VariableDeclarationOrExpression<'alloc>>> {
+        // 13.3.1.1 Static Semantics: Early Errors
+        // TODO: missing check for binding identifiers named `let`.
+        // TODO: missing check for duplicated let bindings.
+        if *kind == VariableDeclarationKind::Const {
+            for v in declarators.iter() {
+                if v.init == None {
+                   return Err(ParseError::NotImplemented("Missing initializer in a lexical binding."));
+                }
+            }
+        }
+
+        Ok(self.alloc(VariableDeclarationOrExpression::VariableDeclaration(
             VariableDeclaration {
                 kind: kind.unbox(),
                 declarators: declarators.unbox(),
             },
-        ))
+        )))
     }
 
     // LetOrConst : `let`


### PR DESCRIPTION
This is probably badly handled, as we should probably be adding a new enumerated error kind, and also properly report the error location on the corresponding identifier. However, it does address the issue detected while fuzzing.

The problem encountered here, is that `LetOrConst` is not part of the `BindingList` and `LexicalDeclaration` productions, and as such checking whether we are in the `const` case of `LetOrConst` while synthesizing the `LexicalDeclaration` is not yet possible.

In this case, a proper solution would be to add variable to implement left-to-right attribute of an attribute grammar. In the current implementation left-to-right attributes are easy to implement if we restrict our-selfs to only mutate left-to-right attributes while synthesizing productions.
