### PR TITLE
Initialize new arrays to the expected length. Fixes #209.

### DIFF
--- a/rust/emitter/src/ast_emitter.rs
+++ b/rust/emitter/src/ast_emitter.rs
@@ -514,8 +514,16 @@ impl<'alloc> AstEmitter<'alloc> {
     }
 
     fn emit_array_expression(&mut self, array: &ArrayExpression) -> Result<(), EmitError> {
-        // TODO: Initialze to correct length where possible.
-        self.emit.new_array(0);
+        // Initialize the array to its minimum possible length.
+        let min_length = array.elements.iter()
+            .map(|e| match e {
+                ArrayExpressionElement::Expression(_) => 1,
+                ArrayExpressionElement::Elision { .. } => 1,
+                ArrayExpressionElement::SpreadElement { .. } => 0,
+            })
+            .sum::<u32>();
+
+        self.emit.new_array(min_length);
 
         for (index, element) in array.elements.iter().enumerate() {
             match element {
@@ -527,7 +535,9 @@ impl<'alloc> AstEmitter<'alloc> {
                     self.emit.hole();
                     self.emit.init_elem_array(index as u32);
                 }
-                _ => return Err(EmitError::NotImplemented("TODO: Array Element")),
+                ArrayExpressionElement::SpreadElement { .. } => {
+                    return Err(EmitError::NotImplemented("TODO: SpreadElement"));
+                }
             }
         }
 


### PR DESCRIPTION
`array.elements.len()` would be fine as a stopgap, but I went ahead and
implemented what the C++ frontend does.