### PR TITLE
Add back use std::io::{self, Write}

### DIFF
--- a/rust/parser/src/lib.rs
+++ b/rust/parser/src/lib.rs
@@ -18,6 +18,7 @@ use generated_parser::{
 };
 pub use generated_parser::{ParseError, Result};
 use lexer::Lexer;
+use std::io::{self, Write};
 
 pub fn parse_script<'alloc>(
     allocator: &'alloc bumpalo::Bump,


### PR DESCRIPTION
reverts https://github.com/mozilla-spidermonkey/jsparagus/pull/111
that conflicted with https://github.com/mozilla-spidermonkey/jsparagus/pull/106
(sorry I overlooked)