### PR TITLE
Add AtomSet to store Strings and use index into it in emitter (fixes #178, fixes #308)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+
+[[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,7 +83,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "cfg-if",
  "lazy_static",
 ]
@@ -113,6 +119,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+dependencies = [
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -161,6 +176,7 @@ version = "0.1.0"
 dependencies = [
  "bumpalo",
  "byteorder",
+ "indexmap",
  "jsparagus-ast",
  "jsparagus-parser",
 ]

--- a/crates/emitter/Cargo.toml
+++ b/crates/emitter/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT/Apache-2.0"
 [dependencies]
 bumpalo = "2.6.0"
 byteorder = "1.3.2"
+indexmap = "1.0"
 jsparagus-ast = { path = "../ast" }
 
 [dev-dependencies]

--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -4,6 +4,11 @@
 
 use super::emitter::{BytecodeOffset, EmitError, EmitOptions, EmitResult, InstructionWriter};
 use super::opcode::Opcode;
+use crate::reference_op_emitter::{
+    AssignmentEmitter, CallEmitter, GetElemEmitter, GetNameEmitter, GetPropEmitter,
+    GetSuperElemEmitter, GetSuperPropEmitter, NameReferenceEmitter, NewEmitter,
+    PropReferenceEmitter,
+};
 use ast::types::*;
 
 /// Emit a program, converting the AST directly to bytecode.
@@ -23,8 +28,8 @@ pub fn emit_program(ast: &Program, options: &EmitOptions) -> Result<EmitResult, 
     Ok(emitter.emit.into_emit_result())
 }
 
-struct AstEmitter<'alloc> {
-    emit: InstructionWriter,
+pub struct AstEmitter<'alloc> {
+    pub emit: InstructionWriter,
     options: &'alloc EmitOptions,
 }
 
@@ -164,9 +169,11 @@ impl<'alloc> AstEmitter<'alloc> {
                     ..
                 },
             )) => {
-                self.emit_expression(object)?;
-                self.emit_expression(expression)?;
-                self.emit.get_elem();
+                GetElemEmitter {
+                    obj: |emitter| emitter.emit_expression(object),
+                    key: |emitter| emitter.emit_expression(expression),
+                }
+                .emit(self)?;
             }
 
             Expression::MemberExpression(MemberExpression::ComputedMemberExpression(
@@ -176,11 +183,11 @@ impl<'alloc> AstEmitter<'alloc> {
                     ..
                 },
             )) => {
-                self.emit_this()?;
-                self.emit_expression(expression)?;
-                self.emit.callee();
-                self.emit.super_base();
-                self.emit.get_elem_super();
+                GetSuperElemEmitter {
+                    this: |emitter| emitter.emit_this(),
+                    key: |emitter| emitter.emit_expression(expression),
+                }
+                .emit(self)?;
             }
 
             Expression::MemberExpression(MemberExpression::StaticMemberExpression(
@@ -190,9 +197,11 @@ impl<'alloc> AstEmitter<'alloc> {
                     ..
                 },
             )) => {
-                self.emit_expression(object)?;
-                let name_index = self.emit.get_atom_index(&property.value);
-                self.emit.get_prop(name_index);
+                GetPropEmitter {
+                    obj: |emitter| emitter.emit_expression(object),
+                    key: &property.value,
+                }
+                .emit(self)?;
             }
 
             Expression::MemberExpression(MemberExpression::StaticMemberExpression(
@@ -202,11 +211,11 @@ impl<'alloc> AstEmitter<'alloc> {
                     ..
                 },
             )) => {
-                self.emit_this()?;
-                self.emit.callee();
-                self.emit.super_base();
-                let name_index = self.emit.get_atom_index(&property.value);
-                self.emit.get_prop_super(name_index);
+                GetSuperPropEmitter {
+                    this: |emitter| emitter.emit_this(),
+                    key: &property.value,
+                }
+                .emit(self)?;
             }
 
             Expression::MemberExpression(MemberExpression::PrivateFieldExpression(
@@ -590,29 +599,25 @@ impl<'alloc> AstEmitter<'alloc> {
         binding: &AssignmentTarget,
         expression: &Expression,
     ) -> Result<(), EmitError> {
-        match binding {
-            AssignmentTarget::SimpleAssignmentTarget(
-                SimpleAssignmentTarget::AssignmentTargetIdentifier(AssignmentTargetIdentifier {
-                    name,
-                    ..
-                }),
-            ) => {
-                let name_index = self.emit.get_atom_index(name.value);
-                self.emit.bind_g_name(name_index);
-                self.emit_expression(expression)?;
-                self.emit.set_g_name(name_index);
-                return Ok(());
-            }
-            _ => {}
+        AssignmentEmitter {
+            lhs: |emitter| match binding {
+                AssignmentTarget::SimpleAssignmentTarget(
+                    SimpleAssignmentTarget::AssignmentTargetIdentifier(
+                        AssignmentTargetIdentifier { name, .. },
+                    ),
+                ) => Ok(NameReferenceEmitter { name: name.value }.emit_for_assignment(emitter)),
+                _ => Err(EmitError::NotImplemented(
+                    "non-identifier assignment target",
+                )),
+            },
+            rhs: |emitter| emitter.emit_expression(expression),
         }
-
-        return Err(EmitError::NotImplemented("TODO: AssignmentExpression"));
+        .emit(self)
     }
 
     fn emit_identifier_expression(&mut self, ast: &IdentifierExpression) {
         let name = &ast.name.value;
-        let name_index = self.emit.get_atom_index(name);
-        self.emit.get_g_name(name_index);
+        GetNameEmitter { name }.emit(self);
     }
 
     fn emit_new_expression(
@@ -626,19 +631,14 @@ impl<'alloc> AstEmitter<'alloc> {
             }
         }
 
-        self.emit_expression(callee)?;
-        // Callee
-
-        self.emit.is_constructing();
-        // Callee JS_IS_CONSTRUCTING
-
-        self.emit_arguments(arguments)?;
-        // Callee JS_IS_CONSTRUCTING Args..
-
-        self.emit.dup_at(arguments.args.len() as u32 + 1);
-        // Callee JS_IS_CONSTRUCTING Args.. Callee
-
-        self.emit.new_(arguments.args.len() as u16);
+        NewEmitter {
+            callee: |emitter| emitter.emit_expression(callee),
+            arguments: |emitter| {
+                emitter.emit_arguments(arguments)?;
+                Ok(arguments.args.len())
+            },
+        }
+        .emit(self)?;
 
         Ok(())
     }
@@ -650,46 +650,40 @@ impl<'alloc> AstEmitter<'alloc> {
     ) -> Result<(), EmitError> {
         // Don't do super handling in an emit_expresion_or_super because the bytecode heavily
         // depends on how you're using the super
-        match callee {
-            ExpressionOrSuper::Expression(expr) => match &**expr {
-                Expression::IdentifierExpression(IdentifierExpression { name, .. }) => {
-                    self.emit_expression(expr)?;
-                    let name_index = self.emit.get_atom_index(name.value);
-                    self.emit.g_implicit_this(name_index);
-                }
-                Expression::MemberExpression(MemberExpression::StaticMemberExpression(
-                    StaticMemberExpression {
-                        object: ExpressionOrSuper::Expression(object),
-                        property,
-                        ..
-                    },
-                )) => {
-                    self.emit_expression(object)?;
-                    // [stack] Obj
 
-                    self.emit.dup();
-                    // [stack] Obj Obj
-
-                    let property_index = self.emit.get_atom_index(property.value);
-                    self.emit.call_prop(property_index);
-                    // [stack] Obj Callee
-
-                    self.emit.swap();
-                    // [stack] Callee Obj/This
-                }
+        CallEmitter {
+            callee: |emitter| match callee {
+                ExpressionOrSuper::Expression(expr) => match &**expr {
+                    Expression::IdentifierExpression(IdentifierExpression { name, .. }) => {
+                        Ok(NameReferenceEmitter { name: name.value }.emit_for_call(emitter))
+                    }
+                    Expression::MemberExpression(MemberExpression::StaticMemberExpression(
+                        StaticMemberExpression {
+                            object: ExpressionOrSuper::Expression(object),
+                            property,
+                            ..
+                        },
+                    )) => PropReferenceEmitter {
+                        obj: |emitter| emitter.emit_expression(object),
+                        key: property.value,
+                    }
+                    .emit_for_call(emitter),
+                    _ => {
+                        return Err(EmitError::NotImplemented(
+                            "TODO: Call (only global functions are supported)",
+                        ));
+                    }
+                },
                 _ => {
-                    return Err(EmitError::NotImplemented(
-                        "TODO: Call (only global functions are supported)",
-                    ));
+                    return Err(EmitError::NotImplemented("TODO: Super"));
                 }
             },
-            _ => {
-                return Err(EmitError::NotImplemented("TODO: Super"));
-            }
+            arguments: |emitter| {
+                emitter.emit_arguments(arguments)?;
+                Ok(arguments.args.len())
+            },
         }
-
-        self.emit_arguments(arguments)?;
-        self.emit.call(arguments.args.len() as u16);
+        .emit(self)?;
 
         Ok(())
     }

--- a/crates/emitter/src/atoms.rs
+++ b/crates/emitter/src/atoms.rs
@@ -1,0 +1,41 @@
+use crate::atomset::AtomSetIndex;
+use indexmap::set::IndexSet;
+
+/// Index into AtomList.atoms.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct AtomIndex {
+    index: u32,
+}
+impl AtomIndex {
+    fn new(index: u32) -> Self {
+        Self { index }
+    }
+
+    pub fn into_raw(self) -> u32 {
+        self.index
+    }
+}
+
+/// List of atoms referred from bytecode.
+///
+/// Maps to JSScript::atoms() in js/src/vm/JSScript.h.
+pub struct AtomList {
+    atoms: IndexSet<AtomSetIndex>,
+}
+
+impl AtomList {
+    pub fn new() -> Self {
+        Self {
+            atoms: IndexSet::new(),
+        }
+    }
+
+    pub fn insert(&mut self, value: AtomSetIndex) -> AtomIndex {
+        let (index, _) = self.atoms.insert_full(value);
+        AtomIndex::new(index as u32)
+    }
+
+    pub fn into_vec(mut self) -> Vec<AtomSetIndex> {
+        self.atoms.drain(..).collect()
+    }
+}

--- a/crates/emitter/src/atomset.rs
+++ b/crates/emitter/src/atomset.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+
+/// Index into AtomSet.atoms.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct AtomSetIndex {
+    index: usize,
+}
+impl AtomSetIndex {
+    fn new(index: usize) -> Self {
+        Self { index }
+    }
+
+    pub fn into_raw(self) -> usize {
+        self.index
+    }
+}
+
+/// Set of atoms, including the following:
+///
+///   * atoms referred from bytecode
+///   * variable names referred from scope data
+///
+/// WARNING: This set itself does *NOT* map to JSScript::atoms().
+///          See atoms.rs.
+#[derive(Debug)]
+pub struct AtomSet<'alloc> {
+    atoms: Vec<String>,
+
+    /// Cache for the case the same string is inserted multiple times.
+    atom_indices: HashMap<&'alloc str, AtomSetIndex>,
+}
+
+impl<'alloc> AtomSet<'alloc> {
+    pub fn new() -> Self {
+        Self {
+            atoms: Vec::new(),
+            atom_indices: HashMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, s: &'alloc str) -> AtomSetIndex {
+        match self.atom_indices.get(s) {
+            Some(index) => return *index,
+            _ => {}
+        }
+
+        let index = self.atoms.len();
+        self.atoms.push(s.to_string());
+        let result = AtomSetIndex::new(index);
+        self.atom_indices.insert(s, result);
+        result
+    }
+
+    pub fn into_vec(self) -> Vec<String> {
+        self.atoms
+    }
+}

--- a/crates/emitter/src/compilation_info.rs
+++ b/crates/emitter/src/compilation_info.rs
@@ -1,0 +1,11 @@
+use crate::atomset::AtomSet;
+
+pub struct CompilationInfo<'alloc> {
+    pub atoms: AtomSet<'alloc>,
+}
+
+impl<'alloc> CompilationInfo<'alloc> {
+    pub fn new(atoms: AtomSet<'alloc>) -> Self {
+        Self { atoms }
+    }
+}

--- a/crates/emitter/src/lib.rs
+++ b/crates/emitter/src/lib.rs
@@ -3,6 +3,7 @@ mod dis;
 mod emitter;
 mod lower;
 pub mod opcode;
+mod reference_op_emitter;
 
 extern crate jsparagus_ast as ast;
 

--- a/crates/emitter/src/lib.rs
+++ b/crates/emitter/src/lib.rs
@@ -1,4 +1,7 @@
 mod ast_emitter;
+mod atoms;
+mod atomset;
+mod compilation_info;
 mod dis;
 mod emitter;
 mod lower;
@@ -10,9 +13,15 @@ extern crate jsparagus_ast as ast;
 pub use crate::emitter::{EmitError, EmitOptions, EmitResult};
 pub use dis::dis;
 
-pub fn emit(ast: &mut ast::types::Program, options: &EmitOptions) -> Result<EmitResult, EmitError> {
-    //lower::run(ast);
-    ast_emitter::emit_program(ast, options)
+pub fn emit<'alloc>(
+    ast: &mut ast::types::Program<'alloc>,
+    options: &EmitOptions,
+) -> Result<EmitResult, EmitError> {
+    let atoms = atomset::AtomSet::new();
+
+    // NOTE: atoms will be modified by scope pass here.
+
+    ast_emitter::emit_program(ast, options, atoms)
 }
 
 #[cfg(test)]

--- a/crates/emitter/src/reference_op_emitter.rs
+++ b/crates/emitter/src/reference_op_emitter.rs
@@ -1,0 +1,452 @@
+use super::emitter::{AtomIndex, EmitError};
+use crate::ast_emitter::AstEmitter;
+
+#[derive(Debug, PartialEq)]
+enum AssignmentReferenceKind {
+    GlobalName(AtomIndex),
+    #[allow(dead_code)]
+    Prop(AtomIndex),
+    #[allow(dead_code)]
+    Elem,
+}
+
+// See AssignmentReferenceEmitter.
+// This uses struct to hide the details from the consumer.
+#[derive(Debug)]
+#[must_use]
+pub struct AssignmentReference {
+    kind: AssignmentReferenceKind,
+}
+impl AssignmentReference {
+    fn new(kind: AssignmentReferenceKind) -> Self {
+        Self { kind }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum CallKind {
+    Normal,
+    // FIXME: Support eval, Function#call, Function#apply etc.
+}
+
+// See *ReferenceEmitter.
+// This uses struct to hide the details from the consumer.
+#[derive(Debug)]
+#[must_use]
+pub struct CallReference {
+    kind: CallKind,
+}
+impl CallReference {
+    fn new(kind: CallKind) -> Self {
+        Self { kind }
+    }
+}
+
+// Struct for emitting bytecode for get `name` operation.
+pub struct GetNameEmitter<'alloc> {
+    pub name: &'alloc str,
+}
+impl<'alloc> GetNameEmitter<'alloc> {
+    pub fn emit(self, emitter: &mut AstEmitter) {
+        let name_index = emitter.emit.get_atom_index(self.name);
+
+        //              [stack]
+
+        // FIXME: Support non-global case.
+        emitter.emit.get_g_name(name_index);
+        //              [stack] VAL
+    }
+}
+
+// Struct for emitting bytecode for get `obj.key` operation.
+pub struct GetPropEmitter<'alloc, F>
+where
+    F: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub obj: F,
+    pub key: &'alloc str,
+}
+impl<'alloc, F> GetPropEmitter<'alloc, F>
+where
+    F: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub fn emit(self, emitter: &mut AstEmitter) -> Result<(), EmitError> {
+        let key_index = emitter.emit.get_atom_index(self.key);
+
+        //              [stack]
+
+        (self.obj)(emitter)?;
+        //              [stack] OBJ
+
+        emitter.emit.get_prop(key_index);
+        //              [stack] VAL
+
+        Ok(())
+    }
+}
+
+// Struct for emitting bytecode for get `super.key` operation.
+pub struct GetSuperPropEmitter<'alloc, F>
+where
+    F: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub this: F,
+    pub key: &'alloc str,
+}
+impl<'alloc, F> GetSuperPropEmitter<'alloc, F>
+where
+    F: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub fn emit(self, emitter: &mut AstEmitter) -> Result<(), EmitError> {
+        let key_index = emitter.emit.get_atom_index(self.key);
+
+        //              [stack]
+
+        (self.this)(emitter)?;
+        //              [stack] THIS
+
+        emitter.emit.callee();
+        //              [stack] THIS CALLEE
+
+        emitter.emit.super_base();
+        //              [stack] THIS OBJ
+
+        emitter.emit.get_prop_super(key_index);
+        //              [stack] VAL
+
+        Ok(())
+    }
+}
+
+// Struct for emitting bytecode for get `obj[key]` operation.
+pub struct GetElemEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub obj: F1,
+    pub key: F2,
+}
+impl<F1, F2> GetElemEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub fn emit(self, emitter: &mut AstEmitter) -> Result<(), EmitError> {
+        //              [stack]
+
+        (self.obj)(emitter)?;
+        //              [stack] OBJ
+
+        (self.key)(emitter)?;
+        //              [stack] OBJ KEY
+
+        emitter.emit.get_elem();
+        //              [stack] VAL
+
+        Ok(())
+    }
+}
+
+// Struct for emitting bytecode for get `super[key]` operation.
+pub struct GetSuperElemEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub this: F1,
+    pub key: F2,
+}
+impl<F1, F2> GetSuperElemEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub fn emit(self, emitter: &mut AstEmitter) -> Result<(), EmitError> {
+        //              [stack]
+
+        (self.this)(emitter)?;
+        //              [stack] THIS
+
+        (self.key)(emitter)?;
+        //              [stack] THIS KEY
+
+        emitter.emit.callee();
+        //              [stack] THIS KEY CALLEE
+
+        emitter.emit.super_base();
+        //              [stack] THIS KEY OBJ
+
+        emitter.emit.get_elem_super();
+        //              [stack] VAL
+
+        Ok(())
+    }
+}
+
+// Struct for emitting bytecode for `name` reference.
+pub struct NameReferenceEmitter<'alloc> {
+    pub name: &'alloc str,
+}
+impl<'alloc> NameReferenceEmitter<'alloc> {
+    pub fn emit_for_call(self, emitter: &mut AstEmitter) -> CallReference {
+        let name_index = emitter.emit.get_atom_index(self.name);
+
+        //              [stack]
+
+        // FIXME: Support non-global case.
+        emitter.emit.get_g_name(name_index);
+        //              [stack] CALLEE
+
+        // FIXME: Support non-global cases.
+        emitter.emit.g_implicit_this(name_index);
+        //              [stack] CALLEE THIS
+
+        CallReference::new(CallKind::Normal)
+    }
+
+    pub fn emit_for_assignment(self, emitter: &mut AstEmitter) -> AssignmentReference {
+        let name_index = emitter.emit.get_atom_index(self.name);
+
+        //              [stack]
+
+        // FIXME: Support non-global case.
+        emitter.emit.bind_g_name(name_index);
+        //              [stack] GLOBAL
+
+        AssignmentReference::new(AssignmentReferenceKind::GlobalName(name_index))
+    }
+}
+
+// Struct for emitting bytecode for `obj.key` reference.
+pub struct PropReferenceEmitter<'alloc, F>
+where
+    F: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub obj: F,
+    pub key: &'alloc str,
+}
+impl<'alloc, F> PropReferenceEmitter<'alloc, F>
+where
+    F: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub fn emit_for_call(self, emitter: &mut AstEmitter) -> Result<CallReference, EmitError> {
+        let key_index = emitter.emit.get_atom_index(self.key);
+
+        //              [stack]
+
+        (self.obj)(emitter)?;
+        //              [stack] THIS
+
+        emitter.emit.dup();
+        //              [stack] THIS THIS
+
+        // FIXME: Support super.
+        emitter.emit.call_prop(key_index);
+        //              [stack] THIS CALLEE
+
+        emitter.emit.swap();
+        //              [stack] CALLEE THIS
+
+        Ok(CallReference::new(CallKind::Normal))
+    }
+
+    #[allow(dead_code)]
+    pub fn emit_for_assignment(
+        self,
+        emitter: &mut AstEmitter,
+    ) -> Result<AssignmentReference, EmitError> {
+        let key_index = emitter.emit.get_atom_index(self.key);
+
+        //              [stack]
+
+        (self.obj)(emitter)?;
+        //              [stack] OBJ
+
+        Ok(AssignmentReference::new(AssignmentReferenceKind::Prop(
+            key_index,
+        )))
+    }
+}
+
+// Struct for emitting bytecode for `obj[key]` reference.
+#[allow(dead_code)]
+pub struct ElemReferenceEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub obj: F1,
+    pub key: F2,
+}
+impl<F1, F2> ElemReferenceEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    #[allow(dead_code)]
+    pub fn emit_for_call(self, emitter: &mut AstEmitter) -> Result<CallReference, EmitError> {
+        //              [stack]
+
+        (self.obj)(emitter)?;
+        //              [stack] THIS
+
+        emitter.emit.dup();
+        //              [stack] THIS THIS
+
+        (self.key)(emitter)?;
+        //              [stack] THIS THIS KEY
+
+        // FIXME: Support super.
+        emitter.emit.call_elem();
+        //              [stack] THIS CALLEE
+
+        emitter.emit.swap();
+        //              [stack] CALLEE THIS
+
+        Ok(CallReference::new(CallKind::Normal))
+    }
+
+    #[allow(dead_code)]
+    pub fn emit_for_assignment(
+        self,
+        emitter: &mut AstEmitter,
+    ) -> Result<AssignmentReference, EmitError> {
+        //              [stack]
+
+        (self.obj)(emitter)?;
+        //              [stack] OBJ
+
+        (self.key)(emitter)?;
+        //              [stack] OBJ KEY
+
+        Ok(AssignmentReference::new(AssignmentReferenceKind::Elem))
+    }
+}
+
+// Struct for emitting bytecode for call `callee(arguments)` operation.
+pub struct CallEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<CallReference, EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<usize, EmitError>,
+{
+    pub callee: F1,
+    pub arguments: F2,
+}
+impl<F1, F2> CallEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<CallReference, EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<usize, EmitError>,
+{
+    pub fn emit(self, emitter: &mut AstEmitter) -> Result<(), EmitError> {
+        //              [stack]
+
+        let reference = (self.callee)(emitter)?;
+        //              [stack] CALLEE THIS
+
+        // FIXME: Support spread.
+        let len = (self.arguments)(emitter)?;
+        //              [stack] CALLEE THIS ARGS...
+
+        match reference.kind {
+            CallKind::Normal => {
+                emitter.emit.call(len as u16);
+                //      [stack] VAL
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// Struct for emitting bytecode for `new callee(arguments)` operation.
+pub struct NewEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<usize, EmitError>,
+{
+    pub callee: F1,
+    pub arguments: F2,
+}
+impl<F1, F2> NewEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<usize, EmitError>,
+{
+    pub fn emit(self, emitter: &mut AstEmitter) -> Result<(), EmitError> {
+        //              [stack]
+
+        (self.callee)(emitter)?;
+        //              [stack] CALLEE
+
+        emitter.emit.is_constructing();
+        //              [stack] CALLEE JS_IS_CONSTRUCTING
+
+        // FIXME: Support spread.
+        let len = (self.arguments)(emitter)?;
+        //              [stack] CALLEE JS_IS_CONSTRUCTING ARGS...
+
+        emitter.emit.dup_at(len as u32 + 1);
+        //              [stack] CALLEE JS_IS_CONSTRUCTING ARGS... CALLEE
+
+        emitter.emit.new_(len as u16);
+        //              [stack] VAL
+
+        Ok(())
+    }
+}
+
+// Struct for emitting bytecode for assignment `lhs = rhs` operation.
+pub struct AssignmentEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<AssignmentReference, EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub lhs: F1,
+    pub rhs: F2,
+}
+impl<F1, F2> AssignmentEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<AssignmentReference, EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub fn emit(self, emitter: &mut AstEmitter) -> Result<(), EmitError> {
+        //              [stack]
+
+        let reference = (self.lhs)(emitter)?;
+        //              [stack] REF...
+
+        (self.rhs)(emitter)?;
+        //              [stack] REF... VAL
+
+        match reference.kind {
+            AssignmentReferenceKind::GlobalName(name_index) => {
+                //      [stack] GLOBAL VAL
+
+                // FIXME: Support non-global cases.
+                emitter.emit.set_g_name(name_index);
+                //      [stack] VAL
+            }
+            AssignmentReferenceKind::Prop(key_index) => {
+                //      [stack] OBJ VAL
+
+                // FIXME: Support strict mode and super.
+                emitter.emit.set_prop(key_index);
+                //      [stack] VAL
+            }
+            AssignmentReferenceKind::Elem => {
+                //      [stack] OBJ KEY VAL
+
+                // FIXME: Support strict mode and super.
+                emitter.emit.set_elem();
+                //      [stack] VAL
+            }
+        }
+
+        Ok(())
+    }
+
+    // FIXME: Support compound assignment
+}
+
+// FIXME: Add increment

--- a/crates/interpreter/src/evaluate.rs
+++ b/crates/interpreter/src/evaluate.rs
@@ -53,7 +53,8 @@ impl Helpers for EmitResult {
     }
 
     fn read_atom(&self, offset: usize) -> String {
-        self.strings[self.read_i32(offset) as usize].clone()
+        let index = self.atoms[self.read_i32(offset) as usize];
+        self.all_atoms[index.into_raw()].clone()
     }
 }
 


### PR DESCRIPTION
based on https://github.com/mozilla-spidermonkey/jsparagus/pull/257
will rebase after that.

Added separate structs for the following:
  * all strings that needs to be converted into `JSAtom`in C++ side (`AtomSet` and `AtomSetIndex` in `atomset.rs`)  
    scope handling will create more `JSAtom`s, that is referred from `BindingName` in `*Scope::Data`, so this needs to be separate struct than atoms directly referred by atom ops in bytcode
  * `JSSctipt::atoms()` (`AtomList` and `AtomIndex` in `atoms.rs`)

I guess the naming isn't good.
suggestions welcome
