### PR TITLE
Throw NotImplemented when lexer found yield and await (fixes #116)

### DIFF
--- a/rust/interpreter/src/evaluate.rs
+++ b/rust/interpreter/src/evaluate.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::fmt;
 
-use crate::value::{to_number, to_boolean, JSValue};
+use crate::value::{to_boolean, to_number, JSValue};
 
 /// The error of evaluating JS bytecode.
 #[derive(Clone, Debug)]

--- a/rust/parser/src/lexer.rs
+++ b/rust/parser/src/lexer.rs
@@ -353,7 +353,12 @@ impl<'alloc> Lexer<'alloc> {
             match &text as &str {
                 "as" => TerminalId::As,
                 "async" => TerminalId::Async,
-                "await" => TerminalId::Await,
+                "await" => {
+                    //TerminalId::Await
+                    return Err(ParseError::NotImplemented(
+                        "await cannot be handled in parser",
+                    ));
+                }
                 "break" => TerminalId::Break,
                 "case" => TerminalId::Case,
                 "catch" => TerminalId::Catch,
@@ -393,7 +398,12 @@ impl<'alloc> Lexer<'alloc> {
                 "void" => TerminalId::Void,
                 "while" => TerminalId::While,
                 "with" => TerminalId::With,
-                "yield" => TerminalId::Yield,
+                "yield" => {
+                    //TerminalId::Yield
+                    return Err(ParseError::NotImplemented(
+                        "yield cannot be handled in parser",
+                    ));
+                }
                 "null" => TerminalId::NullLiteral,
                 "true" | "false" => TerminalId::BooleanLiteral,
                 _ => TerminalId::Name,


### PR DESCRIPTION
Given parser cannot handle yield/await token properly at this point, I think the quick and less-change fix is just to return NotImplemented from lexer.
This will affect the case when they're used for IdentifierName, but I think that's not much problem.