### PR TITLE
Update test expectations. Fixes #62.

### DIFF
--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -152,7 +152,7 @@ class ESTestCase(unittest.TestCase):
                ('expression_statement',
                 ('compound_assignment_expr',
                  ('identifier_expr', ('identifier_reference', 'x')),
-                 ('box_assign_op', ('div_assign_op',)),
+                 ('box_assign_op', ('div_assign_op', '/=')),
                  ('numeric_literal', '2')))))))
 
     def test_can_close(self):


### PR DESCRIPTION
The string was added here when location information was added to the Rust parser. (It would be kind of nice to get location information in the Python parser too, but low priority.)