### PR TITLE
Implement Early Erros for AssignmentTargetType, for arguments/eval (fixes #183)

### DIFF
--- a/rust/emitter/src/ast_emitter.rs
+++ b/rust/emitter/src/ast_emitter.rs
@@ -476,7 +476,7 @@ impl AstEmitter {
                     name,
                     ..
                 }),
-            ) if name.value != "eval" && name.value != "arguments" => {
+            ) => {
                 self.emit.bind_g_name(name.value);
                 self.emit_expression(expression)?;
                 self.emit.set_g_name(name.value);

--- a/rust/parser/src/tests.rs
+++ b/rust/parser/src/tests.rs
@@ -603,5 +603,4 @@ fn test_async_arrows() {
 fn test_coalesce() {
     assert_parses("const f = options.prop ?? 0;");
     assert_syntax_error("if (options.prop ?? 0 || options.prop > 1000) {}");
-
 }


### PR DESCRIPTION
Added the following to AstBuilder, and removed workaround in AstEmitter.

https://tc39.es/ecma262/#sec-identifiers-static-semantics-assignmenttargettype
```
12.1.3 Static Semantics: AssignmentTargetType

IdentifierReference : Identifier

1. If this IdentifierReference is contained in strict mode code and
   StringValue of Identifier is "eval" or "arguments", return invalid.
2. Return simple.
```

and also added some comments for spec steps.

currently `is_strict()` just returns `NotImplemented`.
So, script that contains any assignment to `eval` or `arguments` will fallback to C++