### PR TITLE
move githooks initialization to make init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ PIP := $(VENV_BIN_DIR)/pip
 init:
 	python3 -m venv jsparagus_build_venv &&\
 	$(PIP) install --upgrade pip &&\
-	$(PIP) install -r requirements.txt
+	$(PIP) install -r requirements.txt &&\
+	git config core.hooksPath .githooks
 
 all: $(PY_OUT) rust
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Join us on Discord: https://discord.gg/tUFFk9Y
 ## Getting started
 
 ```sh
-git config core.hooksPath .githooks
 make init
 make all
 ```


### PR DESCRIPTION
I noticed while we were discussing cargo-fmt that we still had the git hooks outside of the make init file. This updates it so that githooks are set in the init file.