### PR TITLE
Tag revisions in ci_generated branch, in order to refer it even after next update (fixes #333)

### DIFF
--- a/.github/workflows/ci-generated.yml
+++ b/.github/workflows/ci-generated.yml
@@ -25,13 +25,16 @@ jobs:
         sed -i.bak '/*_generated.rs/d' .gitignore && rm .gitignore.bak
     - name: Commit files
       run: |
+        MASTER_REV=$(git log -1 --pretty=%H)
         git add .
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git commit -m "Add Generated Files" -a
+        git tag "generated-for-${MASTER_REV}"
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: ci_generated
+        tags: true
         force: true


### PR DESCRIPTION
m-c will refer revisions in ci_generated
we should keep them alive.
we're currently using force-push for the branch, so we'll loose references for previous heads unless they're referred in other way.

here, I use tag.

the tag name is `generated-for-{sha of master branch}`