### PR TITLE
Support simple array and object literals

### DIFF
--- a/rust/emitter/src/ast_emitter.rs
+++ b/rust/emitter/src/ast_emitter.rs
@@ -267,8 +267,8 @@ impl AstEmitter {
                 return Err(EmitError::NotImplemented("TODO: NewTargetExpression"));
             }
 
-            Expression::ObjectExpression(_) => {
-                return Err(EmitError::NotImplemented("TODO: ObjectExpression"));
+            Expression::ObjectExpression(ast) => {
+                self.emit_object_expression(ast)?;
             }
 
             Expression::UnaryExpression {
@@ -435,6 +435,42 @@ impl AstEmitter {
             }
         }
         self.emit.double(value);
+    }
+
+    fn emit_object_expression(&mut self, object: &ObjectExpression) -> Result<(), EmitError> {
+        self.emit.new_init(0);
+
+        for property in object.properties.iter() {
+            self.emit_object_property(property)?;
+        }
+
+        Ok(())
+    }
+
+    fn emit_object_property(&mut self, property: &ObjectProperty) -> Result<(), EmitError> {
+        match property {
+            ObjectProperty::NamedObjectProperty(NamedObjectProperty::DataProperty(
+                DataProperty {
+                    property_name,
+                    expression,
+                    ..
+                },
+            )) => {
+                self.emit_expression(expression)?;
+
+                match property_name {
+                    PropertyName::StaticPropertyName(StaticPropertyName { value, .. }) => {
+                        self.emit.init_prop(value);
+                    }
+                    PropertyName::ComputedPropertyName(ComputedPropertyName { .. }) => {
+                        return Err(EmitError::NotImplemented("TODO: computed property"))
+                    }
+                }
+            }
+            _ => return Err(EmitError::NotImplemented("TODO: non data property")),
+        }
+
+        Ok(())
     }
 
     fn emit_array_expression(&mut self, array: &ArrayExpression) -> Result<(), EmitError> {

--- a/rust/emitter/src/ast_emitter.rs
+++ b/rust/emitter/src/ast_emitter.rs
@@ -205,8 +205,8 @@ impl AstEmitter {
                 self.emit.string(value);
             }
 
-            Expression::ArrayExpression(_) => {
-                return Err(EmitError::NotImplemented("TODO: ArrayExpression"));
+            Expression::ArrayExpression(ast) => {
+                self.emit_array_expression(ast)?;
             }
 
             Expression::ArrowExpression { .. } => {
@@ -435,6 +435,23 @@ impl AstEmitter {
             }
         }
         self.emit.double(value);
+    }
+
+    fn emit_array_expression(&mut self, array: &ArrayExpression) -> Result<(), EmitError> {
+        // TODO: Initialze to correct length where possible.
+        self.emit.new_array(0);
+
+        for (index, element) in array.elements.iter().enumerate() {
+            match element {
+                ArrayExpressionElement::Expression(expr) => {
+                    self.emit_expression(&expr)?;
+                    self.emit.init_elem_array(index as u32);
+                }
+                _ => return Err(EmitError::NotImplemented("TODO: Array Element")),
+            }
+        }
+
+        Ok(())
     }
 
     fn emit_conditional_expression(

--- a/rust/interpreter/src/evaluate.rs
+++ b/rust/interpreter/src/evaluate.rs
@@ -168,6 +168,21 @@ pub fn evaluate(emit: &EmitResult) -> Result<JSValue, EvalError> {
                 stack.push(value);
             }
 
+            Opcode::InitProp => {
+                let value = stack.pop().ok_or(EvalError::EmptyStack)?;
+                let obj = stack.pop().ok_or(EvalError::EmptyStack)?;
+
+                let atom = emit.read_atom(pc + 1);
+                match obj {
+                    JSValue::Object(ref obj) => {
+                        obj.borrow_mut().set(atom, value);
+                    }
+                    _ => return Err(EvalError::NotImplemented("not an object".to_owned())),
+                }
+
+                stack.push(obj);
+            }
+
             Opcode::InitElemArray => {
                 let value = stack.pop().ok_or(EvalError::EmptyStack)?;
                 let obj = stack.pop().ok_or(EvalError::EmptyStack)?;
@@ -240,7 +255,7 @@ pub fn evaluate(emit: &EmitResult) -> Result<JSValue, EvalError> {
 
             Opcode::JumpTarget => {}
 
-            Opcode::NewArray => {
+            Opcode::NewArray | Opcode::NewInit => {
                 stack.push(JSValue::Object(Rc::new(RefCell::new(Object::new()))));
             }
 


### PR DESCRIPTION
This adds support for array literals without holes or spread elements. For object literals this only supports "normal" data properties. 