### PR TITLE
Return Err(NotImplemented) for '\08' and '\09'. Fixes #161.

### DIFF
--- a/rust/parser/src/lexer.rs
+++ b/rust/parser/src/lexer.rs
@@ -1013,6 +1013,11 @@ impl<'alloc> Lexer<'alloc> {
                                 "legacy octal escape sequence in string",
                             ));
                         }
+                        Some('8'..='9') => {
+                            return Err(ParseError::NotImplemented(
+                                "digit immediately following \\0 escape sequence",
+                            ));
+                        }
                         _ => {}
                     }
                     text.push('\0');


### PR DESCRIPTION
In non-strict code, these are two-character strings, a null character
followed by an ASCII digit. In strict code, they're SyntaxErrors.