### PR TITLE
Refactor Call Expression for reusability

### DIFF
--- a/rust/ast/ast.json
+++ b/rust/ast/ast.json
@@ -223,10 +223,7 @@
       "left": "Box<Expression>",
       "right": "Box<Expression>"
     },
-    "CallExpression": {
-      "callee": "ExpressionOrSuper",
-      "arguments": "Arguments"
-    },
+    "CallExpression": "CallExpression",
     "CompoundAssignmentExpression": {
       "operator": "CompoundAssignmentOperator",
       "binding": "SimpleAssignmentTarget",
@@ -279,6 +276,11 @@
     "_type": "enum",
     "ComputedPropertyName": "ComputedPropertyName",
     "StaticPropertyName": "StaticPropertyName"
+  },
+  "CallExpression": {
+    "_type": "struct",
+    "callee": "ExpressionOrSuper",
+    "arguments": "Arguments"
   },
   "ClassElementName": {
     "_type": "enum",

--- a/rust/ast/src/source_location_accessor_generated.rs
+++ b/rust/ast/src/source_location_accessor_generated.rs
@@ -470,6 +470,17 @@ impl<'alloc> SourceLocationAccessor<'alloc> for Block<'alloc> {
     }
 }
 
+impl<'alloc> SourceLocationAccessor<'alloc> for CallExpression<'alloc> {
+    fn set_loc(&mut self, start: SourceLocation, end: SourceLocation) {
+        self.loc.start = start.start;
+        self.loc.end = end.end;
+    }
+
+    fn get_loc(&self) -> SourceLocation {
+        self.loc
+    }
+}
+
 impl<'alloc> SourceLocationAccessor<'alloc> for CatchClause<'alloc> {
     fn set_loc(&mut self, start: SourceLocation, end: SourceLocation) {
         self.loc.start = start.start;
@@ -844,10 +855,7 @@ impl<'alloc> SourceLocationAccessor<'alloc> for Expression<'alloc> {
                 loc.start = start.start;
                 loc.end = end.end;
             }
-            Expression::CallExpression { mut loc, .. } => {
-                loc.start = start.start;
-                loc.end = end.end;
-            }
+            Expression::CallExpression(content) => content.set_loc(start, end),
             Expression::CompoundAssignmentExpression { mut loc, .. } => {
                 loc.start = start.start;
                 loc.end = end.end;
@@ -913,7 +921,7 @@ impl<'alloc> SourceLocationAccessor<'alloc> for Expression<'alloc> {
             Expression::ArrowExpression { loc, .. } => *loc,
             Expression::AssignmentExpression { loc, .. } => *loc,
             Expression::BinaryExpression { loc, .. } => *loc,
-            Expression::CallExpression { loc, .. } => *loc,
+            Expression::CallExpression(content) => content.get_loc(),
             Expression::CompoundAssignmentExpression { loc, .. } => *loc,
             Expression::ConditionalExpression { loc, .. } => *loc,
             Expression::FunctionExpression(content) => content.get_loc(),

--- a/rust/ast/src/types_generated.rs
+++ b/rust/ast/src/types_generated.rs
@@ -279,11 +279,7 @@ pub enum Expression<'alloc> {
         right: arena::Box<'alloc, Expression<'alloc>>,
         loc: SourceLocation,
     },
