### PR TITLE
Simple bytecode interpreter

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "ast 0.1.0",
  "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "emitter 0.1.0",
+ "interpreter 0.1.0",
  "parser 0.1.0",
 ]
 
@@ -45,6 +46,13 @@ version = "0.1.0"
 dependencies = [
  "ast 0.1.0",
  "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "interpreter"
+version = "0.1.0"
+dependencies = [
+ "emitter 0.1.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "emitter",
     "generated_parser",
     "parser",
+    "interpreter",
 ]
 
 [profile.release]

--- a/rust/driver/Cargo.toml
+++ b/rust/driver/Cargo.toml
@@ -9,6 +9,7 @@ ast = { path = "../ast" }
 bumpalo = "2.6.0"
 emitter = { path = "../emitter" }
 parser = { path = "../parser" }
+interpreter = { path = "../interpreter" }
 
 # jemalloc is temporarily disabled due to a known upstream bug (macOS crashes
 # in release builds): <https://github.com/gnzlbg/jemallocator/issues/136>

--- a/rust/driver/src/demo.rs
+++ b/rust/driver/src/demo.rs
@@ -116,6 +116,9 @@ fn handle_script<'alloc>(script: Script<'alloc>) {
         Ok(emit_result) => {
             println!("\n{:#?}", emit_result);
             println!("\n{}", emitter::dis(&emit_result.bytecode));
+
+            let eval_result = interpreter::evaluate(&emit_result);
+            println!("{:?}", eval_result);
         }
     }
 }

--- a/rust/emitter/src/lib.rs
+++ b/rust/emitter/src/lib.rs
@@ -2,7 +2,7 @@ mod ast_emitter;
 mod dis;
 mod emitter;
 mod lower;
-mod opcode;
+pub mod opcode;
 
 pub use crate::emitter::{EmitError, EmitResult};
 pub use dis::dis;

--- a/rust/interpreter/Cargo.toml
+++ b/rust/interpreter/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "interpreter"
+version = "0.1.0"
+authors = ["Tom Schuster <evilpies@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+emitter = { path = "../emitter" }

--- a/rust/interpreter/src/evaluate.rs
+++ b/rust/interpreter/src/evaluate.rs
@@ -1,0 +1,92 @@
+use emitter::opcode::Opcode;
+use emitter::EmitResult;
+
+use std::convert::TryFrom;
+use std::fmt;
+
+use crate::value::{to_number, JSValue};
+
+/// The error of evaluating JS bytecode.
+#[derive(Clone, Debug)]
+pub enum EvalError {
+    NotImplemented(String),
+    EmptyStack,
+}
+
+impl fmt::Display for EvalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EvalError::NotImplemented(message) => write!(f, "not implemented: {}", message),
+            EvalError::EmptyStack => write!(f, "trying to pop from empty stack"),
+        }
+    }
+}
+
+pub fn evaluate(emit: &EmitResult) -> Result<JSValue, EvalError> {
+    let mut pc = 0;
+    let mut stack = Vec::new();
+    let mut rval = JSValue::Undefined;
+
+    loop {
+        let op = match Opcode::try_from(emit.bytecode[pc]) {
+            Ok(op) => op,
+            Err(_) => {
+                return Err(EvalError::NotImplemented(format!(
+                    "{} is not an opcode",
+                    emit.bytecode[pc]
+                )))
+            }
+        };
+
+        match op {
+            Opcode::Int8 => stack.push(JSValue::Number(emit.bytecode[pc + 1] as f64)),
+
+            Opcode::Add => {
+                let rhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                let lhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                // TODO: Add is special, i.e. string concat
+                stack.push(JSValue::Number(to_number(lhs) + to_number(rhs)))
+            }
+
+            Opcode::Sub => {
+                let rhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                let lhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                stack.push(JSValue::Number(to_number(lhs) - to_number(rhs)))
+            }
+
+            Opcode::Pos => {
+                let v = stack.pop().ok_or(EvalError::EmptyStack)?;
+                stack.push(JSValue::Number(to_number(v)));
+            }
+
+            Opcode::Neg => {
+                let v = stack.pop().ok_or(EvalError::EmptyStack)?;
+                stack.push(JSValue::Number(-to_number(v)));
+            }
+
+            Opcode::Void => {
+                stack.pop().ok_or(EvalError::EmptyStack)?;
+                stack.push(JSValue::Undefined);
+            }
+
+            Opcode::Pop => {
+                stack.pop().ok_or(EvalError::EmptyStack)?;
+            }
+
+            Opcode::SetRval => {
+                rval = stack.pop().ok_or(EvalError::EmptyStack)?;
+            }
+
+            Opcode::RetRval => {
+                return Ok(rval);
+            }
+
+            Opcode::Undefined => stack.push(JSValue::Undefined),
+            Opcode::Null => stack.push(JSValue::Null),
+
+            _ => return Err(EvalError::NotImplemented(format!("{:?}", op))),
+        }
+
+        pc += op.instruction_length();
+    }
+}

--- a/rust/interpreter/src/lib.rs
+++ b/rust/interpreter/src/lib.rs
@@ -1,0 +1,4 @@
+mod evaluate;
+mod value;
+
+pub use evaluate::evaluate;

--- a/rust/interpreter/src/value.rs
+++ b/rust/interpreter/src/value.rs
@@ -1,0 +1,19 @@
+use std::f64;
+
+#[derive(Debug)]
+pub enum JSValue {
+    Boolean(bool),
+    Number(f64),
+    Undefined,
+    Null,
+}
+
+pub fn to_number(v: JSValue) -> f64 {
+    match v {
+        JSValue::Boolean(true) => 1.0,
+        JSValue::Boolean(false) => 0.0,
+        JSValue::Number(n) => n,
+        JSValue::Undefined => f64::NAN,
+        JSValue::Null => 0.0,
+    }
+}


### PR DESCRIPTION
We don't yet emit many opcodes, so this actually has pretty good coverage. 
I think we might soon need a small refactoring to implement something like `read_int8`, `read_int32` for the Opcode bytecode operands.
I made sure that we don't unnecessarily panic, so this is relatively robust when implementing new opcodes.