### PR TITLE
fix rust warnings

### DIFF
--- a/rust/parser/src/lib.rs
+++ b/rust/parser/src/lib.rs
@@ -17,7 +17,6 @@ use generated_parser::{
 };
 pub use generated_parser::{ParseError, Result};
 use lexer::Lexer;
-use std::io::{self, Write};
 
 pub fn parse_script<'alloc>(
     allocator: &'alloc bumpalo::Bump,


### PR DESCRIPTION
I am not sure if this stuff was hanging around for a specific reason, but this fixes the following two warnings: 

```
warning: unused imports: `Write`, `self`
  --> parser/src/lib.rs:20:15
   |
20 | use std::io::{self, Write};
   |               ^^^^  ^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: method is never used: `can_close`
   --> parser/src/parser.rs:211:5
    |
211 |     pub fn can_close(&self) -> bool {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```