### PR TITLE
Implement And, Or, and Coalesce in the interpreter

### DIFF
--- a/rust/interpreter/src/value.rs
+++ b/rust/interpreter/src/value.rs
@@ -1,6 +1,6 @@
 use std::f64;
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum JSValue {
     Boolean(bool),
     Number(f64),


### PR DESCRIPTION
I am not sure what the recommended way in Rust to implement to_boolean and to_number.
Should we make JSValue copyable, or change those methodes to take references?