### PR TITLE
Implement method call

### DIFF
--- a/rust/emitter/src/ast_emitter.rs
+++ b/rust/emitter/src/ast_emitter.rs
@@ -606,6 +606,26 @@ impl<'alloc> AstEmitter<'alloc> {
                     let name_index = self.emit.get_atom_index(name.value);
                     self.emit.g_implicit_this(name_index);
                 }
+                Expression::MemberExpression(MemberExpression::StaticMemberExpression(
+                    StaticMemberExpression {
+                        object: ExpressionOrSuper::Expression(object),
+                        property,
+                        ..
+                    },
+                )) => {
+                    self.emit_expression(object)?;
+                    // [stack] Obj
+
+                    self.emit.dup();
+                    // [stack] Obj Obj
+
+                    let property_index = self.emit.get_atom_index(property.value);
+                    self.emit.call_prop(property_index);
+                    // [stack] Obj Callee
+
+                    self.emit.swap();
+                    // [stack] Callee Obj/This
+                }
                 _ => {
                     return Err(EmitError::NotImplemented(
                         "TODO: Call (only global functions are supported)",

--- a/rust/interpreter/src/globals.rs
+++ b/rust/interpreter/src/globals.rs
@@ -1,0 +1,35 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::object::Object;
+use crate::value::{to_number, JSValue};
+
+fn print(_this_value: JSValue, args: &[JSValue]) -> JSValue {
+    println!("{:?}", args);
+    JSValue::Undefined
+}
+
+fn sqrt(_this_value: JSValue, args: &[JSValue]) -> JSValue {
+    let n = to_number(args.first().unwrap_or(&JSValue::Undefined));
+    JSValue::Number(n.sqrt())
+}
+
+pub fn create_global() -> Rc<RefCell<Object>> {
+    let global = Rc::new(RefCell::new(Object::new()));
+    global
+        .borrow_mut()
+        .set("print".to_owned(), JSValue::NativeFunction(print));
+    global
+        .borrow_mut()
+        .set("undefined".to_owned(), JSValue::Undefined);
+
+    let math = Rc::new(RefCell::new(Object::new()));
+    math.borrow_mut()
+        .set("sqrt".to_owned(), JSValue::NativeFunction(sqrt));
+
+    global
+        .borrow_mut()
+        .set("Math".to_owned(), JSValue::Object(math));
+
+    global
+}

--- a/rust/interpreter/src/lib.rs
+++ b/rust/interpreter/src/lib.rs
@@ -1,4 +1,5 @@
 mod evaluate;
+mod globals;
 mod object;
 mod value;
 

--- a/rust/interpreter/src/tests.rs
+++ b/rust/interpreter/src/tests.rs
@@ -110,4 +110,9 @@ fn test_call() {
         Ok(JSValue::Undefined) => (),
         _ => panic!("wrong result"),
     }
+
+    match try_evaluate("Math.sqrt(36)") {
+        Ok(JSValue::Number(n)) if n == 6.0 => (),
+        _ => panic!("wrong result"),
+    }
 }


### PR DESCRIPTION
Implement method calls where the base/object is an ordinary expression and not super. I didn't notice any new failure when running with jstests or jittest.