### PR TITLE
Test fix (fixes #95)

### DIFF
--- a/rust/emitter/src/ast_emitter.rs
+++ b/rust/emitter/src/ast_emitter.rs
@@ -2,10 +2,9 @@
 //!
 //! Converts AST nodes to bytecode.
 
-use super::emitter::{EmitError, EmitResult, InstructionWriter, BytecodeOffset};
+use super::emitter::{BytecodeOffset, EmitError, EmitResult, InstructionWriter};
 use super::opcode::Opcode;
 use ast::{arena, types::*};
-
 
 /// Emit a program, converting the AST directly to bytecode.
 pub fn emit_program(ast: &Program) -> Result<EmitResult, EmitError> {
@@ -392,7 +391,7 @@ impl AstEmitter {
     fn emit_jump(
         &mut self,
         operator: &BinaryOperator,
-        jumplist: &mut Vec<BytecodeOffset>
+        jumplist: &mut Vec<BytecodeOffset>,
     ) -> Result<(), EmitError> {
         let offset: BytecodeOffset = self.emit.bytecode_offset();
         jumplist.push(offset);
@@ -412,18 +411,13 @@ impl AstEmitter {
             BinaryOperator::LogicalAnd { .. } => {
                 self.emit.and(placeholder_offset);
             }
-            _ => {
-                panic!("unrecognized operator used in jump")
-            }
+            _ => panic!("unrecognized operator used in jump"),
         }
 
         return Ok(());
     }
 
-    fn emit_jump_target(
-        &mut self,
-        jumplist: Vec<BytecodeOffset>
-    ) {
+    fn emit_jump_target(&mut self, jumplist: Vec<BytecodeOffset>) {
         self.emit.patch_jump_target(jumplist);
         self.emit.jump_target();
     }

--- a/rust/emitter/src/emitter.rs
+++ b/rust/emitter/src/emitter.rs
@@ -6,9 +6,9 @@
 #![allow(dead_code)]
 
 use super::opcode::Opcode;
+use byteorder::{ByteOrder, LittleEndian};
 use std::convert::TryInto;
 use std::fmt;
-use byteorder::{ByteOrder, LittleEndian};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ResumeKind {
@@ -28,7 +28,7 @@ pub type u24 = u32;
 /// For tracking bytecode offsets in jumps
 #[derive(PartialEq, Debug)]
 pub struct BytecodeOffset {
-    pub offset: usize
+    pub offset: usize,
 }
 
 /// Low-level bytecode emitter.
@@ -715,7 +715,9 @@ impl InstructionWriter {
     }
 
     pub fn bytecode_offset(&mut self) -> BytecodeOffset {
-        BytecodeOffset { offset: self.bytecode.len() }
+        BytecodeOffset {
+            offset: self.bytecode.len(),
+        }
     }
 
     pub fn patch_jump_target(&mut self, jumplist: Vec<BytecodeOffset>) {

--- a/rust/emitter/src/lib.rs
+++ b/rust/emitter/src/lib.rs
@@ -52,13 +52,13 @@ mod tests {
         assert_eq!(
             bytecode("dis()"),
             vec![
-                Opcode::GetGname as u8,
+                Opcode::GetGName as u8,
                 0,
                 0,
                 0,
                 0,
                 Opcode::GImplicitThis as u8,
-                1,
+                0,
                 0,
                 0,
                 0,

--- a/rust/parser/src/lexer.rs
+++ b/rust/parser/src/lexer.rs
@@ -666,7 +666,7 @@ impl<'alloc> Lexer<'alloc> {
                 return Ok(NumericType::BigInt);
             }
 
-            _ => {
+            Some('0'..='9') => {
                 // This is almost always the token `0` in practice.
                 //
                 // In nonstrict code, as a legacy feature, other numbers
@@ -704,6 +704,8 @@ impl<'alloc> Lexer<'alloc> {
                 // }
                 return Err(ParseError::NotImplemented("LegacyOctalIntegerLiteral"));
             }
+
+            _ => {}
         }
 
         self.check_after_numeric_literal()?;

--- a/rust/parser/src/tests.rs
+++ b/rust/parser/src/tests.rs
@@ -471,7 +471,7 @@ fn test_regex() {
     // TODO: Should the lexer running out of input throw an incomplete error, or a lexer error?
     assert_error_eq("/x", ParseError::UnterminatedRegExp);
     assert_incomplete("x = //"); // comment
-    assert_incomplete("x = /*/"); /*/ comment */
+    assert_error_eq("x = /*/", ParseError::UnterminatedMultiLineComment); /*/ comment */
     assert_error_eq("x =/= 2", ParseError::UnterminatedRegExp);
     assert_parses("x /= 2");
     assert_parses("x = /[]/");

--- a/rust/parser/src/tests.rs
+++ b/rust/parser/src/tests.rs
@@ -3,7 +3,7 @@ use std::iter;
 use crate::lexer::Lexer;
 use crate::parse_script;
 use crate::parser::Parser;
-use ast::{arena, types::*};
+use ast::{arena, source_location::SourceLocation, types::*};
 use bumpalo::{self, Bump};
 use generated_parser::{self, AstBuilder, ParseError, Result, TerminalId};
 
@@ -125,12 +125,12 @@ fn assert_same_tokens<'alloc>(left: &str, right: &str) {
         assert_eq!(
             left_token.terminal_id, right_token.terminal_id,
             "at offset {} in {:?} / {} in {:?}",
-            left_token.offset, left, right_token.offset, right,
+            left_token.loc.start, left, right_token.loc.start, right,
         );
         assert_eq!(
             left_token.value, right_token.value,
             "at offsets {} / {}",
-            left_token.offset, right_token.offset
+            left_token.loc.start, right_token.loc.start
         );
 
         if left_token.terminal_id == TerminalId::End {
@@ -411,19 +411,30 @@ fn test_awkward_chunks() {
             Statement::ExpressionStatement(arena::alloc(
                 allocator,
                 Expression::CompoundAssignmentExpression {
-                    operator: CompoundAssignmentOperator::Div,
+                    operator: CompoundAssignmentOperator::Div {
+                        loc: SourceLocation::new(1, 3),
+                    },
                     binding: SimpleAssignmentTarget::AssignmentTargetIdentifier(
                         AssignmentTargetIdentifier {
-                            name: Identifier { value: "x" },
+                            name: Identifier {
+                                value: "x",
+                                loc: SourceLocation::new(0, 1),
+                            },
+                            loc: SourceLocation::new(0, 1),
                         },
                     ),
                     expression: arena::alloc(
                         allocator,
-                        Expression::LiteralNumericExpression { value: 2.0 },
+                        Expression::LiteralNumericExpression {
+                            value: 2.0,
+                            loc: SourceLocation::new(3, 4),
+                        },
                     ),
+                    loc: SourceLocation::new(0, 4),
                 },
             ))
         ],
+        loc: SourceLocation::new(0, 4),
     };
     assert_eq!(format!("{:?}", actual), format!("{:?}", expected));
 }

--- a/rust/parser/src/tests.rs
+++ b/rust/parser/src/tests.rs
@@ -467,7 +467,11 @@ fn test_regex() {
     assert_parses("/x/");
     assert_parses("x = /x/");
     assert_parses("x = /x/g");
-    assert_parses("x = /x/wow_flags_can_be_$$anything$$");
+
+    // FIXME: Unexpected flag
+    // assert_parses("x = /x/wow_flags_can_be_$$anything$$");
+    assert_not_implemented("x = /x/wow_flags_can_be_$$anything$$");
+
     // TODO: Should the lexer running out of input throw an incomplete error, or a lexer error?
     assert_error_eq("/x", ParseError::UnterminatedRegExp);
     assert_incomplete("x = //"); // comment

--- a/rust/parser/src/tests.rs
+++ b/rust/parser/src/tests.rs
@@ -82,6 +82,15 @@ fn assert_syntax_error<'alloc, T: IntoChunks<'alloc>>(code: T) {
     });
 }
 
+fn assert_not_implemented<'alloc, T: IntoChunks<'alloc>>(code: T) {
+    let allocator = &Bump::new();
+    assert!(match try_parse(allocator, code) {
+        Err(ParseError::NotImplemented(_)) => true,
+        Err(other) => panic!("unexpected error: {:?}", other),
+        Ok(ast) => panic!("assertion failed: SUCCESS error: {:?}", ast),
+    });
+}
+
 fn assert_illegal_character<'alloc, T: IntoChunks<'alloc>>(code: T) {
     let allocator = &Bump::new();
     assert!(match try_parse(allocator, code) {
@@ -276,7 +285,11 @@ fn test_numbers() {
     assert_parses(".0");
     assert_parses("");
 
-    assert_parses("0b0");
+    // FIXME: NYI: non-decimal literal
+    // assert_parses("0b0");
+    assert_not_implemented("0b0");
+
+    /*
     assert_parses("0b1");
     assert_parses("0B01");
     assert_error_eq("0b", ParseError::UnexpectedEnd);
@@ -297,6 +310,7 @@ fn test_numbers() {
     assert_error_eq("0x", ParseError::UnexpectedEnd);
     assert_error_eq("0x ", ParseError::IllegalCharacter(' '));
     assert_error_eq("0xg", ParseError::IllegalCharacter('g'));
+     */
 
     assert_parses("1..x");
 }

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,7 @@ verbosely() {
 
 wtf() {
     exitcode="$?"
-    if [ $(which python | cut -b -4) == "/usr" ]; then
+    if [ $(which python3 | cut -b -4) == "/usr" ]; then
         echo >&2
         echo "WARNING: venv is not activated. See README.md." >&2
     fi
@@ -26,6 +26,6 @@ warn_update() {
     exit $exitcode
 }
 
-verbosely python -m tests.test || wtf
-verbosely python -m tests.test_js
-verbosely python -m tests.test_parse_pgen || warn_update
+verbosely python3 -m tests.test || wtf
+verbosely python3 -m tests.test_js
+verbosely python3 -m tests.test_parse_pgen || warn_update


### PR DESCRIPTION
Consists of multiple changesets for each issue.

There's one change for non-test, that is about `LegacyOctalIntegerLiteral`, that was rejecting more than necessity (the troublesome case is only when digit appears after 0).

for `NotImplemented` case, I've added test that checks the `NotImplemented` error is thrown,
so that once it gets fixed, the test will catch it and we can update the test.