### PR TITLE
Implement Early Error for Identifier (fixes #113)

### DIFF
--- a/rust/generated_parser/src/ast_builder.rs
+++ b/rust/generated_parser/src/ast_builder.rs
@@ -131,65 +131,68 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn identifier_reference(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
-    ) -> arena::Box<'alloc, Identifier<'alloc>> {
-        self.alloc(self.identifier(token))
+    ) -> Result<'alloc, arena::Box<'alloc, Identifier<'alloc>>> {
+        let loc = token.loc;
+        self.on_identifier_reference(token.value.unwrap(), loc.start)?;
+        Ok(self.alloc(self.identifier(token)))
     }
 
     // BindingIdentifier : Identifier
     pub fn binding_identifier(
         &mut self,
         token: arena::Box<'alloc, Token<'alloc>>,
-    ) -> arena::Box<'alloc, BindingIdentifier<'alloc>> {
+    ) -> Result<'alloc, arena::Box<'alloc, BindingIdentifier<'alloc>>> {
         let loc = token.loc;
-        self.on_binding_identifier(token.value.unwrap(), loc.start);
-        self.alloc(BindingIdentifier {
+        self.on_binding_identifier(token.value.unwrap(), loc.start)?;
+        Ok(self.alloc(BindingIdentifier {
             name: self.identifier(token),
             loc,
-        })
+        }))
     }
 
     // BindingIdentifier : `yield`
     pub fn binding_identifier_yield(
         &mut self,
         token: arena::Box<'alloc, Token<'alloc>>,
-    ) -> arena::Box<'alloc, BindingIdentifier<'alloc>> {
+    ) -> Result<'alloc, arena::Box<'alloc, BindingIdentifier<'alloc>>> {
         let loc = token.loc;
-        self.on_binding_identifier("yield", loc.start);
-        self.alloc(BindingIdentifier {
+        self.on_binding_identifier("yield", loc.start)?;
+        Ok(self.alloc(BindingIdentifier {
             name: Identifier {
                 value: "yield",
                 loc,
             },
             loc,
-        })
+        }))
     }
 
     // BindingIdentifier : `await`
     pub fn binding_identifier_await(
         &mut self,
         token: arena::Box<'alloc, Token<'alloc>>,
-    ) -> arena::Box<'alloc, BindingIdentifier<'alloc>> {
+    ) -> Result<'alloc, arena::Box<'alloc, BindingIdentifier<'alloc>>> {
         let loc = token.loc;
-        self.on_binding_identifier("await", loc.start);
-        self.alloc(BindingIdentifier {
+        self.on_binding_identifier("await", loc.start)?;
+        Ok(self.alloc(BindingIdentifier {
             name: Identifier {
                 value: "await",
                 loc,
             },
             loc,
-        })
+        }))
     }
 
     // LabelIdentifier : Identifier
     pub fn label_identifier(
         &self,
         token: arena::Box<'alloc, Token<'alloc>>,
-    ) -> arena::Box<'alloc, Label<'alloc>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Label<'alloc>>> {
         let loc = token.loc;
-        self.alloc(Label {
+        self.on_label_identifier(token.value.unwrap(), loc.start)?;
+        Ok(self.alloc(Label {
             value: token.value.unwrap(),
             loc,
-        })
+        }))
     }
 
     // PrimaryExpression : `this`
@@ -4150,8 +4153,12 @@ impl<'alloc> AstBuilder<'alloc> {
         Err(ParseError::NotImplemented("export"))
     }
 
