### PR TITLE
Add ast::AssociatedData (fixes #244)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ HANDLER_FILE = rust/generated_parser/src/ast_builder.rs
 HANDLER_INFO_OUT = jsparagus/emit/collect_handler_info/info.json
 RS_TABLES_OUT = rust/generated_parser/src/parser_tables_generated.rs
 RS_AST_OUT = rust/ast/src/types_generated.rs \
+	rust/ast/src/type_id_generated.rs \
 	rust/ast/src/visit_generated.rs \
 	rust/ast/src/source_location_accessor_generated.rs \
 	rust/generated_parser/src/stack_value_generated.rs

--- a/rust/ast/generate_ast.py
+++ b/rust/ast/generate_ast.py
@@ -252,7 +252,7 @@ def loc_trait(ast):
         write(0, "use crate::types::*;")
         write(0, "use std::borrow::{Borrow, BorrowMut};")
         write(0, "")
-        write(0, "pub trait SourceLocationAccessor<'alloc> {")
+        write(0, "pub trait SourceLocationAccessor {")
         write(1, "fn set_loc(&mut self, start: SourceLocation, end: SourceLocation);")
         write(1, "fn get_loc(&self) -> SourceLocation;")
         write(0, "}")
@@ -271,7 +271,7 @@ def loc_trait(ast):
             rust_ty = ty.to_rust_type(ast)
             decl = ast.type_decls[ty.name]
 
-            write(0, "impl<'alloc> SourceLocationAccessor<'alloc> for {} {{", rust_ty)
+            write(0, "impl<'alloc> SourceLocationAccessor for {} {{", rust_ty)
             if isinstance(decl, Struct):
                 write(1, "fn set_loc(&mut self, start: SourceLocation, end: SourceLocation) {")
                 write(2, "self.loc.start = start.start;")
@@ -329,9 +329,9 @@ def loc_trait(ast):
         for ty in extra_types:
             define_accessor(ty)
 
-        write(0, "impl<'alloc, T> SourceLocationAccessor<'alloc> for arena::Box<'alloc, T>")
+        write(0, "impl<'alloc, T> SourceLocationAccessor for arena::Box<'alloc, T>")
         write(0, "where")
-        write(1, "T: SourceLocationAccessor<'alloc>,")
+        write(1, "T: SourceLocationAccessor,")
         write(0, "{")
         write(1, "fn set_loc(&mut self, start: SourceLocation, end: SourceLocation) {")
         write(2, "(self.borrow_mut() as &mut T).set_loc(start, end)")

--- a/rust/ast/src/associated_data.rs
+++ b/rust/ast/src/associated_data.rs
@@ -1,0 +1,125 @@
+use crate::source_location_accessor::SourceLocationAccessor;
+use crate::type_id::{NodeTypeId, NodeTypeIdAccessor};
+use crate::SourceLocation;
+use std::collections::HashMap;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+struct Key {
+    type_id: NodeTypeId,
+    loc: SourceLocation,
+}
+
+impl Key {
+    fn new<NodeT>(node: &NodeT) -> Self
+    where
+        NodeT: SourceLocationAccessor + NodeTypeIdAccessor,
+    {
+        Self {
+            type_id: node.get_type_id(),
+            loc: node.get_loc(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Item<ValueT> {
+    key: Key,
+    value: ValueT,
+}
+
+impl<ValueT> Item<ValueT> {
+    fn new(key: Key, value: ValueT) -> Self {
+        Self { key, value }
+    }
+}
+
+type ItemIndex = usize;
+
+#[derive(Debug)]
+pub struct AssociatedDataItemIndex {
+    index: ItemIndex,
+}
+impl AssociatedDataItemIndex {
+    fn new(index: ItemIndex) -> Self {
+        Self { index }
+    }
+}
+
+// A map from AST node to `ValueT`, to associate extra data to AST node.
+#[derive(Debug)]
+pub struct AssociatedData<ValueT> {
+    items: Vec<Item<ValueT>>,
+    map: HashMap<Key, ItemIndex>,
+}
+
+impl<ValueT> AssociatedData<ValueT> {
+    pub fn new() -> Self {
+        Self {
+            items: Vec::new(),
+            map: HashMap::new(),
+        }
+    }
+
+    // Insert an item for `node`.
+    // Returns the index of the inserted item.
+    pub fn insert<NodeT>(&mut self, node: &NodeT, value: ValueT) -> AssociatedDataItemIndex
+    where
+        NodeT: SourceLocationAccessor + NodeTypeIdAccessor,
+    {
+        let index = self.items.len();
+        let key = Key::new(node);
+        self.items.push(Item::new(key.clone(), value));
+        self.map.insert(key, index);
+
+        AssociatedDataItemIndex::new(index)
+    }
+
+    // Get the immutable reference of the item for the index.
+    // The index is the return value of `insert` or `to_index`.
+    pub fn get_by_index(&self, index: AssociatedDataItemIndex) -> &ValueT {
+        // NOTE: This can panic if `index` is created by another instance of
+        // `AssociatedData`.
+        &self.items[index.index].value
+    }
+
+    // Get the mutable reference of the item for the index.
+    // The index is the return value of `insert` or `to_index`.
+    pub fn get_mut_by_index(&mut self, index: AssociatedDataItemIndex) -> &mut ValueT {
+        // NOTE: This can panic if `index` is created by another instance of
+        // `AssociatedData`.
+        &mut self.items[index.index].value
+    }
+
+    // Get the immutable reference of the item for `node`.
+    // `None` if there's no item inserted for `node`.
+    pub fn get<NodeT>(&self, node: &NodeT) -> Option<&ValueT>
+    where
+        NodeT: SourceLocationAccessor + NodeTypeIdAccessor,
+    {
+        self.to_index(node)
+            .and_then(|index| Some(self.get_by_index(index)))
+    }
+
+    // Get the mutable reference of the item for `node`.
+    // `None` if there's no item inserted for `node`.
+    pub fn get_mut<NodeT>(&mut self, node: &NodeT) -> Option<&mut ValueT>
+    where
+        NodeT: SourceLocationAccessor + NodeTypeIdAccessor,
+    {
+        self.to_index(node)
+            .and_then(move |index| Some(self.get_mut_by_index(index)))
+    }
+
+    // Returns the index for the item for `node`.
+    // `None` if there's no item inserted for `node`.
+    pub fn to_index<NodeT>(&self, node: &NodeT) -> Option<AssociatedDataItemIndex>
+    where
+        NodeT: SourceLocationAccessor + NodeTypeIdAccessor,
+    {
+        let key = Key::new(node);
+        match self.map.get(&key) {
+            Some(index) => Some(AssociatedDataItemIndex::new(*index)),
+            None => None,
+        }
+    }
+}

--- a/rust/ast/src/lib.rs
+++ b/rust/ast/src/lib.rs
@@ -1,6 +1,7 @@
 //! The Visage AST (abstract syntax tree).
 
 pub mod arena;
+pub mod associated_data;
 pub mod source_location;
 
 mod source_location_accessor_generated;
@@ -14,6 +15,10 @@ pub mod types {
 mod visit_generated;
 pub mod visit {
     pub use crate::visit_generated::*;
+}
+mod type_id_generated;
+pub mod type_id {
+    pub use crate::type_id_generated::*;
 }
 
 pub use source_location::SourceLocation;

--- a/rust/ast/src/source_location.rs
+++ b/rust/ast/src/source_location.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct SourceLocation {
     pub start: usize,
     pub end: usize,


### PR DESCRIPTION
This add the following:
  * `NodeTypeId` that represents AST node type (basically a map from AST node type to integer)
  * `NodeTypeIdAccessor` that adds `get_type_id` method for each AST node type, that returns `NodeTypeId`
 * `AssociatedData`, that is a map from AST node (`NodeTypeId`+`SourceLocation`) to arbitrary  data

Assuming `AssociatedData` is created (`AssociatedData,insert`) while visiting AST node, and also the consumer will get (`AssociatedData.remove`) the data in the same order, the implementation is optimized for sequential access (`AssociatedData.next_index`).

`AssociatedData.allocate` and `AssociatedData.populate` are for the case when the order differs.
This is especially for the case that creating scope information.
The scope information is created at the end of the node (after visiting all fields), while the scope information is used at the beginning of the node (before visiting all fields).
So, instead of doing `insert` at the end, do `allocate` at the beginning, and `populate` at the end.
