### PR TITLE
Add jsparagus- prefix to all crates (fixes #310)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11,15 +11,6 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "ast"
-version = "0.1.0"
-dependencies = [
- "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,37 +91,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "driver"
-version = "0.1.0"
-dependencies = [
- "ast 0.1.0",
- "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "emitter 0.1.0",
- "interpreter 0.1.0",
- "parser 0.1.0",
- "rustyline 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustyline-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "emitter"
-version = "0.1.0"
-dependencies = [
- "ast 0.1.0",
- "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parser 0.1.0",
-]
-
-[[package]]
-name = "generated_parser"
-version = "0.1.0"
-dependencies = [
- "ast 0.1.0",
- "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,19 +101,69 @@ dependencies = [
 ]
 
 [[package]]
-name = "interpreter"
-version = "0.1.0"
-dependencies = [
- "ast 0.1.0",
- "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "emitter 0.1.0",
- "parser 0.1.0",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jsparagus-ast"
+version = "0.1.0"
+dependencies = [
+ "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsparagus-driver"
+version = "0.1.0"
+dependencies = [
+ "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsparagus-ast 0.1.0",
+ "jsparagus-emitter 0.1.0",
+ "jsparagus-interpreter 0.1.0",
+ "jsparagus-parser 0.1.0",
+ "rustyline 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustyline-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsparagus-emitter"
+version = "0.1.0"
+dependencies = [
+ "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsparagus-ast 0.1.0",
+ "jsparagus-parser 0.1.0",
+]
+
+[[package]]
+name = "jsparagus-generated-parser"
+version = "0.1.0"
+dependencies = [
+ "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsparagus-ast 0.1.0",
+]
+
+[[package]]
+name = "jsparagus-interpreter"
+version = "0.1.0"
+dependencies = [
+ "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsparagus-ast 0.1.0",
+ "jsparagus-emitter 0.1.0",
+ "jsparagus-parser 0.1.0",
+]
+
+[[package]]
+name = "jsparagus-parser"
+version = "0.1.0"
+dependencies = [
+ "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsparagus-ast 0.1.0",
+ "jsparagus-generated-parser 0.1.0",
+ "unic-ucd-ident 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazy_static"
@@ -188,16 +198,6 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parser"
-version = "0.1.0"
-dependencies = [
- "ast 0.1.0",
- "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "generated_parser 0.1.0",
- "unic-ucd-ident 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/rust/ast/Cargo.toml
+++ b/rust/ast/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ast"
+name = "jsparagus-ast"
 version = "0.1.0"
 authors = ["khyperia <khyperia@live.com>"]
 edition = "2018"

--- a/rust/driver/Cargo.toml
+++ b/rust/driver/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "driver"
+name = "jsparagus-driver"
 version = "0.1.0"
 authors = ["khyperia <khyperia@live.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-ast = { path = "../ast" }
 bumpalo = "2.6.0"
+jsparagus-ast = { path = "../ast" }
+jsparagus-emitter = { path = "../emitter" }
+jsparagus-interpreter = { path = "../interpreter" }
+jsparagus-parser = { path = "../parser" }
 rustyline = "6.0.0"
 rustyline-derive = "0.3.0"
-emitter = { path = "../emitter" }
-parser = { path = "../parser" }
-interpreter = { path = "../interpreter" }
 
 # jemalloc is temporarily disabled due to a known upstream bug (macOS crashes
 # in release builds): <https://github.com/gnzlbg/jemallocator/issues/136>

--- a/rust/driver/src/demo.rs
+++ b/rust/driver/src/demo.rs
@@ -6,12 +6,13 @@ use std::io;
 use std::io::prelude::*; // flush() at least
 use std::path::Path;
 
-use ast::{
-    self,
-    types::{Program, Script},
-};
+extern crate jsparagus_ast as ast;
+extern crate jsparagus_emitter as emitter;
+extern crate jsparagus_interpreter as interpreter;
+extern crate jsparagus_parser as parser;
+
+use ast::types::{Program, Script};
 use bumpalo::Bump;
-use emitter;
 use parser::{is_partial_script, parse_script, ParseOptions};
 
 use rustyline::error::ReadlineError;

--- a/rust/emitter/Cargo.toml
+++ b/rust/emitter/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "emitter"
+name = "jsparagus-emitter"
 version = "0.1.0"
 authors = ["khyperia <github@khyperia.com>"]
 edition = "2018"
@@ -8,9 +8,9 @@ license = "MIT/Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ast = { path = "../ast" }
 bumpalo = "2.6.0"
 byteorder = "1.3.2"
+jsparagus-ast = { path = "../ast" }
 
 [dev-dependencies]
-parser = { path = "../parser" }
+jsparagus-parser = { path = "../parser" }

--- a/rust/emitter/src/lib.rs
+++ b/rust/emitter/src/lib.rs
@@ -4,6 +4,8 @@ mod emitter;
 mod lower;
 pub mod opcode;
 
+extern crate jsparagus_ast as ast;
+
 pub use crate::emitter::{EmitError, EmitOptions, EmitResult};
 pub use dis::dis;
 
@@ -14,6 +16,8 @@ pub fn emit(ast: &mut ast::types::Program, options: &EmitOptions) -> Result<Emit
 
 #[cfg(test)]
 mod tests {
+    extern crate jsparagus_parser as parser;
+
     use super::{emit, EmitOptions};
     use crate::dis::*;
     use crate::opcode::*;

--- a/rust/generated_parser/Cargo.toml
+++ b/rust/generated_parser/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "generated_parser"
+name = "jsparagus-generated-parser"
 version = "0.1.0"
 authors = ["khyperia <khyperia@live.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-ast = { path = "../ast" }
 bumpalo = "2.6.0"
+jsparagus-ast = { path = "../ast" }

--- a/rust/generated_parser/src/ast_builder.rs
+++ b/rust/generated_parser/src/ast_builder.rs
@@ -1043,10 +1043,12 @@ impl<'alloc> AstBuilder<'alloc> {
         }
 
         let loc = token.loc;
-        Ok(self.alloc(PropertyName::StaticPropertyName(StaticPropertyName {
-            value,
-            loc,
-        })))
+        Ok(
+            self.alloc(PropertyName::StaticPropertyName(StaticPropertyName {
+                value,
+                loc,
+            })),
+        )
     }
 
     // LiteralPropertyName : StringLiteral
@@ -1060,10 +1062,12 @@ impl<'alloc> AstBuilder<'alloc> {
         }
 
         let loc = token.loc;
-        Ok(self.alloc(PropertyName::StaticPropertyName(StaticPropertyName {
-            value,
-            loc,
-        })))
+        Ok(
+            self.alloc(PropertyName::StaticPropertyName(StaticPropertyName {
+                value,
+                loc,
+            })),
+        )
     }
 
     // LiteralPropertyName : NumericLiteral

--- a/rust/generated_parser/src/lib.rs
+++ b/rust/generated_parser/src/lib.rs
@@ -8,6 +8,8 @@ mod parser_tables_generated;
 mod stack_value_generated;
 mod token;
 
+extern crate jsparagus_ast as ast;
+
 pub use ast_builder::AstBuilder;
 pub use declaration_kind::DeclarationKind;
 pub use error::{ParseError, Result};

--- a/rust/interpreter/Cargo.toml
+++ b/rust/interpreter/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "interpreter"
+name = "jsparagus-interpreter"
 version = "0.1.0"
 authors = ["Tom Schuster <evilpies@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-emitter = { path = "../emitter" }
+jsparagus-emitter = { path = "../emitter" }
 
 [dev-dependencies]
-ast = { path = "../ast" }
-parser = { path = "../parser" }
 bumpalo = "2.6.0"
+jsparagus-ast = { path = "../ast" }
+jsparagus-parser = { path = "../parser" }

--- a/rust/interpreter/src/lib.rs
+++ b/rust/interpreter/src/lib.rs
@@ -6,5 +6,12 @@ mod value;
 #[cfg(test)]
 mod tests;
 
+extern crate jsparagus_emitter as emitter;
+
+#[cfg(test)]
+extern crate jsparagus_ast as ast;
+#[cfg(test)]
+extern crate jsparagus_parser as parser;
+
 pub use evaluate::{evaluate, EvalError};
 pub use value::JSValue;

--- a/rust/parser/Cargo.toml
+++ b/rust/parser/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "parser"
+name = "jsparagus-parser"
 version = "0.1.0"
 authors = ["Jason Orendorff <jason.orendorff@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-generated_parser = { path = "../generated_parser" }
-ast = { path = "../ast" }
 bumpalo = "2.6.0"
+jsparagus-ast = { path = "../ast" }
+jsparagus-generated-parser = { path = "../generated_parser" }
 unic-ucd-ident = { version = "0.9.0", features = ["id"] }

--- a/rust/parser/src/lib.rs
+++ b/rust/parser/src/lib.rs
@@ -7,6 +7,9 @@ mod simulator;
 #[cfg(test)]
 mod tests;
 
+extern crate jsparagus_ast as ast;
+extern crate jsparagus_generated_parser as generated_parser;
+
 use crate::parser::Parser;
 use ast::{
     arena,


### PR DESCRIPTION
context in https://github.com/mozilla-spidermonkey/jsparagus/issues/310

so far:
  * added `jsparagus-` prefix to all crates
  * added alias to them by `extern crate jsparagus_NAME as NAME;` so that existing code doesn't have to be modified

now preparing corresponding change to rust-frontend