### PR TITLE
Handle Numeric Separators in lexer, and throw NotImplemented in AstBuilder (fixes #74)

### DIFF
--- a/rust/emitter/src/ast_emitter.rs
+++ b/rust/emitter/src/ast_emitter.rs
@@ -402,14 +402,14 @@ impl AstEmitter {
         // depends on how you're using the super
         match callee {
             ExpressionOrSuper::Expression(expr) => match &**expr {
-                Expression::IdentifierExpression(
-                    IdentifierExpression { name, .. },
-                ) => {
+                Expression::IdentifierExpression(IdentifierExpression { name, .. }) => {
                     self.emit_expression(expr)?;
                     self.emit.g_implicit_this(name.value);
                 }
                 _ => {
-                    return Err(EmitError::NotImplemented("TODO: Call (only global functions are supported)"));
+                    return Err(EmitError::NotImplemented(
+                        "TODO: Call (only global functions are supported)",
+                    ));
                 }
             },
             _ => {

--- a/rust/generated_parser/src/parser_tables_generated.rs
+++ b/rust/generated_parser/src/parser_tables_generated.rs
@@ -12127,7 +12127,7 @@ pub fn reduce<'alloc>(
         446 => {
             // Literal ::= NumericLiteral => numeric_literal($0)
             let x0: Box<'alloc, Token<'alloc>> = stack.pop().unwrap().to_ast()?;
-            stack.push(TryIntoStack::try_into_stack(handler.numeric_literal(x0))?);
+            stack.push(TryIntoStack::try_into_stack(handler.numeric_literal(x0)?)?);
             Ok(NonterminalId::Literal)
         }
         447 => {
@@ -13493,7 +13493,7 @@ pub fn reduce<'alloc>(
             // LiteralPropertyName ::= NumericLiteral => property_name_numeric($0)
             let x0: Box<'alloc, Token<'alloc>> = stack.pop().unwrap().to_ast()?;
             stack.push(TryIntoStack::try_into_stack(
-                handler.property_name_numeric(x0),
+                handler.property_name_numeric(x0)?,
             )?);
             Ok(NonterminalId::LiteralPropertyName)
         }


### PR DESCRIPTION
Numeric separator is parsed and included in the token value.
`AstBuilder::numeric_literal_value` is updated to throw `NotImplemented` when it fails to parse.
