### PR TITLE
Fix Early Errors handling for lexical-for (fixes #124)

### DIFF
--- a/js_parser/es-simplified.esgrammar
+++ b/js_parser/es-simplified.esgrammar
@@ -828,19 +828,19 @@ IterationStatement[Yield, Await, Return] :
   `for` `(` `var` ForBinding[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
     => for_in_statement($0, for_in_or_of_var_declaration($2, $3), $5, $7)
   `for` `(` ForDeclaration[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-    => for_in_statement($0, unbox_for_declaration($2), $4, $6)
+    => for_in_statement_lexical($0, unbox_for_declaration($2), $4, $6)
   `for` `(` [lookahead <! {`async`, `let`} ] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
     => for_of_statement($0, for_assignment_target($2), $4, $6)
   `for` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
     => for_of_statement($0, for_in_or_of_var_declaration($2, $3), $5, $7)
   `for` `(` ForDeclaration[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-    => for_of_statement($0, unbox_for_declaration($2), $4, $6)
+    => for_of_statement_lexical($0, unbox_for_declaration($2), $4, $6)
   [+Await] `for` `await` `(` [lookahead <! {`async`, `let`} ] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
     => for_await_of_statement($0, for_assignment_target($3), $5, $7)
   [+Await] `for` `await` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
     => for_await_of_statement($0, for_in_or_of_var_declaration($3, $4), $6, $8)
   [+Await] `for` `await` `(` ForDeclaration[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-    => for_await_of_statement($0, unbox_for_declaration($3), $5, $7)
+    => for_await_of_statement_lexical($0, unbox_for_declaration($3), $5, $7)
 
 @returns VariableDeclarationOrAssignmentTarget
 ForDeclaration[Yield, Await] :

--- a/rust/generated_parser/src/ast_builder.rs
+++ b/rust/generated_parser/src/ast_builder.rs
@@ -2782,6 +2782,14 @@ impl<'alloc> AstBuilder<'alloc> {
         kind: arena::Box<'alloc, VariableDeclarationKind>,
         binding: arena::Box<'alloc, Binding<'alloc>>,
     ) -> arena::Box<'alloc, VariableDeclarationOrAssignmentTarget<'alloc>> {
+        let binding_kind = match &*kind {
+            VariableDeclarationKind::Let { .. } => BindingKind::Let,
+            VariableDeclarationKind::Const { .. } => BindingKind::Const,
+            _ => panic!("unexpected VariableDeclarationKind"),
+        };
+
+        self.mark_binding_kind(kind.get_loc().start, None, binding_kind);
+
         let kind_loc = kind.get_loc();
         let binding_loc = binding.get_loc();
         self.alloc(VariableDeclarationOrAssignmentTarget::VariableDeclaration(

--- a/rust/generated_parser/src/parser_tables_generated.rs
+++ b/rust/generated_parser/src/parser_tables_generated.rs
@@ -9131,7 +9131,7 @@ pub fn reduce<'alloc>(
             Ok(NonterminalId::IterationStatement)
         }
         135 => {
-            // IterationStatement ::= "for" "(" ForDeclaration "in" Expression[+In] ")" Statement => for_in_statement($0, unbox_for_declaration($2), $4, $6)
+            // IterationStatement ::= "for" "(" ForDeclaration "in" Expression[+In] ")" Statement => for_in_statement_lexical($0, unbox_for_declaration($2), $4, $6)
             let x6: Box<'alloc, Statement> = stack.pop().unwrap().to_ast()?;
             stack.pop();
             let x4: Box<'alloc, Expression> = stack.pop().unwrap().to_ast()?;
@@ -9148,8 +9148,8 @@ pub fn reduce<'alloc>(
                 };
                 let a2 = x4;
                 let a3 = x6;
-                handler.for_in_statement(a0, a1, a2, a3)
-            })?);
+                handler.for_in_statement_lexical(a0, a1, a2, a3)
+            }?)?);
             Ok(NonterminalId::IterationStatement)
         }
         136 => {
@@ -9197,7 +9197,7 @@ pub fn reduce<'alloc>(
             Ok(NonterminalId::IterationStatement)
         }
         138 => {
-            // IterationStatement ::= "for" "(" ForDeclaration "of" AssignmentExpression[+In] ")" Statement => for_of_statement($0, unbox_for_declaration($2), $4, $6)
+            // IterationStatement ::= "for" "(" ForDeclaration "of" AssignmentExpression[+In] ")" Statement => for_of_statement_lexical($0, unbox_for_declaration($2), $4, $6)
             let x6: Box<'alloc, Statement> = stack.pop().unwrap().to_ast()?;
             stack.pop();
             let x4: Box<'alloc, Expression> = stack.pop().unwrap().to_ast()?;
@@ -9214,8 +9214,8 @@ pub fn reduce<'alloc>(
                 };
                 let a2 = x4;
                 let a3 = x6;
-                handler.for_of_statement(a0, a1, a2, a3)
-            })?);
+                handler.for_of_statement_lexical(a0, a1, a2, a3)
+            }?)?);
             Ok(NonterminalId::IterationStatement)
         }
         139 => {
@@ -9265,7 +9265,7 @@ pub fn reduce<'alloc>(
             Ok(NonterminalId::IterationStatement)
         }
         141 => {
-            // IterationStatement ::= "for" "await" "(" ForDeclaration "of" AssignmentExpression[+In] ")" Statement => for_await_of_statement($0, unbox_for_declaration($3), $5, $7)
+            // IterationStatement ::= "for" "await" "(" ForDeclaration "of" AssignmentExpression[+In] ")" Statement => for_await_of_statement_lexical($0, unbox_for_declaration($3), $5, $7)
             let x7: Box<'alloc, Statement> = stack.pop().unwrap().to_ast()?;
             stack.pop();
             let x5: Box<'alloc, Expression> = stack.pop().unwrap().to_ast()?;
@@ -9283,7 +9283,7 @@ pub fn reduce<'alloc>(
                 };
                 let a2 = x5;
                 let a3 = x7;
-                handler.for_await_of_statement(a0, a1, a2, a3)
+                handler.for_await_of_statement_lexical(a0, a1, a2, a3)
             }?)?);
             Ok(NonterminalId::IterationStatement)
         }


### PR DESCRIPTION
one issue was that `for_*_statement_lexical` wasn't called.
another issue was that `for_declaration` wasn't marking binding.