-    CallExpression {
-        callee: ExpressionOrSuper<'alloc>,
-        arguments: Arguments<'alloc>,
-        loc: SourceLocation,
-    },
+    CallExpression(CallExpression<'alloc>),
     CompoundAssignmentExpression {
         operator: CompoundAssignmentOperator,
         binding: SimpleAssignmentTarget<'alloc>,
@@ -351,6 +347,13 @@ pub enum MemberExpression<'alloc> {
 pub enum PropertyName<'alloc> {
     ComputedPropertyName(ComputedPropertyName<'alloc>),
     StaticPropertyName(StaticPropertyName<'alloc>),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct CallExpression<'alloc> {
+    pub callee: ExpressionOrSuper<'alloc>,
+    pub arguments: Arguments<'alloc>,
+    pub loc: SourceLocation,
 }
 
 #[derive(Debug, PartialEq)]

--- a/rust/emitter/src/ast_emitter.rs
+++ b/rust/emitter/src/ast_emitter.rs
@@ -226,9 +226,9 @@ impl AstEmitter {
                 self.emit_binary_expression(operator, left, right)?;
             }
 
-            Expression::CallExpression {
+            Expression::CallExpression(CallExpression {
                 callee, arguments, ..
-            } => {
+            }) => {
                 self.emit_call_expression(callee, arguments)?;
             }
 

--- a/rust/generated_parser/src/ast_builder.rs
+++ b/rust/generated_parser/src/ast_builder.rs
@@ -1336,11 +1336,11 @@ impl<'alloc> AstBuilder<'alloc> {
     ) -> arena::Box<'alloc, Expression<'alloc>> {
         let callee_loc = callee.get_loc();
         let arguments_loc = arguments.loc;
-        self.alloc(Expression::CallExpression {
+        self.alloc(Expression::CallExpression(CallExpression {
             callee: ExpressionOrSuper::Expression(callee),
             arguments: arguments.unbox(),
             loc: SourceLocation::from_parts(callee_loc, arguments_loc),
-        })
+        }))
     }
 
     // SuperCall : `super` Arguments
@@ -1351,11 +1351,11 @@ impl<'alloc> AstBuilder<'alloc> {
     ) -> arena::Box<'alloc, Expression<'alloc>> {
         let super_loc = super_token.loc;
         let arguments_loc = arguments.loc;
-        self.alloc(Expression::CallExpression {
+        self.alloc(Expression::CallExpression(CallExpression {
             callee: ExpressionOrSuper::Super { loc: super_loc },
             arguments: arguments.unbox(),
             loc: SourceLocation::from_parts(super_loc, arguments_loc),
-        })
+        }))
     }
 
     // ImportCall : `import` `(` AssignmentExpression `)`
@@ -1964,7 +1964,7 @@ impl<'alloc> AstBuilder<'alloc> {
                 ),
             ),
 
-            Expression::CallExpression { .. } => {
+            Expression::CallExpression(CallExpression { .. }) => {
                 return Err(ParseError::NotImplemented(
                     "Assignment to CallExpression is allowed for non-strict mode.",
                 ));
@@ -4002,11 +4002,11 @@ impl<'alloc> AstBuilder<'alloc> {
         call_expression: arena::Box<'alloc, Expression<'alloc>>,
     ) -> Result<'alloc, (arena::Box<'alloc, FormalParameters<'alloc>>, SourceLocation)> {
         match call_expression.unbox() {
-            Expression::CallExpression {
+            Expression::CallExpression(CallExpression {
                 callee: ce,
                 arguments,
                 loc,
-            } => {
+            }) => {
                 // Check that `callee` is `async`.
                 match ce {
                     ExpressionOrSuper::Expression(callee) => match callee.unbox() {

--- a/rust/generated_parser/src/stack_value_generated.rs
+++ b/rust/generated_parser/src/stack_value_generated.rs
@@ -36,6 +36,7 @@ pub enum StackValue<'alloc> {
     BindingPropertyProperty(arena::Box<'alloc, BindingPropertyProperty<'alloc>>),
     BindingWithDefault(arena::Box<'alloc, BindingWithDefault<'alloc>>),
     Block(arena::Box<'alloc, Block<'alloc>>),
+    CallExpression(arena::Box<'alloc, CallExpression<'alloc>>),
     CatchClause(arena::Box<'alloc, CatchClause<'alloc>>),
     ClassDeclaration(arena::Box<'alloc, ClassDeclaration<'alloc>>),
     ClassElement(arena::Box<'alloc, ClassElement<'alloc>>),
@@ -397,6 +398,15 @@ impl<'alloc> StackValueItem<'alloc> for Block<'alloc> {
         match sv {
             StackValue::Block(v) => Ok(v),
             _ => Err(format!("StackValue expected Block, got {:?}", sv)),
+        }
+    }
+}
+
+impl<'alloc> StackValueItem<'alloc> for CallExpression<'alloc> {
+    fn to_ast(sv: StackValue<'alloc>) -> AstResult<'alloc, Self> {
+        match sv {
+            StackValue::CallExpression(v) => Ok(v),
+            _ => Err(format!("StackValue expected CallExpression, got {:?}", sv)),
         }
     }
 }
@@ -1410,6 +1420,13 @@ impl<'alloc> TryIntoStack<'alloc> for arena::Box<'alloc, Block<'alloc>> {
     type Error = Infallible;
     fn try_into_stack(self) -> Result<StackValue<'alloc>, Infallible> {
         Ok(StackValue::Block(self))
+    }
+}
+
+impl<'alloc> TryIntoStack<'alloc> for arena::Box<'alloc, CallExpression<'alloc>> {
+    type Error = Infallible;
+    fn try_into_stack(self) -> Result<StackValue<'alloc>, Infallible> {
+        Ok(StackValue::CallExpression(self))
     }
 }
 


### PR DESCRIPTION
Refactor `CallExpression` so that it can be reused in optionalChain