-    // Note binding info to the stack.
-    fn on_binding_identifier(&mut self, name: &'alloc str, offset: usize) {
+    // Check Early Error for BindingIdentifier and note binding info to the
+    // stack.
+    fn on_binding_identifier(&mut self, name: &'alloc str, offset: usize) -> Result<'alloc, ()> {
+        let context = IdentifierEarlyErrorsContext::new();
+        context.check_binding_identifier(name, offset)?;
+
         if let Some(info) = self.bindings.last() {
             debug_assert!(info.offset < offset);
         }
@@ -4161,6 +4168,20 @@ impl<'alloc> AstBuilder<'alloc> {
             offset,
             kind: BindingKind::Unknown,
         });
+
+        Ok(())
+    }
+
+    // Check Early Error for IdentifierReference.
+    fn on_identifier_reference(&self, name: &'alloc str, offset: usize) -> Result<'alloc, ()> {
+        let context = IdentifierEarlyErrorsContext::new();
+        context.check_identifier_reference(name, offset)
+    }
+
+    // Check Early Error for LabelIdentifier.
+    fn on_label_identifier(&self, name: &'alloc str, offset: usize) -> Result<'alloc, ()> {
+        let context = IdentifierEarlyErrorsContext::new();
+        context.check_label_identifier(name, offset)
     }
 
     // Update the binding kind of all names declared in a specific range of the

--- a/rust/generated_parser/src/error.rs
+++ b/rust/generated_parser/src/error.rs
@@ -21,6 +21,7 @@ pub enum ParseError<'alloc> {
     UnexpectedEnd,
     InvalidAssignmentTarget,
     InvalidParameter,
+    InvalidIdentifier(&'alloc str, usize),
     AstError(String),
 
     // Destructuring errors
@@ -54,6 +55,9 @@ impl<'alloc> ParseError<'alloc> {
             ParseError::UnexpectedEnd => format!("unexpected end of input"),
             ParseError::InvalidAssignmentTarget => format!("invalid left-hand side of assignment"),
             ParseError::InvalidParameter => format!("invalid parameter"),
+            ParseError::InvalidIdentifier(name, _) => {
+                format!("invalid identifier {}", name)
+            }
             ParseError::AstError(ast_error) => format!("{}", ast_error),
             ParseError::ArrayPatternWithNonFinalRest => {
                 format!("array patterns can have a rest element (`...x`) only at the end")

--- a/rust/generated_parser/src/parser_tables_generated.rs
+++ b/rust/generated_parser/src/parser_tables_generated.rs
@@ -9308,7 +9308,7 @@ pub fn reduce<'alloc>(
             stack.push(TryIntoStack::try_into_stack({
                 let a0 = x0;
                 handler.label_identifier(a0)
-            })?);
+            }?)?);
             Ok(NonterminalId::LabelIdentifier)
         }
         144 => {
@@ -9822,7 +9822,7 @@ pub fn reduce<'alloc>(
             stack.push(TryIntoStack::try_into_stack({
                 let a0 = x0;
                 handler.binding_identifier(a0)
-            })?);
+            }?)?);
             Ok(NonterminalId::BindingIdentifier)
         }
         166 => {
@@ -9831,7 +9831,7 @@ pub fn reduce<'alloc>(
             stack.push(TryIntoStack::try_into_stack({
                 let a0 = x0;
                 handler.binding_identifier_yield(a0)
-            })?);
+            }?)?);
             Ok(NonterminalId::BindingIdentifier)
         }
         167 => {
@@ -9840,7 +9840,7 @@ pub fn reduce<'alloc>(
             stack.push(TryIntoStack::try_into_stack({
                 let a0 = x0;
                 handler.binding_identifier_await(a0)
-            })?);
+            }?)?);
             Ok(NonterminalId::BindingIdentifier)
         }
         168 => {
@@ -13433,7 +13433,7 @@ pub fn reduce<'alloc>(
             stack.push(TryIntoStack::try_into_stack({
                 let a0 = x0;
                 handler.identifier_reference(a0)
-            })?);
+            }?)?);
             Ok(NonterminalId::IdentifierReference)
         }
         452 => {


### PR DESCRIPTION
Implemented in the same way as duplicate error.

Now `IdentifierEarlyErrorsContext` doesn't contain any field except phantom for lifetime parameter.
but it will hold something to get strict mode, and also the goal (whether it's Module or not).

as mentioned in https://github.com/mozilla-spidermonkey/jsparagus/issues/116 , this doesn't solve
yield/await for `LabelIdentifier` and `IdentifierReference`, given we don't yet have parameter.

Early Errors for `Identifier` are handled at the same time for the encloding non-terminal (`BindingIdentifier` etc), internally.