### PR TITLE
Support RegExp after ASI. Fixes #137.

### DIFF
--- a/rust/parser/src/lexer.rs
+++ b/rust/parser/src/lexer.rs
@@ -1499,17 +1499,17 @@ impl<'alloc> Lexer<'alloc> {
                         continue;
                     }
                     _ => {
-                        if parser.can_accept_terminal(TerminalId::RegularExpressionLiteral) {
-                            builder.push_matching('/');
-                            return self.regular_expression_literal(&mut builder);
-                        }
-                        match self.peek() {
-                            Some('=') => {
-                                self.chars.next();
-                                return Ok((SourceLocation::new(start, self.offset()), None, TerminalId::DivideAssign));
+                        if parser.can_accept_terminal(TerminalId::Divide) {
+                            match self.peek() {
+                                Some('=') => {
+                                    self.chars.next();
+                                    return Ok((SourceLocation::new(start, self.offset()), None, TerminalId::DivideAssign));
+                                }
+                                _ => return Ok((SourceLocation::new(start, self.offset()), None, TerminalId::Divide)),
                             }
-                            _ => return Ok((SourceLocation::new(start, self.offset()), None, TerminalId::Divide)),
                         }
+                        builder.push_matching('/');
+                        return self.regular_expression_literal(&mut builder);
                     }
                 },
 


### PR DESCRIPTION
The code `a=>{} \n /x/;` involves both ASI and slashes.

The spec language about ASI says that after parsing without ASI fails,
we reparse it as `a=>{}; /x/;`, which succeeds.

This example is subtle because, going by the spec, we would initially
parse the first slash as division. ("In all other contexts,
InputElementDiv is used..."[1]) But after ASI, it is a RegExp. Before
this patch, we do in fact scan it as division and we then fail to
reinterpret it as a RegExp after ASI.

We could fix this by making the lexer rescan the token after doing
ASI. But that is awkward and seems unnecessary. Instead, in places where
neither DivPunctuator nor RegularExpressionLiteral is permitted, choose
RegularExpressionLiteral. Either ASI will happen (and a division
operator is never legal immediately following a semicolon) or the
program is a SyntaxError anyway.

[1]: https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar