### PR TITLE
Update info.json only when ast_builder.rs gets parsed (fixes #156)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(PY_OUT): $(EMIT_FILES) $(DUMP_FILE)
 	$(PYTHON) -m js_parser.generate_js_parser_tables --progress -o $@ $(DUMP_FILE)
 
 $(HANDLER_INFO_OUT): jsparagus/emit/collect_handler_info/src/main.rs $(HANDLER_FILE)
-	(cd jsparagus/emit/collect_handler_info/; cargo run --bin collect_handler_info ../../../$(HANDLER_FILE) > $(subst jsparagus/emit/collect_handler_info/,,$(HANDLER_INFO_OUT)))
+	(cd jsparagus/emit/collect_handler_info/; cargo run --bin collect_handler_info ../../../$(HANDLER_FILE) $(subst jsparagus/emit/collect_handler_info/,,$(HANDLER_INFO_OUT)))
 
 $(RS_AST_OUT): rust/ast/ast.json rust/ast/generate_ast.py
 	(cd rust/ast && $(PYTHON) generate_ast.py)


### PR DESCRIPTION
Now the file is created/updated only when ast_builder.rs is parsed correctly.

So, if there's info.json for previous build and new syntax error is added to ast_builder.rs,
the build process always stops there
(without this patch, info.json was created regardless of the error, and the build process goes to the next step in the next build)

the error message is still unclear, but at least it doesn't fall into unexpected state.