### PR TITLE
Use ID_Start/ID_Continue instead of XID_Start/XID_Continue (fixes #160)

### DIFF
--- a/rust/parser/Cargo.toml
+++ b/rust/parser/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 generated_parser = { path = "../generated_parser" }
 ast = { path = "../ast" }
 bumpalo = "2.6.0"
-unic-ucd-ident = "0.9.0"
+unic-ucd-ident = { version = "0.9.0", features = ["id"] }

--- a/rust/parser/src/lexer.rs
+++ b/rust/parser/src/lexer.rs
@@ -6,7 +6,7 @@ use bumpalo::{collections::String, Bump};
 use generated_parser::{ParseError, Result, TerminalId, Token};
 use std::convert::TryFrom;
 use std::str::Chars;
-use unic_ucd_ident::{is_xid_continue, is_xid_start};
+use unic_ucd_ident::{is_id_continue, is_id_start};
 
 pub struct Lexer<'alloc> {
     allocator: &'alloc Bump,
@@ -221,7 +221,7 @@ fn is_identifier_start(c: char) -> bool {
     if c.is_ascii() {
         c == '$' || c == '_' || c.is_ascii_alphabetic()
     } else {
-        is_xid_start(c)
+        is_id_start(c)
     }
 }
 
@@ -243,7 +243,7 @@ fn is_identifier_part(c: char) -> bool {
     if c.is_ascii() {
         c == '$' || c == '_' || c.is_ascii_alphanumeric()
     } else {
-        is_xid_continue(c) || c == ZWNJ || c == ZWJ
+        is_id_continue(c) || c == ZWNJ || c == ZWJ
     }
 }
 

--- a/rust/parser/src/tests.rs
+++ b/rust/parser/src/tests.rs
@@ -344,6 +344,18 @@ fn test_identifier() {
     assert_parses("_\u{200d}\u{200c}();"); // <ZWJ>
     assert_illegal_character("var \u{200c};"); // <ZWNJ>
     assert_illegal_character("x = \u{200d};"); // <ZWJ>
+
+    // Other_ID_Start for backward compat.
+    assert_parses("\u{309B}();");
+    assert_parses("\u{309C}();");
+    assert_parses("_\u{309B}();");
+    assert_parses("_\u{309C}();");
+
+    // Non-BMP.
+    assert_parses("\u{10000}();");
+    assert_parses("_\u{10000}();");
+    assert_illegal_character("\u{1000c}();");
+    assert_illegal_character("_\u{1000c}();");
 }
 
 #[test]


### PR DESCRIPTION
given the spec mentions ID_Start/ID_Continue, using `is_id_start`/`is_id_continue` should be fine?
https://tc39.es/ecma262/#prod-UnicodeIDStart
