### PR TITLE
Template strings part should return the matching text.

### DIFF
--- a/rust/parser/src/lexer.rs
+++ b/rust/parser/src/lexer.rs
@@ -908,10 +908,10 @@ impl<'alloc> Lexer<'alloc> {
             //   HexDigits [> but only if MV of |HexDigits| ≤ 0x10FFFF ]
             if ch == '$' && self.peek() == Some('{') {
                 self.chars.next();
-                return Ok((start, None, subst));
+                return Ok((start, Some(builder.finish(&self)), subst));
             }
             if ch == '`' {
-                return Ok((start, None, tail));
+                return Ok((start, Some(builder.finish(&self)), tail));
             }
             // TODO: Support escape sequences.
             builder.push_matching(ch);


### PR DESCRIPTION
The following test case fails while unwrapping the content of the template string.

```js
Reflect.parse(`
let a
f2()
`);
```

This patch replace the `None` result, by the content produced while iterating over the template string content, using the `builder` initialized earlier.