### PR TITLE
fix #94 - do not use cargo-fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Join us on Discord: https://discord.gg/tUFFk9Y
 ## Getting started
 
 ```sh
-cargo install cargo-fmt
 git config core.hooksPath .githooks
 make init
 make all


### PR DESCRIPTION
cargo-fmt cannot be installed via `cargo install cargo-fmt` and is bundled with rustfmt