### PR TITLE
Consistently use loc field for all types.

### DIFF
--- a/rust/ast/src/source_location_accessor.rs
+++ b/rust/ast/src/source_location_accessor.rs
@@ -75,7 +75,7 @@ impl<'alloc> SourceLocationAccessor<'alloc> for ArrayExpressionElement<'alloc> {
         match self {
             ArrayExpressionElement::SpreadElement(content) => content.set_loc(start, end),
             ArrayExpressionElement::Expression(content) => content.set_loc(start, end),
-            ArrayExpressionElement::Elision(mut loc) => {
+            ArrayExpressionElement::Elision { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
@@ -86,7 +86,7 @@ impl<'alloc> SourceLocationAccessor<'alloc> for ArrayExpressionElement<'alloc> {
         match self {
             ArrayExpressionElement::SpreadElement(content) => content.get_loc(),
             ArrayExpressionElement::Expression(content) => content.get_loc(),
-            ArrayExpressionElement::Elision(loc) => *loc,
+            ArrayExpressionElement::Elision { loc } => *loc,
         }
     }
 }
@@ -228,107 +228,107 @@ impl<'alloc> SourceLocationAccessor<'alloc> for AssignmentTargetWithDefault<'all
 impl<'alloc> SourceLocationAccessor<'alloc> for BinaryOperator {
     fn set_loc(&mut self, start: SourceLocation, end: SourceLocation) {
         match self {
-            BinaryOperator::Equals(mut loc) => {
+            BinaryOperator::Equals { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::NotEquals(mut loc) => {
+            BinaryOperator::NotEquals { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::StrictEquals(mut loc) => {
+            BinaryOperator::StrictEquals { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::StrictNotEquals(mut loc) => {
+            BinaryOperator::StrictNotEquals { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::LessThan(mut loc) => {
+            BinaryOperator::LessThan { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::LessThanOrEqual(mut loc) => {
+            BinaryOperator::LessThanOrEqual { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::GreaterThan(mut loc) => {
+            BinaryOperator::GreaterThan { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::GreaterThanOrEqual(mut loc) => {
+            BinaryOperator::GreaterThanOrEqual { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::In(mut loc) => {
+            BinaryOperator::In { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::Instanceof(mut loc) => {
+            BinaryOperator::Instanceof { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::LeftShift(mut loc) => {
+            BinaryOperator::LeftShift { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::RightShift(mut loc) => {
+            BinaryOperator::RightShift { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::RightShiftExt(mut loc) => {
+            BinaryOperator::RightShiftExt { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::Add(mut loc) => {
+            BinaryOperator::Add { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::Sub(mut loc) => {
+            BinaryOperator::Sub { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::Mul(mut loc) => {
+            BinaryOperator::Mul { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::Div(mut loc) => {
+            BinaryOperator::Div { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::Mod(mut loc) => {
+            BinaryOperator::Mod { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::Pow(mut loc) => {
+            BinaryOperator::Pow { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::Comma(mut loc) => {
+            BinaryOperator::Comma { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::Coalesce(mut loc) => {
+            BinaryOperator::Coalesce { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::LogicalOr(mut loc) => {
+            BinaryOperator::LogicalOr { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::LogicalAnd(mut loc) => {
+            BinaryOperator::LogicalAnd { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::BitwiseOr(mut loc) => {
+            BinaryOperator::BitwiseOr { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::BitwiseXor(mut loc) => {
+            BinaryOperator::BitwiseXor { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            BinaryOperator::BitwiseAnd(mut loc) => {
+            BinaryOperator::BitwiseAnd { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
@@ -337,32 +337,32 @@ impl<'alloc> SourceLocationAccessor<'alloc> for BinaryOperator {
 
     fn get_loc(&self) -> SourceLocation {
         match self {
-            BinaryOperator::Equals(loc) => *loc,
-            BinaryOperator::NotEquals(loc) => *loc,
-            BinaryOperator::StrictEquals(loc) => *loc,
-            BinaryOperator::StrictNotEquals(loc) => *loc,
-            BinaryOperator::LessThan(loc) => *loc,
-            BinaryOperator::LessThanOrEqual(loc) => *loc,
-            BinaryOperator::GreaterThan(loc) => *loc,
-            BinaryOperator::GreaterThanOrEqual(loc) => *loc,
-            BinaryOperator::In(loc) => *loc,
-            BinaryOperator::Instanceof(loc) => *loc,
-            BinaryOperator::LeftShift(loc) => *loc,
-            BinaryOperator::RightShift(loc) => *loc,
-            BinaryOperator::RightShiftExt(loc) => *loc,
-            BinaryOperator::Add(loc) => *loc,
-            BinaryOperator::Sub(loc) => *loc,
-            BinaryOperator::Mul(loc) => *loc,
-            BinaryOperator::Div(loc) => *loc,
-            BinaryOperator::Mod(loc) => *loc,
-            BinaryOperator::Pow(loc) => *loc,
-            BinaryOperator::Comma(loc) => *loc,
-            BinaryOperator::Coalesce(loc) => *loc,
-            BinaryOperator::LogicalOr(loc) => *loc,
-            BinaryOperator::LogicalAnd(loc) => *loc,
-            BinaryOperator::BitwiseOr(loc) => *loc,
-            BinaryOperator::BitwiseXor(loc) => *loc,
-            BinaryOperator::BitwiseAnd(loc) => *loc,
+            BinaryOperator::Equals { loc } => *loc,
+            BinaryOperator::NotEquals { loc } => *loc,
+            BinaryOperator::StrictEquals { loc } => *loc,
+            BinaryOperator::StrictNotEquals { loc } => *loc,
+            BinaryOperator::LessThan { loc } => *loc,
+            BinaryOperator::LessThanOrEqual { loc } => *loc,
+            BinaryOperator::GreaterThan { loc } => *loc,
+            BinaryOperator::GreaterThanOrEqual { loc } => *loc,
+            BinaryOperator::In { loc } => *loc,
+            BinaryOperator::Instanceof { loc } => *loc,
+            BinaryOperator::LeftShift { loc } => *loc,
+            BinaryOperator::RightShift { loc } => *loc,
+            BinaryOperator::RightShiftExt { loc } => *loc,
+            BinaryOperator::Add { loc } => *loc,
+            BinaryOperator::Sub { loc } => *loc,
+            BinaryOperator::Mul { loc } => *loc,
+            BinaryOperator::Div { loc } => *loc,
+            BinaryOperator::Mod { loc } => *loc,
+            BinaryOperator::Pow { loc } => *loc,
+            BinaryOperator::Comma { loc } => *loc,
+            BinaryOperator::Coalesce { loc } => *loc,
+            BinaryOperator::LogicalOr { loc } => *loc,
+            BinaryOperator::LogicalAnd { loc } => *loc,
+            BinaryOperator::BitwiseOr { loc } => *loc,
+            BinaryOperator::BitwiseXor { loc } => *loc,
+            BinaryOperator::BitwiseAnd { loc } => *loc,
         }
     }
 }
@@ -517,51 +517,51 @@ impl<'alloc> SourceLocationAccessor<'alloc> for ClassExpression<'alloc> {
 impl<'alloc> SourceLocationAccessor<'alloc> for CompoundAssignmentOperator {
     fn set_loc(&mut self, start: SourceLocation, end: SourceLocation) {
         match self {
-            CompoundAssignmentOperator::Add(mut loc) => {
+            CompoundAssignmentOperator::Add { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            CompoundAssignmentOperator::Sub(mut loc) => {
+            CompoundAssignmentOperator::Sub { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            CompoundAssignmentOperator::Mul(mut loc) => {
+            CompoundAssignmentOperator::Mul { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            CompoundAssignmentOperator::Div(mut loc) => {
+            CompoundAssignmentOperator::Div { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            CompoundAssignmentOperator::Mod(mut loc) => {
+            CompoundAssignmentOperator::Mod { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            CompoundAssignmentOperator::Pow(mut loc) => {
+            CompoundAssignmentOperator::Pow { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            CompoundAssignmentOperator::LeftShift(mut loc) => {
+            CompoundAssignmentOperator::LeftShift { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            CompoundAssignmentOperator::RightShift(mut loc) => {
+            CompoundAssignmentOperator::RightShift { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            CompoundAssignmentOperator::RightShiftExt(mut loc) => {
+            CompoundAssignmentOperator::RightShiftExt { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            CompoundAssignmentOperator::Or(mut loc) => {
+            CompoundAssignmentOperator::Or { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            CompoundAssignmentOperator::Xor(mut loc) => {
+            CompoundAssignmentOperator::Xor { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            CompoundAssignmentOperator::And(mut loc) => {
+            CompoundAssignmentOperator::And { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
@@ -570,18 +570,18 @@ impl<'alloc> SourceLocationAccessor<'alloc> for CompoundAssignmentOperator {
 
     fn get_loc(&self) -> SourceLocation {
         match self {
-            CompoundAssignmentOperator::Add(loc) => *loc,
-            CompoundAssignmentOperator::Sub(loc) => *loc,
-            CompoundAssignmentOperator::Mul(loc) => *loc,
-            CompoundAssignmentOperator::Div(loc) => *loc,
-            CompoundAssignmentOperator::Mod(loc) => *loc,
-            CompoundAssignmentOperator::Pow(loc) => *loc,
-            CompoundAssignmentOperator::LeftShift(loc) => *loc,
-            CompoundAssignmentOperator::RightShift(loc) => *loc,
-            CompoundAssignmentOperator::RightShiftExt(loc) => *loc,
-            CompoundAssignmentOperator::Or(loc) => *loc,
-            CompoundAssignmentOperator::Xor(loc) => *loc,
-            CompoundAssignmentOperator::And(loc) => *loc,
+            CompoundAssignmentOperator::Add { loc } => *loc,
+            CompoundAssignmentOperator::Sub { loc } => *loc,
+            CompoundAssignmentOperator::Mul { loc } => *loc,
+            CompoundAssignmentOperator::Div { loc } => *loc,
+            CompoundAssignmentOperator::Mod { loc } => *loc,
+            CompoundAssignmentOperator::Pow { loc } => *loc,
+            CompoundAssignmentOperator::LeftShift { loc } => *loc,
+            CompoundAssignmentOperator::RightShift { loc } => *loc,
+            CompoundAssignmentOperator::RightShiftExt { loc } => *loc,
+            CompoundAssignmentOperator::Or { loc } => *loc,
+            CompoundAssignmentOperator::Xor { loc } => *loc,
+            CompoundAssignmentOperator::And { loc } => *loc,
         }
     }
 }
@@ -782,11 +782,11 @@ impl<'alloc> SourceLocationAccessor<'alloc> for Expression<'alloc> {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            Expression::LiteralInfinityExpression(mut loc) => {
+            Expression::LiteralInfinityExpression { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            Expression::LiteralNullExpression(mut loc) => {
+            Expression::LiteralNullExpression { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
@@ -833,7 +833,7 @@ impl<'alloc> SourceLocationAccessor<'alloc> for Expression<'alloc> {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            Expression::NewTargetExpression(mut loc) => {
+            Expression::NewTargetExpression { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
@@ -843,7 +843,7 @@ impl<'alloc> SourceLocationAccessor<'alloc> for Expression<'alloc> {
                 loc.end = end.end;
             }
             Expression::TemplateExpression(content) => content.set_loc(start, end),
-            Expression::ThisExpression(mut loc) => {
+            Expression::ThisExpression { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
@@ -875,8 +875,8 @@ impl<'alloc> SourceLocationAccessor<'alloc> for Expression<'alloc> {
             Expression::MemberExpression(content) => content.get_loc(),
             Expression::ClassExpression(content) => content.get_loc(),
             Expression::LiteralBooleanExpression { loc, .. } => *loc,
-            Expression::LiteralInfinityExpression(loc) => *loc,
-            Expression::LiteralNullExpression(loc) => *loc,
+            Expression::LiteralInfinityExpression { loc } => *loc,
+            Expression::LiteralNullExpression { loc } => *loc,
             Expression::LiteralNumericExpression { loc, .. } => *loc,
             Expression::LiteralRegExpExpression { loc, .. } => *loc,
             Expression::LiteralStringExpression { loc, .. } => *loc,
@@ -890,11 +890,11 @@ impl<'alloc> SourceLocationAccessor<'alloc> for Expression<'alloc> {
             Expression::FunctionExpression(content) => content.get_loc(),
             Expression::IdentifierExpression(content) => content.get_loc(),
             Expression::NewExpression { loc, .. } => *loc,
-            Expression::NewTargetExpression(loc) => *loc,
+            Expression::NewTargetExpression { loc } => *loc,
             Expression::ObjectExpression(content) => content.get_loc(),
             Expression::UnaryExpression { loc, .. } => *loc,
             Expression::TemplateExpression(content) => content.get_loc(),
-            Expression::ThisExpression(loc) => *loc,
+            Expression::ThisExpression { loc } => *loc,
             Expression::UpdateExpression { loc, .. } => *loc,
             Expression::YieldExpression { loc, .. } => *loc,
             Expression::YieldGeneratorExpression { loc, .. } => *loc,
@@ -908,7 +908,7 @@ impl<'alloc> SourceLocationAccessor<'alloc> for ExpressionOrSuper<'alloc> {
     fn set_loc(&mut self, start: SourceLocation, end: SourceLocation) {
         match self {
             ExpressionOrSuper::Expression(content) => content.set_loc(start, end),
-            ExpressionOrSuper::Super(mut loc) => {
+            ExpressionOrSuper::Super { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
@@ -918,7 +918,7 @@ impl<'alloc> SourceLocationAccessor<'alloc> for ExpressionOrSuper<'alloc> {
     fn get_loc(&self) -> SourceLocation {
         match self {
             ExpressionOrSuper::Expression(content) => content.get_loc(),
-            ExpressionOrSuper::Super(loc) => *loc,
+            ExpressionOrSuper::Super { loc } => *loc,
         }
     }
 }
@@ -1335,7 +1335,7 @@ impl<'alloc> SourceLocationAccessor<'alloc> for Statement<'alloc> {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            Statement::DebuggerStatement(mut loc) => {
+            Statement::DebuggerStatement { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
@@ -1343,7 +1343,7 @@ impl<'alloc> SourceLocationAccessor<'alloc> for Statement<'alloc> {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            Statement::EmptyStatement(mut loc) => {
+            Statement::EmptyStatement { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
@@ -1411,9 +1411,9 @@ impl<'alloc> SourceLocationAccessor<'alloc> for Statement<'alloc> {
             Statement::BlockStatement { loc, .. } => *loc,
             Statement::BreakStatement { loc, .. } => *loc,
             Statement::ContinueStatement { loc, .. } => *loc,
-            Statement::DebuggerStatement(loc) => *loc,
+            Statement::DebuggerStatement { loc } => *loc,
             Statement::DoWhileStatement { loc, .. } => *loc,
-            Statement::EmptyStatement(loc) => *loc,
+            Statement::EmptyStatement { loc } => *loc,
             Statement::ExpressionStatement(content) => content.get_loc(),
             Statement::ForInStatement { loc, .. } => *loc,
             Statement::ForOfStatement { loc, .. } => *loc,
@@ -1531,31 +1531,31 @@ impl<'alloc> SourceLocationAccessor<'alloc> for TemplateExpressionElement<'alloc
 impl<'alloc> SourceLocationAccessor<'alloc> for UnaryOperator {
     fn set_loc(&mut self, start: SourceLocation, end: SourceLocation) {
         match self {
-            UnaryOperator::Plus(mut loc) => {
+            UnaryOperator::Plus { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            UnaryOperator::Minus(mut loc) => {
+            UnaryOperator::Minus { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            UnaryOperator::LogicalNot(mut loc) => {
+            UnaryOperator::LogicalNot { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            UnaryOperator::BitwiseNot(mut loc) => {
+            UnaryOperator::BitwiseNot { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            UnaryOperator::Typeof(mut loc) => {
+            UnaryOperator::Typeof { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            UnaryOperator::Void(mut loc) => {
+            UnaryOperator::Void { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            UnaryOperator::Delete(mut loc) => {
+            UnaryOperator::Delete { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
@@ -1564,13 +1564,13 @@ impl<'alloc> SourceLocationAccessor<'alloc> for UnaryOperator {
 
     fn get_loc(&self) -> SourceLocation {
         match self {
-            UnaryOperator::Plus(loc) => *loc,
-            UnaryOperator::Minus(loc) => *loc,
-            UnaryOperator::LogicalNot(loc) => *loc,
-            UnaryOperator::BitwiseNot(loc) => *loc,
-            UnaryOperator::Typeof(loc) => *loc,
-            UnaryOperator::Void(loc) => *loc,
-            UnaryOperator::Delete(loc) => *loc,
+            UnaryOperator::Plus { loc } => *loc,
+            UnaryOperator::Minus { loc } => *loc,
+            UnaryOperator::LogicalNot { loc } => *loc,
+            UnaryOperator::BitwiseNot { loc } => *loc,
+            UnaryOperator::Typeof { loc } => *loc,
+            UnaryOperator::Void { loc } => *loc,
+            UnaryOperator::Delete { loc } => *loc,
         }
     }
 }
@@ -1578,11 +1578,11 @@ impl<'alloc> SourceLocationAccessor<'alloc> for UnaryOperator {
 impl<'alloc> SourceLocationAccessor<'alloc> for UpdateOperator {
     fn set_loc(&mut self, start: SourceLocation, end: SourceLocation) {
         match self {
-            UpdateOperator::Increment(mut loc) => {
+            UpdateOperator::Increment { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            UpdateOperator::Decrement(mut loc) => {
+            UpdateOperator::Decrement { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
@@ -1591,8 +1591,8 @@ impl<'alloc> SourceLocationAccessor<'alloc> for UpdateOperator {
 
     fn get_loc(&self) -> SourceLocation {
         match self {
-            UpdateOperator::Increment(loc) => *loc,
-            UpdateOperator::Decrement(loc) => *loc,
+            UpdateOperator::Increment { loc } => *loc,
+            UpdateOperator::Decrement { loc } => *loc,
         }
     }
 }
@@ -1611,15 +1611,15 @@ impl<'alloc> SourceLocationAccessor<'alloc> for VariableDeclaration<'alloc> {
 impl<'alloc> SourceLocationAccessor<'alloc> for VariableDeclarationKind {
     fn set_loc(&mut self, start: SourceLocation, end: SourceLocation) {
         match self {
-            VariableDeclarationKind::Var(mut loc) => {
+            VariableDeclarationKind::Var { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            VariableDeclarationKind::Let(mut loc) => {
+            VariableDeclarationKind::Let { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            VariableDeclarationKind::Const(mut loc) => {
+            VariableDeclarationKind::Const { mut loc } => {
                 loc.start = start.start;
                 loc.end = end.end;
             }
@@ -1628,9 +1628,9 @@ impl<'alloc> SourceLocationAccessor<'alloc> for VariableDeclarationKind {
 
     fn get_loc(&self) -> SourceLocation {
         match self {
-            VariableDeclarationKind::Var(loc) => *loc,
-            VariableDeclarationKind::Let(loc) => *loc,
-            VariableDeclarationKind::Const(loc) => *loc,
+            VariableDeclarationKind::Var { loc } => *loc,
+            VariableDeclarationKind::Let { loc } => *loc,
+            VariableDeclarationKind::Const { loc } => *loc,
         }
     }
 }

--- a/rust/ast/src/types.rs
+++ b/rust/ast/src/types.rs
@@ -38,72 +38,72 @@ pub struct Label<'alloc> {
 
 #[derive(Debug, PartialEq)]
 pub enum VariableDeclarationKind {
-    Var(SourceLocation),
-    Let(SourceLocation),
-    Const(SourceLocation),
+    Var { loc: SourceLocation },
+    Let { loc: SourceLocation },
+    Const { loc: SourceLocation },
 }
 
 #[derive(Debug, PartialEq)]
 pub enum CompoundAssignmentOperator {
-    Add(SourceLocation),
-    Sub(SourceLocation),
-    Mul(SourceLocation),
-    Div(SourceLocation),
-    Mod(SourceLocation),
-    Pow(SourceLocation),
-    LeftShift(SourceLocation),
-    RightShift(SourceLocation),
-    RightShiftExt(SourceLocation),
-    Or(SourceLocation),
-    Xor(SourceLocation),
-    And(SourceLocation),
+    Add { loc: SourceLocation },
+    Sub { loc: SourceLocation },
+    Mul { loc: SourceLocation },
+    Div { loc: SourceLocation },
+    Mod { loc: SourceLocation },
+    Pow { loc: SourceLocation },
+    LeftShift { loc: SourceLocation },
+    RightShift { loc: SourceLocation },
+    RightShiftExt { loc: SourceLocation },
+    Or { loc: SourceLocation },
+    Xor { loc: SourceLocation },
+    And { loc: SourceLocation },
 }
 
 #[derive(Debug, PartialEq)]
 pub enum BinaryOperator {
-    Equals(SourceLocation),
-    NotEquals(SourceLocation),
-    StrictEquals(SourceLocation),
-    StrictNotEquals(SourceLocation),
-    LessThan(SourceLocation),
-    LessThanOrEqual(SourceLocation),
-    GreaterThan(SourceLocation),
-    GreaterThanOrEqual(SourceLocation),
-    In(SourceLocation),
-    Instanceof(SourceLocation),
-    LeftShift(SourceLocation),
-    RightShift(SourceLocation),
-    RightShiftExt(SourceLocation),
-    Add(SourceLocation),
-    Sub(SourceLocation),
-    Mul(SourceLocation),
-    Div(SourceLocation),
-    Mod(SourceLocation),
-    Pow(SourceLocation),
-    Comma(SourceLocation),
-    Coalesce(SourceLocation),
-    LogicalOr(SourceLocation),
-    LogicalAnd(SourceLocation),
-    BitwiseOr(SourceLocation),
-    BitwiseXor(SourceLocation),
-    BitwiseAnd(SourceLocation),
+    Equals { loc: SourceLocation },
+    NotEquals { loc: SourceLocation },
+    StrictEquals { loc: SourceLocation },
+    StrictNotEquals { loc: SourceLocation },
+    LessThan { loc: SourceLocation },
+    LessThanOrEqual { loc: SourceLocation },
+    GreaterThan { loc: SourceLocation },
+    GreaterThanOrEqual { loc: SourceLocation },
+    In { loc: SourceLocation },
+    Instanceof { loc: SourceLocation },
+    LeftShift { loc: SourceLocation },
+    RightShift { loc: SourceLocation },
+    RightShiftExt { loc: SourceLocation },
+    Add { loc: SourceLocation },
+    Sub { loc: SourceLocation },
+    Mul { loc: SourceLocation },
+    Div { loc: SourceLocation },
+    Mod { loc: SourceLocation },
+    Pow { loc: SourceLocation },
+    Comma { loc: SourceLocation },
+    Coalesce { loc: SourceLocation },
+    LogicalOr { loc: SourceLocation },
+    LogicalAnd { loc: SourceLocation },
+    BitwiseOr { loc: SourceLocation },
+    BitwiseXor { loc: SourceLocation },
+    BitwiseAnd { loc: SourceLocation },
 }
 
 #[derive(Debug, PartialEq)]
 pub enum UnaryOperator {
-    Plus(SourceLocation),
-    Minus(SourceLocation),
-    LogicalNot(SourceLocation),
-    BitwiseNot(SourceLocation),
-    Typeof(SourceLocation),
-    Void(SourceLocation),
-    Delete(SourceLocation),
+    Plus { loc: SourceLocation },
+    Minus { loc: SourceLocation },
+    LogicalNot { loc: SourceLocation },
+    BitwiseNot { loc: SourceLocation },
+    Typeof { loc: SourceLocation },
+    Void { loc: SourceLocation },
+    Delete { loc: SourceLocation },
 }
 
 #[derive(Debug, PartialEq)]
 pub enum UpdateOperator {
-    Increment(SourceLocation),
-    Decrement(SourceLocation),
+    Increment { loc: SourceLocation },
+    Decrement { loc: SourceLocation },
 }
 
 #[derive(Debug, PartialEq)]
@@ -136,13 +136,17 @@ pub enum Statement<'alloc> {
         label: Option<Label<'alloc>>,
         loc: SourceLocation,
     },
-    DebuggerStatement(SourceLocation),
+    DebuggerStatement {
+        loc: SourceLocation,
+    },
     DoWhileStatement {
         block: arena::Box<'alloc, Statement<'alloc>>,
         test: arena::Box<'alloc, Expression<'alloc>>,
         loc: SourceLocation,
     },
-    EmptyStatement(SourceLocation),
+    EmptyStatement {
+        loc: SourceLocation,
+    },
     ExpressionStatement(arena::Box<'alloc, Expression<'alloc>>),
     ForInStatement {
         left: VariableDeclarationOrAssignmentTarget<'alloc>,
@@ -228,8 +232,12 @@ pub enum Expression<'alloc> {
         value: bool,
         loc: SourceLocation,
     },
-    LiteralInfinityExpression(SourceLocation),
-    LiteralNullExpression(SourceLocation),
+    LiteralInfinityExpression {
+        loc: SourceLocation,
+    },
+    LiteralNullExpression {
+        loc: SourceLocation,
+    },
     LiteralNumericExpression {
         value: f64,
         loc: SourceLocation,
@@ -289,7 +297,9 @@ pub enum Expression<'alloc> {
         arguments: Arguments<'alloc>,
         loc: SourceLocation,
     },
-    NewTargetExpression(SourceLocation),
+    NewTargetExpression {
+        loc: SourceLocation,
+    },
     ObjectExpression(ObjectExpression<'alloc>),
     UnaryExpression {
         operator: UnaryOperator,
@@ -297,7 +307,9 @@ pub enum Expression<'alloc> {
         loc: SourceLocation,
     },
     TemplateExpression(TemplateExpression<'alloc>),
-    ThisExpression(SourceLocation),
+    ThisExpression {
+        loc: SourceLocation,
+    },
     UpdateExpression {
         is_prefix: bool,
         operator: UpdateOperator,
@@ -433,7 +445,7 @@ pub struct AssignmentTargetIdentifier<'alloc> {
 #[derive(Debug, PartialEq)]
 pub enum ExpressionOrSuper<'alloc> {
     Expression(arena::Box<'alloc, Expression<'alloc>>),
-    Super(SourceLocation),
+    Super { loc: SourceLocation },
 }
 
 #[derive(Debug, PartialEq)]
@@ -698,7 +710,7 @@ pub struct StaticPropertyName<'alloc> {
 pub enum ArrayExpressionElement<'alloc> {
     SpreadElement(arena::Box<'alloc, Expression<'alloc>>),
     Expression(arena::Box<'alloc, Expression<'alloc>>),
-    Elision(SourceLocation),
+    Elision { loc: SourceLocation },
 }
 
 #[derive(Debug, PartialEq)]

--- a/rust/ast/src/visit.rs
+++ b/rust/ast/src/visit.rs
@@ -35,76 +35,76 @@ pub trait Pass<'alloc> {
 
     fn visit_variable_declaration_kind(&mut self, ast: &mut VariableDeclarationKind) {
         match ast {
-            VariableDeclarationKind::Var(_) => (),
-            VariableDeclarationKind::Let(_) => (),
-            VariableDeclarationKind::Const(_) => (),
+            VariableDeclarationKind::Var { .. } => (),
+            VariableDeclarationKind::Let { .. } => (),
+            VariableDeclarationKind::Const { .. } => (),
         }
     }
 
     fn visit_compound_assignment_operator(&mut self, ast: &mut CompoundAssignmentOperator) {
         match ast {
-            CompoundAssignmentOperator::Add(_) => (),
-            CompoundAssignmentOperator::Sub(_) => (),
-            CompoundAssignmentOperator::Mul(_) => (),
-            CompoundAssignmentOperator::Div(_) => (),
-            CompoundAssignmentOperator::Mod(_) => (),
-            CompoundAssignmentOperator::Pow(_) => (),
-            CompoundAssignmentOperator::LeftShift(_) => (),
-            CompoundAssignmentOperator::RightShift(_) => (),
-            CompoundAssignmentOperator::RightShiftExt(_) => (),
-            CompoundAssignmentOperator::Or(_) => (),
-            CompoundAssignmentOperator::Xor(_) => (),
-            CompoundAssignmentOperator::And(_) => (),
+            CompoundAssignmentOperator::Add { .. } => (),
+            CompoundAssignmentOperator::Sub { .. } => (),
+            CompoundAssignmentOperator::Mul { .. } => (),
+            CompoundAssignmentOperator::Div { .. } => (),
+            CompoundAssignmentOperator::Mod { .. } => (),
+            CompoundAssignmentOperator::Pow { .. } => (),
+            CompoundAssignmentOperator::LeftShift { .. } => (),
+            CompoundAssignmentOperator::RightShift { .. } => (),
+            CompoundAssignmentOperator::RightShiftExt { .. } => (),
+            CompoundAssignmentOperator::Or { .. } => (),
+            CompoundAssignmentOperator::Xor { .. } => (),
+            CompoundAssignmentOperator::And { .. } => (),
         }
     }
 
     fn visit_binary_operator(&mut self, ast: &mut BinaryOperator) {
         match ast {
-            BinaryOperator::Equals(_) => (),
-            BinaryOperator::NotEquals(_) => (),
-            BinaryOperator::StrictEquals(_) => (),
-            BinaryOperator::StrictNotEquals(_) => (),
-            BinaryOperator::LessThan(_) => (),
-            BinaryOperator::LessThanOrEqual(_) => (),
-            BinaryOperator::GreaterThan(_) => (),
-            BinaryOperator::GreaterThanOrEqual(_) => (),
-            BinaryOperator::In(_) => (),
-            BinaryOperator::Instanceof(_) => (),
-            BinaryOperator::LeftShift(_) => (),
-            BinaryOperator::RightShift(_) => (),
-            BinaryOperator::RightShiftExt(_) => (),
-            BinaryOperator::Add(_) => (),
-            BinaryOperator::Sub(_) => (),
-            BinaryOperator::Mul(_) => (),
-            BinaryOperator::Div(_) => (),
-            BinaryOperator::Mod(_) => (),
-            BinaryOperator::Pow(_) => (),
-            BinaryOperator::Comma(_) => (),
-            BinaryOperator::Coalesce(_) => (),
-            BinaryOperator::LogicalOr(_) => (),
-            BinaryOperator::LogicalAnd(_) => (),
-            BinaryOperator::BitwiseOr(_) => (),
-            BinaryOperator::BitwiseXor(_) => (),
-            BinaryOperator::BitwiseAnd(_) => (),
+            BinaryOperator::Equals { .. } => (),
+            BinaryOperator::NotEquals { .. } => (),
+            BinaryOperator::StrictEquals { .. } => (),
+            BinaryOperator::StrictNotEquals { .. } => (),
+            BinaryOperator::LessThan { .. } => (),
+            BinaryOperator::LessThanOrEqual { .. } => (),
+            BinaryOperator::GreaterThan { .. } => (),
+            BinaryOperator::GreaterThanOrEqual { .. } => (),
+            BinaryOperator::In { .. } => (),
+            BinaryOperator::Instanceof { .. } => (),
+            BinaryOperator::LeftShift { .. } => (),
+            BinaryOperator::RightShift { .. } => (),
+            BinaryOperator::RightShiftExt { .. } => (),
+            BinaryOperator::Add { .. } => (),
+            BinaryOperator::Sub { .. } => (),
+            BinaryOperator::Mul { .. } => (),
+            BinaryOperator::Div { .. } => (),
+            BinaryOperator::Mod { .. } => (),
+            BinaryOperator::Pow { .. } => (),
+            BinaryOperator::Comma { .. } => (),
+            BinaryOperator::Coalesce { .. } => (),
+            BinaryOperator::LogicalOr { .. } => (),
+            BinaryOperator::LogicalAnd { .. } => (),
+            BinaryOperator::BitwiseOr { .. } => (),
+            BinaryOperator::BitwiseXor { .. } => (),
+            BinaryOperator::BitwiseAnd { .. } => (),
         }
     }
 
     fn visit_unary_operator(&mut self, ast: &mut UnaryOperator) {
         match ast {
-            UnaryOperator::Plus(_) => (),
-            UnaryOperator::Minus(_) => (),
-            UnaryOperator::LogicalNot(_) => (),
-            UnaryOperator::BitwiseNot(_) => (),
-            UnaryOperator::Typeof(_) => (),
-            UnaryOperator::Void(_) => (),
-            UnaryOperator::Delete(_) => (),
+            UnaryOperator::Plus { .. } => (),
+            UnaryOperator::Minus { .. } => (),
+            UnaryOperator::LogicalNot { .. } => (),
+            UnaryOperator::BitwiseNot { .. } => (),
+            UnaryOperator::Typeof { .. } => (),
+            UnaryOperator::Void { .. } => (),
+            UnaryOperator::Delete { .. } => (),
         }
     }
 
     fn visit_update_operator(&mut self, ast: &mut UpdateOperator) {
         match ast {
-            UpdateOperator::Increment(_) => (),
-            UpdateOperator::Decrement(_) => (),
+            UpdateOperator::Increment { .. } => (),
+            UpdateOperator::Decrement { .. } => (),
         }
     }
 
@@ -142,12 +142,12 @@ pub trait Pass<'alloc> {
                     self.visit_label(item);
                 }
             }
-            Statement::DebuggerStatement(_) => (),
+            Statement::DebuggerStatement { .. } => (),
             Statement::DoWhileStatement { block, test, .. } => {
                 self.visit_statement(block);
                 self.visit_expression(test);
             }
-            Statement::EmptyStatement(_) => (),
+            Statement::EmptyStatement { .. } => (),
             Statement::ExpressionStatement(ast) => {
                 self.visit_expression(ast);
             }
@@ -280,8 +280,8 @@ pub trait Pass<'alloc> {
                 self.visit_class_expression(ast);
             }
             Expression::LiteralBooleanExpression { value, .. } => {}
-            Expression::LiteralInfinityExpression(_) => (),
-            Expression::LiteralNullExpression(_) => (),
+            Expression::LiteralInfinityExpression { .. } => (),
+            Expression::LiteralNullExpression { .. } => (),
             Expression::LiteralNumericExpression { value, .. } => {}
             Expression::LiteralRegExpExpression {
                 pattern,
@@ -361,7 +361,7 @@ pub trait Pass<'alloc> {
                 self.visit_expression(callee);
                 self.visit_arguments(arguments);
             }
-            Expression::NewTargetExpression(_) => (),
+            Expression::NewTargetExpression { .. } => (),
             Expression::ObjectExpression(ast) => {
                 self.visit_object_expression(ast);
             }
@@ -374,7 +374,7 @@ pub trait Pass<'alloc> {
             Expression::TemplateExpression(ast) => {
                 self.visit_template_expression(ast);
             }
-            Expression::ThisExpression(_) => (),
+            Expression::ThisExpression { .. } => (),
             Expression::UpdateExpression {
                 is_prefix,
                 operator,
@@ -588,7 +588,7 @@ pub trait Pass<'alloc> {
             ExpressionOrSuper::Expression(ast) => {
                 self.visit_expression(ast);
             }
-            ExpressionOrSuper::Super(_) => (),
+            ExpressionOrSuper::Super { .. } => (),
         }
     }
 
@@ -901,7 +901,7 @@ pub trait Pass<'alloc> {
             ArrayExpressionElement::Expression(ast) => {
                 self.visit_expression(ast);
             }
-            ArrayExpressionElement::Elision(_) => (),
+            ArrayExpressionElement::Elision { .. } => (),
         }
     }
 
@@ -2070,9 +2070,9 @@ impl<'alloc, T: PostfixPass<'alloc>> PostfixPassVisitor<'alloc, T> {
         ast: &mut VariableDeclarationKind,
     ) -> T::Value {
         match ast {
-            VariableDeclarationKind::Var(_) => T::Value::default(),
-            VariableDeclarationKind::Let(_) => T::Value::default(),
-            VariableDeclarationKind::Const(_) => T::Value::default(),
+            VariableDeclarationKind::Var { .. } => T::Value::default(),
+            VariableDeclarationKind::Let { .. } => T::Value::default(),
+            VariableDeclarationKind::Const { .. } => T::Value::default(),
         }
     }
 
@@ -2081,68 +2081,68 @@ impl<'alloc, T: PostfixPass<'alloc>> PostfixPassVisitor<'alloc, T> {
         ast: &mut CompoundAssignmentOperator,
     ) -> T::Value {
         match ast {
-            CompoundAssignmentOperator::Add(_) => T::Value::default(),
-            CompoundAssignmentOperator::Sub(_) => T::Value::default(),
-            CompoundAssignmentOperator::Mul(_) => T::Value::default(),
-            CompoundAssignmentOperator::Div(_) => T::Value::default(),
-            CompoundAssignmentOperator::Mod(_) => T::Value::default(),
-            CompoundAssignmentOperator::Pow(_) => T::Value::default(),
-            CompoundAssignmentOperator::LeftShift(_) => T::Value::default(),
-            CompoundAssignmentOperator::RightShift(_) => T::Value::default(),
-            CompoundAssignmentOperator::RightShiftExt(_) => T::Value::default(),
-            CompoundAssignmentOperator::Or(_) => T::Value::default(),
-            CompoundAssignmentOperator::Xor(_) => T::Value::default(),
-            CompoundAssignmentOperator::And(_) => T::Value::default(),
+            CompoundAssignmentOperator::Add { .. } => T::Value::default(),
+            CompoundAssignmentOperator::Sub { .. } => T::Value::default(),
+            CompoundAssignmentOperator::Mul { .. } => T::Value::default(),
+            CompoundAssignmentOperator::Div { .. } => T::Value::default(),
+            CompoundAssignmentOperator::Mod { .. } => T::Value::default(),
+            CompoundAssignmentOperator::Pow { .. } => T::Value::default(),
+            CompoundAssignmentOperator::LeftShift { .. } => T::Value::default(),
+            CompoundAssignmentOperator::RightShift { .. } => T::Value::default(),
+            CompoundAssignmentOperator::RightShiftExt { .. } => T::Value::default(),
+            CompoundAssignmentOperator::Or { .. } => T::Value::default(),
+            CompoundAssignmentOperator::Xor { .. } => T::Value::default(),
+            CompoundAssignmentOperator::And { .. } => T::Value::default(),
         }
     }
 
     pub fn visit_binary_operator(&mut self, ast: &mut BinaryOperator) -> T::Value {
         match ast {
-            BinaryOperator::Equals(_) => T::Value::default(),
-            BinaryOperator::NotEquals(_) => T::Value::default(),
-            BinaryOperator::StrictEquals(_) => T::Value::default(),
-            BinaryOperator::StrictNotEquals(_) => T::Value::default(),
-            BinaryOperator::LessThan(_) => T::Value::default(),
-            BinaryOperator::LessThanOrEqual(_) => T::Value::default(),
-            BinaryOperator::GreaterThan(_) => T::Value::default(),
-            BinaryOperator::GreaterThanOrEqual(_) => T::Value::default(),
-            BinaryOperator::In(_) => T::Value::default(),
-            BinaryOperator::Instanceof(_) => T::Value::default(),
-            BinaryOperator::LeftShift(_) => T::Value::default(),
-            BinaryOperator::RightShift(_) => T::Value::default(),
-            BinaryOperator::RightShiftExt(_) => T::Value::default(),
-            BinaryOperator::Add(_) => T::Value::default(),
-            BinaryOperator::Sub(_) => T::Value::default(),
-            BinaryOperator::Mul(_) => T::Value::default(),
-            BinaryOperator::Div(_) => T::Value::default(),
-            BinaryOperator::Mod(_) => T::Value::default(),
-            BinaryOperator::Pow(_) => T::Value::default(),
-            BinaryOperator::Comma(_) => T::Value::default(),
-            BinaryOperator::Coalesce(_) => T::Value::default(),
-            BinaryOperator::LogicalOr(_) => T::Value::default(),
-            BinaryOperator::LogicalAnd(_) => T::Value::default(),
-            BinaryOperator::BitwiseOr(_) => T::Value::default(),
-            BinaryOperator::BitwiseXor(_) => T::Value::default(),
-            BinaryOperator::BitwiseAnd(_) => T::Value::default(),
+            BinaryOperator::Equals { .. } => T::Value::default(),
+            BinaryOperator::NotEquals { .. } => T::Value::default(),
+            BinaryOperator::StrictEquals { .. } => T::Value::default(),
+            BinaryOperator::StrictNotEquals { .. } => T::Value::default(),
+            BinaryOperator::LessThan { .. } => T::Value::default(),
+            BinaryOperator::LessThanOrEqual { .. } => T::Value::default(),
+            BinaryOperator::GreaterThan { .. } => T::Value::default(),
+            BinaryOperator::GreaterThanOrEqual { .. } => T::Value::default(),
+            BinaryOperator::In { .. } => T::Value::default(),
+            BinaryOperator::Instanceof { .. } => T::Value::default(),
+            BinaryOperator::LeftShift { .. } => T::Value::default(),
+            BinaryOperator::RightShift { .. } => T::Value::default(),
+            BinaryOperator::RightShiftExt { .. } => T::Value::default(),
+            BinaryOperator::Add { .. } => T::Value::default(),
+            BinaryOperator::Sub { .. } => T::Value::default(),
+            BinaryOperator::Mul { .. } => T::Value::default(),
+            BinaryOperator::Div { .. } => T::Value::default(),
+            BinaryOperator::Mod { .. } => T::Value::default(),
+            BinaryOperator::Pow { .. } => T::Value::default(),
+            BinaryOperator::Comma { .. } => T::Value::default(),
+            BinaryOperator::Coalesce { .. } => T::Value::default(),
+            BinaryOperator::LogicalOr { .. } => T::Value::default(),
+            BinaryOperator::LogicalAnd { .. } => T::Value::default(),
+            BinaryOperator::BitwiseOr { .. } => T::Value::default(),
+            BinaryOperator::BitwiseXor { .. } => T::Value::default(),
+            BinaryOperator::BitwiseAnd { .. } => T::Value::default(),
         }
     }
 
     pub fn visit_unary_operator(&mut self, ast: &mut UnaryOperator) -> T::Value {
         match ast {
-            UnaryOperator::Plus(_) => T::Value::default(),
-            UnaryOperator::Minus(_) => T::Value::default(),
-            UnaryOperator::LogicalNot(_) => T::Value::default(),
-            UnaryOperator::BitwiseNot(_) => T::Value::default(),
-            UnaryOperator::Typeof(_) => T::Value::default(),
-            UnaryOperator::Void(_) => T::Value::default(),
-            UnaryOperator::Delete(_) => T::Value::default(),
+            UnaryOperator::Plus { .. } => T::Value::default(),
+            UnaryOperator::Minus { .. } => T::Value::default(),
+            UnaryOperator::LogicalNot { .. } => T::Value::default(),
+            UnaryOperator::BitwiseNot { .. } => T::Value::default(),
+            UnaryOperator::Typeof { .. } => T::Value::default(),
+            UnaryOperator::Void { .. } => T::Value::default(),
+            UnaryOperator::Delete { .. } => T::Value::default(),
         }
     }
 
     pub fn visit_update_operator(&mut self, ast: &mut UpdateOperator) -> T::Value {
         match ast {
-            UpdateOperator::Increment(_) => T::Value::default(),
-            UpdateOperator::Decrement(_) => T::Value::default(),
+            UpdateOperator::Increment { .. } => T::Value::default(),
+            UpdateOperator::Decrement { .. } => T::Value::default(),
         }
     }
 
@@ -2178,13 +2178,13 @@ impl<'alloc, T: PostfixPass<'alloc>> PostfixPassVisitor<'alloc, T> {
                 let a0 = (label).as_mut().map(|item| self.visit_label(item));
                 self.pass.visit_continue_statement(a0)
             }
-            Statement::DebuggerStatement(_) => T::Value::default(),
+            Statement::DebuggerStatement { .. } => T::Value::default(),
             Statement::DoWhileStatement { block, test, .. } => {
                 let a0 = self.visit_statement((block));
                 let a1 = self.visit_expression((test));
                 self.pass.visit_do_while_statement(a0, a1)
             }
-            Statement::EmptyStatement(_) => T::Value::default(),
+            Statement::EmptyStatement { .. } => T::Value::default(),
             Statement::ExpressionStatement(ast) => self.visit_expression(ast),
             Statement::ForInStatement {
                 left, right, block, ..
@@ -2327,8 +2327,8 @@ impl<'alloc, T: PostfixPass<'alloc>> PostfixPassVisitor<'alloc, T> {
                 let a0 = value;
                 self.pass.visit_literal_boolean_expression(a0)
             }
-            Expression::LiteralInfinityExpression(_) => T::Value::default(),
-            Expression::LiteralNullExpression(_) => T::Value::default(),
+            Expression::LiteralInfinityExpression { .. } => T::Value::default(),
+            Expression::LiteralNullExpression { .. } => T::Value::default(),
             Expression::LiteralNumericExpression { value, .. } => {
                 let a0 = value;
                 self.pass.visit_literal_numeric_expression(a0)
@@ -2425,7 +2425,7 @@ impl<'alloc, T: PostfixPass<'alloc>> PostfixPassVisitor<'alloc, T> {
                 let a1 = self.visit_arguments((arguments));
                 self.pass.visit_new_expression(a0, a1)
             }
-            Expression::NewTargetExpression(_) => T::Value::default(),
+            Expression::NewTargetExpression { .. } => T::Value::default(),
             Expression::ObjectExpression(ast) => self.visit_object_expression(ast),
             Expression::UnaryExpression {
                 operator, operand, ..
@@ -2435,7 +2435,7 @@ impl<'alloc, T: PostfixPass<'alloc>> PostfixPassVisitor<'alloc, T> {
                 self.pass.visit_unary_expression(a0, a1)
             }
             Expression::TemplateExpression(ast) => self.visit_template_expression(ast),
-            Expression::ThisExpression(_) => T::Value::default(),
+            Expression::ThisExpression { .. } => T::Value::default(),
             Expression::UpdateExpression {
                 is_prefix,
                 operator,
@@ -2620,7 +2620,7 @@ impl<'alloc, T: PostfixPass<'alloc>> PostfixPassVisitor<'alloc, T> {
     pub fn visit_expression_or_super(&mut self, ast: &mut ExpressionOrSuper<'alloc>) -> T::Value {
         match ast {
             ExpressionOrSuper::Expression(ast) => self.visit_expression(ast),
-            ExpressionOrSuper::Super(_) => T::Value::default(),
+            ExpressionOrSuper::Super { .. } => T::Value::default(),
         }
     }
 
@@ -3036,7 +3036,7 @@ impl<'alloc, T: PostfixPass<'alloc>> PostfixPassVisitor<'alloc, T> {
         match ast {
             ArrayExpressionElement::SpreadElement(ast) => self.visit_expression(ast),
             ArrayExpressionElement::Expression(ast) => self.visit_expression(ast),
-            ArrayExpressionElement::Elision(_) => T::Value::default(),
+            ArrayExpressionElement::Elision { .. } => T::Value::default(),
         }
     }
 

--- a/rust/emitter/src/ast_emitter.rs
+++ b/rust/emitter/src/ast_emitter.rs
@@ -50,13 +50,13 @@ impl AstEmitter {
             Statement::ContinueStatement { .. } => {
                 return Err(EmitError::NotImplemented("TODO: ContinueStatement"));
             }
-            Statement::DebuggerStatement(_) => {
+            Statement::DebuggerStatement { .. } => {
                 return Err(EmitError::NotImplemented("TODO: DebuggerStatement"));
             }
             Statement::DoWhileStatement { .. } => {
                 return Err(EmitError::NotImplemented("TODO: DoWhileStatement"));
             }
-            Statement::EmptyStatement(_) => (),
+            Statement::EmptyStatement { .. } => (),
             Statement::ExpressionStatement(ast) => {
                 self.emit_expression(ast)?;
                 self.emit.set_rval();
@@ -113,9 +113,9 @@ impl AstEmitter {
 
     fn emit_variable_declaration(&mut self, ast: &VariableDeclaration) -> Result<(), EmitError> {
         match ast.kind {
-            VariableDeclarationKind::Var(_) => (),
-            VariableDeclarationKind::Let(_) => (),
-            VariableDeclarationKind::Const(_) => (),
+            VariableDeclarationKind::Var { .. } => (),
+            VariableDeclarationKind::Let { .. } => (),
+            VariableDeclarationKind::Const { .. } => (),
         }
         for declarator in &ast.declarators {
             let _ = match &declarator.binding {
@@ -174,7 +174,7 @@ impl AstEmitter {
 
             Expression::MemberExpression(MemberExpression::ComputedMemberExpression(
                 ComputedMemberExpression {
-                    object: ExpressionOrSuper::Super(_),
+                    object: ExpressionOrSuper::Super { .. },
                     expression,
                     ..
                 },
@@ -199,7 +199,7 @@ impl AstEmitter {
 
             Expression::MemberExpression(MemberExpression::StaticMemberExpression(
                 StaticMemberExpression {
-                    object: ExpressionOrSuper::Super(_),
+                    object: ExpressionOrSuper::Super { .. },
                     property,
                     ..
                 },
@@ -218,11 +218,11 @@ impl AstEmitter {
                 self.emit.emit_boolean(*value);
             }
 
-            Expression::LiteralInfinityExpression(_) => {
+            Expression::LiteralInfinityExpression { .. } => {
                 self.emit.double(std::f64::INFINITY);
             }
 
-            Expression::LiteralNullExpression(_) => {
+            Expression::LiteralNullExpression { .. } => {
                 self.emit.null();
             }
 
@@ -287,7 +287,7 @@ impl AstEmitter {
                 return Err(EmitError::NotImplemented("TODO: NewExpression"));
             }
 
-            Expression::NewTargetExpression(_) => {
+            Expression::NewTargetExpression { .. } => {
                 return Err(EmitError::NotImplemented("TODO: NewTargetExpression"));
             }
 
@@ -299,15 +299,15 @@ impl AstEmitter {
                 operator, operand, ..
             } => {
                 let opcode = match operator {
-                    UnaryOperator::Plus(_) => Opcode::Pos,
-                    UnaryOperator::Minus(_) => Opcode::Neg,
-                    UnaryOperator::LogicalNot(_) => Opcode::Not,
-                    UnaryOperator::BitwiseNot(_) => Opcode::BitNot,
-                    UnaryOperator::Void(_) => Opcode::Void,
-                    UnaryOperator::Typeof(_) => {
+                    UnaryOperator::Plus { .. } => Opcode::Pos,
+                    UnaryOperator::Minus { .. } => Opcode::Neg,
+                    UnaryOperator::LogicalNot { .. } => Opcode::Not,
+                    UnaryOperator::BitwiseNot { .. } => Opcode::BitNot,
+                    UnaryOperator::Void { .. } => Opcode::Void,
+                    UnaryOperator::Typeof { .. } => {
                         return Err(EmitError::NotImplemented("TODO: Typeof"));
                     }
-                    UnaryOperator::Delete(_) => {
+                    UnaryOperator::Delete { .. } => {
                         return Err(EmitError::NotImplemented("TODO: Delete"));
                     }
                 };
@@ -319,7 +319,7 @@ impl AstEmitter {
                 return Err(EmitError::NotImplemented("TODO: TemplateExpression"));
             }
 
-            Expression::ThisExpression(_) => {
+            Expression::ThisExpression { .. } => {
                 self.emit_this()?;
             }
 
@@ -354,38 +354,38 @@ impl AstEmitter {
         right: &Expression,
     ) -> Result<(), EmitError> {
         let opcode = match operator {
-            BinaryOperator::Equals(_) => Opcode::Eq,
-            BinaryOperator::NotEquals(_) => Opcode::Ne,
-            BinaryOperator::StrictEquals(_) => Opcode::StrictEq,
-            BinaryOperator::StrictNotEquals(_) => Opcode::StrictNe,
-            BinaryOperator::LessThan(_) => Opcode::Lt,
-            BinaryOperator::LessThanOrEqual(_) => Opcode::Le,
-            BinaryOperator::GreaterThan(_) => Opcode::Gt,
-            BinaryOperator::GreaterThanOrEqual(_) => Opcode::Ge,
-            BinaryOperator::In(_) => Opcode::In,
-            BinaryOperator::Instanceof(_) => Opcode::Instanceof,
-            BinaryOperator::LeftShift(_) => Opcode::Lsh,
-            BinaryOperator::RightShift(_) => Opcode::Rsh,
-            BinaryOperator::RightShiftExt(_) => Opcode::Ursh,
-            BinaryOperator::Add(_) => Opcode::Add,
-            BinaryOperator::Sub(_) => Opcode::Sub,
-            BinaryOperator::Mul(_) => Opcode::Mul,
-            BinaryOperator::Div(_) => Opcode::Div,
-            BinaryOperator::Mod(_) => Opcode::Mod,
-            BinaryOperator::Pow(_) => Opcode::Pow,
-            BinaryOperator::BitwiseOr(_) => Opcode::BitOr,
-            BinaryOperator::BitwiseXor(_) => Opcode::BitXor,
-            BinaryOperator::BitwiseAnd(_) => Opcode::BitAnd,
-            BinaryOperator::Coalesce(_) => {
+            BinaryOperator::Equals { .. } => Opcode::Eq,
+            BinaryOperator::NotEquals { .. } => Opcode::Ne,
+            BinaryOperator::StrictEquals { .. } => Opcode::StrictEq,
+            BinaryOperator::StrictNotEquals { .. } => Opcode::StrictNe,
+            BinaryOperator::LessThan { .. } => Opcode::Lt,
+            BinaryOperator::LessThanOrEqual { .. } => Opcode::Le,
+            BinaryOperator::GreaterThan { .. } => Opcode::Gt,
+            BinaryOperator::GreaterThanOrEqual { .. } => Opcode::Ge,
+            BinaryOperator::In { .. } => Opcode::In,
+            BinaryOperator::Instanceof { .. } => Opcode::Instanceof,
+            BinaryOperator::LeftShift { .. } => Opcode::Lsh,
+            BinaryOperator::RightShift { .. } => Opcode::Rsh,
+            BinaryOperator::RightShiftExt { .. } => Opcode::Ursh,
+            BinaryOperator::Add { .. } => Opcode::Add,
+            BinaryOperator::Sub { .. } => Opcode::Sub,
+            BinaryOperator::Mul { .. } => Opcode::Mul,
+            BinaryOperator::Div { .. } => Opcode::Div,
+            BinaryOperator::Mod { .. } => Opcode::Mod,
+            BinaryOperator::Pow { .. } => Opcode::Pow,
+            BinaryOperator::BitwiseOr { .. } => Opcode::BitOr,
+            BinaryOperator::BitwiseXor { .. } => Opcode::BitXor,
+            BinaryOperator::BitwiseAnd { .. } => Opcode::BitAnd,
+            BinaryOperator::Coalesce { .. } => {
                 return Err(EmitError::NotImplemented("TODO: Coalescer"));
             }
-            BinaryOperator::LogicalOr(_) => {
+            BinaryOperator::LogicalOr { .. } => {
                 return Err(EmitError::NotImplemented("TODO: LogicalOr"));
             }
-            BinaryOperator::LogicalAnd(_) => {
+            BinaryOperator::LogicalAnd { .. } => {
                 return Err(EmitError::NotImplemented("TODO: LogicalAndr"));
             }
-            BinaryOperator::Comma(_) => {
+            BinaryOperator::Comma { .. } => {
                 self.emit_expression(left)?;
                 self.emit.pop();
                 self.emit_expression(right)?;
@@ -427,7 +427,7 @@ impl AstEmitter {
         // depends on how you're using the super
         match callee {
             ExpressionOrSuper::Expression(ast) => self.emit_expression(ast)?,
-            ExpressionOrSuper::Super(_) => {
+            ExpressionOrSuper::Super { .. } => {
                 return Err(EmitError::NotImplemented("TODO: Super"));
             }
         }

--- a/rust/emitter/src/emitter.rs
+++ b/rust/emitter/src/emitter.rs
@@ -107,8 +107,10 @@ impl InstructionWriter {
     }
 
     fn emit_op_common(&mut self, opcode: Opcode, nuses: usize) {
-        assert!(self.stack_depth >= nuses as usize,
-                "InstructionWriter misuse! Not enough arguments on the stack.");
+        assert!(
+            self.stack_depth >= nuses as usize,
+            "InstructionWriter misuse! Not enough arguments on the stack."
+        );
         self.stack_depth -= nuses as usize;
 
         let ndefs = opcode.ndefs();
@@ -393,7 +395,7 @@ impl InstructionWriter {
     pub fn call_prop(&mut self, name: &str) {
         self.emit_with_name_index(Opcode::CallProp, name);
     }
-    
+
     pub fn get_elem(&mut self) {
         self.emit1(Opcode::GetElem);
     }

--- a/rust/emitter/src/opcode.rs
+++ b/rust/emitter/src/opcode.rs
@@ -348,7 +348,6 @@ const JOF_CODE_OFFSET: u32 = 23;
 /// mask for above immediate types
 const JOF_TYPEMASK: u32 = 0x001f;
 
-
 /// name operation
 const JOF_NAME: u32 = 1 << 5;
 
@@ -360,7 +359,6 @@ const JOF_ELEM: u32 = 3 << 5;
 
 // /// mask for above addressing modes
 // const JOF_MODEMASK: u32 = 3 << 5;
-
 
 /// property/element/name set operation
 const JOF_PROPSET: u32 = 1 << 7;
@@ -388,9 +386,6 @@ const JOF_TYPESET: u32 = 1 << 14;
 
 /// baseline may use an IC for this op
 const JOF_IC: u32 = 1 << 15;
-
-
-
 
 impl Opcode {
     /// Return the numeric bytecode value for this opcode, as understood by the

--- a/rust/generated_parser/src/ast_builder.rs
+++ b/rust/generated_parser/src/ast_builder.rs
@@ -111,7 +111,7 @@ impl<'alloc> AstBuilder<'alloc> {
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> arena::Box<'alloc, Expression<'alloc>> {
         let loc = token.loc;
-        self.alloc(Expression::ThisExpression(loc))
+        self.alloc(Expression::ThisExpression { loc })
     }
 
     // PrimaryExpression : IdentifierReference
@@ -462,7 +462,7 @@ impl<'alloc> AstBuilder<'alloc> {
                 ArrayExpressionElement::SpreadElement(_expr) =>
                     // ([...a, b]) => {}
                     Err(ParseError::ArrayPatternWithNonFinalRest),
-                ArrayExpressionElement::Elision(_) => Ok(None),
+                ArrayExpressionElement::Elision { .. } => Ok(None),
             }))
     }
 
@@ -558,7 +558,7 @@ impl<'alloc> AstBuilder<'alloc> {
         //         `(` UniqueFormalParameters[?Yield, ?Await] `)`
         match expression.unbox() {
             Expression::BinaryExpression {
-                operator: BinaryOperator::Comma(_),
+                operator: BinaryOperator::Comma { .. },
                 left,
                 right,
                 ..
@@ -626,7 +626,7 @@ impl<'alloc> AstBuilder<'alloc> {
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> arena::Box<'alloc, Expression<'alloc>> {
         let loc = token.loc;
-        self.alloc(Expression::LiteralNullExpression(loc))
+        self.alloc(Expression::LiteralNullExpression { loc })
     }
 
     // Literal : BooleanLiteral
@@ -803,7 +803,7 @@ impl<'alloc> AstBuilder<'alloc> {
     ) -> arena::Box<'alloc, ArrayExpression<'alloc>> {
         let loc = token.loc;
         self.alloc(ArrayExpression {
-            elements: self.new_vec_single(ArrayExpressionElement::Elision(loc)),
+            elements: self.new_vec_single(ArrayExpressionElement::Elision { loc }),
             // This will be overwritten once the enclosing array gets parsed.
             loc: SourceLocation::default(),
         })
@@ -816,7 +816,7 @@ impl<'alloc> AstBuilder<'alloc> {
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> arena::Box<'alloc, ArrayExpression<'alloc>> {
         let loc = token.loc;
-        self.push(&mut array.elements, ArrayExpressionElement::Elision(loc));
+        self.push(&mut array.elements, ArrayExpressionElement::Elision { loc });
         array
     }
 
@@ -1130,7 +1130,7 @@ impl<'alloc> AstBuilder<'alloc> {
         let super_loc = super_token.loc;
         self.alloc(Expression::MemberExpression(
             MemberExpression::ComputedMemberExpression(ComputedMemberExpression {
-                object: ExpressionOrSuper::Super(super_loc),
+                object: ExpressionOrSuper::Super { loc: super_loc },
                 expression: expression,
                 loc: SourceLocation::from_parts(super_loc, close_token.loc),
             }),
@@ -1147,7 +1147,7 @@ impl<'alloc> AstBuilder<'alloc> {
         let identifier_loc = identifier_token.loc;
         self.alloc(Expression::MemberExpression(
             MemberExpression::StaticMemberExpression(StaticMemberExpression {
-                object: ExpressionOrSuper::Super(super_loc),
+                object: ExpressionOrSuper::Super { loc: super_loc },
                 property: self.identifier_name(identifier_token),
                 loc: SourceLocation::from_parts(super_loc, identifier_loc),
             }),
@@ -1160,10 +1160,9 @@ impl<'alloc> AstBuilder<'alloc> {
         new_token: arena::Box<'alloc, Token<'alloc>>,
         target_token: arena::Box<'alloc, Token<'alloc>>,
     ) -> arena::Box<'alloc, Expression<'alloc>> {
-        return self.alloc(Expression::NewTargetExpression(SourceLocation::from_parts(
-            new_token.loc,
-            target_token.loc,
-        )));
+        return self.alloc(Expression::NewTargetExpression {
+            loc: SourceLocation::from_parts(new_token.loc, target_token.loc),
+        });
     }
 
     // NewExpression : `new` NewExpression
@@ -1209,7 +1208,7 @@ impl<'alloc> AstBuilder<'alloc> {
         let super_loc = super_token.loc;
         let arguments_loc = arguments.loc;
         self.alloc(Expression::CallExpression {
-            callee: ExpressionOrSuper::Super(super_loc),
+            callee: ExpressionOrSuper::Super { loc: super_loc },
             arguments: arguments.unbox(),
             loc: SourceLocation::from_parts(super_loc, arguments_loc),
         })
@@ -1306,7 +1305,9 @@ impl<'alloc> AstBuilder<'alloc> {
         let operand_loc = operand.get_loc();
         Ok(self.alloc(Expression::UpdateExpression {
             is_prefix: false,
-            operator: UpdateOperator::Increment(operator_token.loc),
+            operator: UpdateOperator::Increment {
+                loc: operator_token.loc,
+            },
             operand,
             loc: SourceLocation::from_parts(operand_loc, operator_token.loc),
         }))
@@ -1322,7 +1323,9 @@ impl<'alloc> AstBuilder<'alloc> {
         let operand_loc = operand.get_loc();
         Ok(self.alloc(Expression::UpdateExpression {
             is_prefix: false,
-            operator: UpdateOperator::Decrement(operator_token.loc),
+            operator: UpdateOperator::Decrement {
+                loc: operator_token.loc,
+            },
             operand,
             loc: SourceLocation::from_parts(operand_loc, operator_token.loc),
         }))
@@ -1338,7 +1341,9 @@ impl<'alloc> AstBuilder<'alloc> {
         let operand_loc = operand.get_loc();
         Ok(self.alloc(Expression::UpdateExpression {
             is_prefix: true,
-            operator: UpdateOperator::Increment(operator_token.loc),
+            operator: UpdateOperator::Increment {
+                loc: operator_token.loc,
+            },
             operand,
             loc: SourceLocation::from_parts(operator_token.loc, operand_loc),
         }))
@@ -1354,7 +1359,9 @@ impl<'alloc> AstBuilder<'alloc> {
         let operand_loc = operand.get_loc();
         Ok(self.alloc(Expression::UpdateExpression {
             is_prefix: true,
-            operator: UpdateOperator::Decrement(operator_token.loc),
+            operator: UpdateOperator::Decrement {
+                loc: operator_token.loc,
+            },
             operand,
             loc: SourceLocation::from_parts(operator_token.loc, operand_loc),
         }))
@@ -1368,7 +1375,9 @@ impl<'alloc> AstBuilder<'alloc> {
     ) -> arena::Box<'alloc, Expression<'alloc>> {
         let operand_loc = operand.get_loc();
         self.alloc(Expression::UnaryExpression {
-            operator: UnaryOperator::Delete(operator_token.loc),
+            operator: UnaryOperator::Delete {
+                loc: operator_token.loc,
+            },
             operand,
             loc: SourceLocation::from_parts(operator_token.loc, operand_loc),
         })
@@ -1382,7 +1391,9 @@ impl<'alloc> AstBuilder<'alloc> {
     ) -> arena::Box<'alloc, Expression<'alloc>> {
         let operand_loc = operand.get_loc();
         self.alloc(Expression::UnaryExpression {
-            operator: UnaryOperator::Void(operator_token.loc),
+            operator: UnaryOperator::Void {
+                loc: operator_token.loc,
+            },
             operand,
             loc: SourceLocation::from_parts(operator_token.loc, operand_loc),
         })
@@ -1396,7 +1407,9 @@ impl<'alloc> AstBuilder<'alloc> {
     ) -> arena::Box<'alloc, Expression<'alloc>> {
         let operand_loc = operand.get_loc();
         self.alloc(Expression::UnaryExpression {
-            operator: UnaryOperator::Typeof(operator_token.loc),
+            operator: UnaryOperator::Typeof {
+                loc: operator_token.loc,
+            },
             operand,
             loc: SourceLocation::from_parts(operator_token.loc, operand_loc),
         })
@@ -1410,7 +1423,9 @@ impl<'alloc> AstBuilder<'alloc> {
     ) -> arena::Box<'alloc, Expression<'alloc>> {
         let operand_loc = operand.get_loc();
         self.alloc(Expression::UnaryExpression {
-            operator: UnaryOperator::Plus(operator_token.loc),
+            operator: UnaryOperator::Plus {
+                loc: operator_token.loc,
+            },
             operand,
             loc: SourceLocation::from_parts(operator_token.loc, operand_loc),
         })
@@ -1424,7 +1439,9 @@ impl<'alloc> AstBuilder<'alloc> {
     ) -> arena::Box<'alloc, Expression<'alloc>> {
         let operand_loc = operand.get_loc();
         self.alloc(Expression::UnaryExpression {
-            operator: UnaryOperator::Minus(operator_token.loc),
+            operator: UnaryOperator::Minus {
+                loc: operator_token.loc,
+            },
             operand,
             loc: SourceLocation::from_parts(operator_token.loc, operand_loc),
         })
@@ -1438,7 +1455,9 @@ impl<'alloc> AstBuilder<'alloc> {
     ) -> arena::Box<'alloc, Expression<'alloc>> {
         let operand_loc = operand.get_loc();
         self.alloc(Expression::UnaryExpression {
-            operator: UnaryOperator::BitwiseNot(operator_token.loc),
+            operator: UnaryOperator::BitwiseNot {
+                loc: operator_token.loc,
+            },
             operand,
             loc: SourceLocation::from_parts(operator_token.loc, operand_loc),
         })
@@ -1452,95 +1471,97 @@ impl<'alloc> AstBuilder<'alloc> {
     ) -> arena::Box<'alloc, Expression<'alloc>> {
         let operand_loc = operand.get_loc();
         self.alloc(Expression::UnaryExpression {
-            operator: UnaryOperator::LogicalNot(operator_token.loc),
+            operator: UnaryOperator::LogicalNot {
+                loc: operator_token.loc,
+            },
             operand,
             loc: SourceLocation::from_parts(operator_token.loc, operand_loc),
         })
     }
 
     pub fn equals_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::Equals(token.loc)
+        BinaryOperator::Equals { loc: token.loc }
     }
     pub fn not_equals_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::NotEquals(token.loc)
+        BinaryOperator::NotEquals { loc: token.loc }
     }
     pub fn strict_equals_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::StrictEquals(token.loc)
+        BinaryOperator::StrictEquals { loc: token.loc }
     }
     pub fn strict_not_equals_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::StrictNotEquals(token.loc)
+        BinaryOperator::StrictNotEquals { loc: token.loc }
     }
     pub fn less_than_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::LessThan(token.loc)
+        BinaryOperator::LessThan { loc: token.loc }
     }
     pub fn less_than_or_equal_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> BinaryOperator {
-        BinaryOperator::LessThanOrEqual(token.loc)
+        BinaryOperator::LessThanOrEqual { loc: token.loc }
     }
     pub fn greater_than_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::GreaterThan(token.loc)
+        BinaryOperator::GreaterThan { loc: token.loc }
     }
     pub fn greater_than_or_equal_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> BinaryOperator {
-        BinaryOperator::GreaterThanOrEqual(token.loc)
+        BinaryOperator::GreaterThanOrEqual { loc: token.loc }
     }
     pub fn in_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::In(token.loc)
+        BinaryOperator::In { loc: token.loc }
     }
     pub fn instanceof_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::Instanceof(token.loc)
+        BinaryOperator::Instanceof { loc: token.loc }
     }
     pub fn left_shift_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::LeftShift(token.loc)
+        BinaryOperator::LeftShift { loc: token.loc }
     }
     pub fn right_shift_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::RightShift(token.loc)
+        BinaryOperator::RightShift { loc: token.loc }
     }
     pub fn right_shift_ext_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::RightShiftExt(token.loc)
+        BinaryOperator::RightShiftExt { loc: token.loc }
     }
     pub fn add_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::Add(token.loc)
+        BinaryOperator::Add { loc: token.loc }
     }
     pub fn sub_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::Sub(token.loc)
+        BinaryOperator::Sub { loc: token.loc }
     }
     pub fn mul_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::Mul(token.loc)
+        BinaryOperator::Mul { loc: token.loc }
     }
     pub fn div_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::Div(token.loc)
+        BinaryOperator::Div { loc: token.loc }
     }
     pub fn mod_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::Mod(token.loc)
+        BinaryOperator::Mod { loc: token.loc }
     }
     pub fn pow_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::Pow(token.loc)
+        BinaryOperator::Pow { loc: token.loc }
     }
     pub fn comma_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::Comma(token.loc)
+        BinaryOperator::Comma { loc: token.loc }
     }
     pub fn coalesce_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::Coalesce(token.loc)
+        BinaryOperator::Coalesce { loc: token.loc }
     }
     pub fn logical_or_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::LogicalOr(token.loc)
+        BinaryOperator::LogicalOr { loc: token.loc }
     }
     pub fn logical_and_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::LogicalAnd(token.loc)
+        BinaryOperator::LogicalAnd { loc: token.loc }
     }
     pub fn bitwise_or_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::BitwiseOr(token.loc)
+        BinaryOperator::BitwiseOr { loc: token.loc }
     }
     pub fn bitwise_xor_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::BitwiseXor(token.loc)
+        BinaryOperator::BitwiseXor { loc: token.loc }
     }
     pub fn bitwise_and_op(&self, token: arena::Box<'alloc, Token<'alloc>>) -> BinaryOperator {
-        BinaryOperator::BitwiseAnd(token.loc)
+        BinaryOperator::BitwiseAnd { loc: token.loc }
     }
 
     // Due to limitations of the current parser generator,
@@ -1629,7 +1650,7 @@ impl<'alloc> AstBuilder<'alloc> {
                 ArrayExpressionElement::Expression(expression) => Ok(Some(
                     self.expression_to_assignment_target_maybe_default(expression)?,
                 )),
-                ArrayExpressionElement::Elision(_) => Ok(None),
+                ArrayExpressionElement::Elision { .. } => Ok(None),
             }))?;
         let rest: Option<Result<'alloc, arena::Box<'alloc, AssignmentTarget<'alloc>>>> =
             spread.map(|expr| Ok(self.alloc(self.expression_to_assignment_target(expr)?)));
@@ -1825,73 +1846,73 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> CompoundAssignmentOperator {
-        CompoundAssignmentOperator::Add(token.loc)
+        CompoundAssignmentOperator::Add { loc: token.loc }
     }
     pub fn sub_assign_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> CompoundAssignmentOperator {
-        CompoundAssignmentOperator::Sub(token.loc)
+        CompoundAssignmentOperator::Sub { loc: token.loc }
     }
     pub fn mul_assign_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> CompoundAssignmentOperator {
-        CompoundAssignmentOperator::Mul(token.loc)
+        CompoundAssignmentOperator::Mul { loc: token.loc }
     }
     pub fn div_assign_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> CompoundAssignmentOperator {
-        CompoundAssignmentOperator::Div(token.loc)
+        CompoundAssignmentOperator::Div { loc: token.loc }
     }
     pub fn mod_assign_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> CompoundAssignmentOperator {
-        CompoundAssignmentOperator::Mod(token.loc)
+        CompoundAssignmentOperator::Mod { loc: token.loc }
     }
     pub fn pow_assign_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> CompoundAssignmentOperator {
-        CompoundAssignmentOperator::Pow(token.loc)
+        CompoundAssignmentOperator::Pow { loc: token.loc }
     }
     pub fn left_shift_assign_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> CompoundAssignmentOperator {
-        CompoundAssignmentOperator::LeftShift(token.loc)
+        CompoundAssignmentOperator::LeftShift { loc: token.loc }
     }
     pub fn right_shift_assign_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> CompoundAssignmentOperator {
-        CompoundAssignmentOperator::RightShift(token.loc)
+        CompoundAssignmentOperator::RightShift { loc: token.loc }
     }
     pub fn right_shift_ext_assign_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> CompoundAssignmentOperator {
-        CompoundAssignmentOperator::RightShiftExt(token.loc)
+        CompoundAssignmentOperator::RightShiftExt { loc: token.loc }
     }
     pub fn bitwise_or_assign_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> CompoundAssignmentOperator {
-        CompoundAssignmentOperator::Or(token.loc)
+        CompoundAssignmentOperator::Or { loc: token.loc }
     }
     pub fn bitwise_xor_assign_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> CompoundAssignmentOperator {
-        CompoundAssignmentOperator::Xor(token.loc)
+        CompoundAssignmentOperator::Xor { loc: token.loc }
     }
     pub fn bitwise_and_assign_op(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> CompoundAssignmentOperator {
-        CompoundAssignmentOperator::And(token.loc)
+        CompoundAssignmentOperator::And { loc: token.loc }
     }
 
     pub fn box_assign_op(
@@ -1975,7 +1996,7 @@ impl<'alloc> AstBuilder<'alloc> {
         // 13.3.1.1 Static Semantics: Early Errors
         // TODO: missing check for binding identifiers named `let`.
         // TODO: missing check for duplicated let bindings.
-        if let VariableDeclarationKind::Const(_) = *kind {
+        if let VariableDeclarationKind::Const { .. } = *kind {
             for v in declarators.iter() {
                 if v.init == None {
                     return Err(ParseError::NotImplemented(
@@ -2008,7 +2029,7 @@ impl<'alloc> AstBuilder<'alloc> {
         // 13.3.1.1 Static Semantics: Early Errors
         // TODO: missing check for binding identifiers named `let`.
         // TODO: missing check for duplicated let bindings.
-        if let VariableDeclarationKind::Const(_) = *kind {
+        if let VariableDeclarationKind::Const { .. } = *kind {
             for v in declarators.iter() {
                 if v.init == None {
                     return Err(ParseError::NotImplemented(
@@ -2039,7 +2060,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> arena::Box<'alloc, VariableDeclarationKind> {
-        self.alloc(VariableDeclarationKind::Let(token.loc))
+        self.alloc(VariableDeclarationKind::Let { loc: token.loc })
     }
 
     // LetOrConst : `const`
@@ -2047,7 +2068,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> arena::Box<'alloc, VariableDeclarationKind> {
-        self.alloc(VariableDeclarationKind::Const(token.loc))
+        self.alloc(VariableDeclarationKind::Const { loc: token.loc })
     }
 
     // VariableStatement : `var` VariableDeclarationList `;`
@@ -2063,7 +2084,7 @@ impl<'alloc> AstBuilder<'alloc> {
             .get_loc();
         self.alloc(Statement::VariableDeclarationStatement(
             VariableDeclaration {
-                kind: VariableDeclarationKind::Var(var_loc),
+                kind: VariableDeclarationKind::Var { loc: var_loc },
                 declarators: declarators.unbox(),
                 loc: SourceLocation::from_parts(var_loc, declarator_loc),
             },
@@ -2315,7 +2336,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> arena::Box<'alloc, Statement<'alloc>> {
-        self.alloc(Statement::EmptyStatement(token.loc))
+        self.alloc(Statement::EmptyStatement { loc: token.loc })
     }
 
     // ExpressionStatement : [lookahead not in {'{', 'function', 'async', 'class', 'let'}] Expression `;`
@@ -2417,7 +2438,7 @@ impl<'alloc> AstBuilder<'alloc> {
             .expect("There should be at least one declarator")
             .get_loc();
         VariableDeclarationOrExpression::VariableDeclaration(VariableDeclaration {
-            kind: VariableDeclarationKind::Var(var_loc),
+            kind: VariableDeclarationKind::Var { loc: var_loc },
             declarators: declarators.unbox(),
             loc: SourceLocation::from_parts(var_loc, declarator_loc),
         })
@@ -2457,7 +2478,7 @@ impl<'alloc> AstBuilder<'alloc> {
         let var_loc = var_token.loc;
         let binding_loc = binding.get_loc();
         VariableDeclarationOrAssignmentTarget::VariableDeclaration(VariableDeclaration {
-            kind: VariableDeclarationKind::Var(var_loc),
+            kind: VariableDeclarationKind::Var { loc: var_loc },
             declarators: self.new_vec_single(VariableDeclarator {
                 binding: binding.unbox(),
                 init: None,
@@ -2653,7 +2674,9 @@ impl<'alloc> AstBuilder<'alloc> {
         self.alloc(Statement::SwitchStatement {
             // This will be overwritten once the enclosing switch statement
             // gets parsed.
-            discriminant: self.alloc(Expression::LiteralNullExpression(SourceLocation::default())),
+            discriminant: self.alloc(Expression::LiteralNullExpression {
+                loc: SourceLocation::default(),
+            }),
             cases: match cases {
                 None => self.new_vec(),
                 Some(boxed) => boxed.unbox(),
@@ -2675,7 +2698,9 @@ impl<'alloc> AstBuilder<'alloc> {
         self.alloc(Statement::SwitchStatementWithDefault {
             // This will be overwritten once the enclosing switch statement
             // gets parsed.
-            discriminant: self.alloc(Expression::LiteralNullExpression(SourceLocation::default())),
+            discriminant: self.alloc(Expression::LiteralNullExpression {
+                loc: SourceLocation::default(),
+            }),
             pre_default_cases: match pre_default_cases {
                 None => self.new_vec(),
                 Some(boxed) => boxed.unbox(),
@@ -2849,7 +2874,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
     ) -> arena::Box<'alloc, Statement<'alloc>> {
-        self.alloc(Statement::DebuggerStatement(token.loc))
+        self.alloc(Statement::DebuggerStatement { loc: token.loc })
     }
 
     pub fn function_decl(&self, f: Function<'alloc>) -> arena::Box<'alloc, Statement<'alloc>> {
@@ -3483,7 +3508,7 @@ impl<'alloc> AstBuilder<'alloc> {
                         }
                     },
 
-                    ExpressionOrSuper::Super(_) => {
+                    ExpressionOrSuper::Super { .. } => {
                         // Can't happen: `super()` doesn't match
                         // CoverCallExpressionAndAsyncArrowHead.
                         return Err(ParseError::ArrowHeadInvalid);


### PR DESCRIPTION
In the previous change I used `Var(SourceLocation)` etc for the case the enum has no field, but now I think it's better to be consistent with other cases, so changed to `Var { loc: SourceLocation }`
