### PR TITLE
create generated branch (fixes #316)

### DIFF
--- a/.github/workflows/ci-generated.yml
+++ b/.github/workflows/ci-generated.yml
@@ -1,0 +1,36 @@
+name: Generate Files
+
+on:
+  push:
+      branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: "3.7"
+    - name: Generate Files
+      run: |
+        make init-venv && make all
+        # OS independant replace
+        sed -i.bak '/*_generated.rs/d' .gitignore && rm .gitignore.bak
+    - name: Commit files
+      run: |
+        git add .
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git commit -m "Add Generated Files" -a
+        git fetch --unshallow upstream
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ci_generated
+        force: true

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,12 @@ VENV_BIN_DIR := $(JSPARAGUS_DIR)jsparagus_build_venv/bin
 PYTHON := $(VENV_BIN_DIR)/python
 PIP := $(VENV_BIN_DIR)/pip
 
-init:
+init-venv:
 	python3 -m venv jsparagus_build_venv &&\
 	$(PIP) install --upgrade pip &&\
-	$(PIP) install -r requirements.txt &&\
+	$(PIP) install -r requirements.txt
+
+init: init-venv
 	git config core.hooksPath .githooks
 
 all: $(PY_OUT) rust


### PR DESCRIPTION
This action introduces a way for us to automatically generate a `ci_generated` branch on push to master. The files generated are these ones: https://github.com/mozilla-spidermonkey/jsparagus/commit/7a277811102a52004d4276df8a52c87019bffd89