### PR TITLE
Use hidden branch for ci_generated, and merge previous head (fixes #333)

### DIFF
--- a/.github/workflows/ci-generated.yml
+++ b/.github/workflows/ci-generated.yml
@@ -18,6 +18,31 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: "3.7"
+    - name: Setup Git Profile
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+    - name: Revert Previous Change and Merge Master
+      run: |
+        git ls-remote origin
+        if git ls-remote origin | grep refs/ci_generated/master; then
+          # If the remote hidden branch exists
+          # Map the remote ref to branch.
+          git fetch origin +refs/ci_generated/master:refs/remotes/origin/ci_generated/master
+          git checkout -b ci_generated-prev origin/ci_generated/master
+
+          # Revert the previous generated files, so that the merge is clean.
+          git revert HEAD
+
+          # Merge master.
+          MASTER_REV=$(git log -1 master --pretty=%H)
+
+          git checkout -b ci_generated-master origin/master
+          git merge ci_generated-prev -m "Merge master ${MASTER_REV}" -s ours --allow-unrelated-histories
+        else
+          # Otherwise, just start from master branch
+          git checkout -b ci_generated-master
+        fi
     - name: Generate Files
       run: |
         make init-venv && make all
@@ -26,12 +51,11 @@ jobs:
     - name: Commit files
       run: |
         git add .
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git commit -m "Add Generated Files" -a
+        MASTER_REV=$(git log -1 master --pretty=%H)
+        git commit -m "Add Generated Files for ${MASTER_REV}" -a
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ci_generated
-        force: true
+        branch: refs/ci_generated/master
+


### PR DESCRIPTION
2 changes:
  * Now generated files are stored in `refs/ci_generated/master` branch (previously `refs/heads/ci_generated`)
  * previous change is reverted and merged, so that all revisions are inside history 
https://github.com/mozilla-spidermonkey/jsparagus/issues/333#issuecomment-592342818


`refs/ci_generated/master` isn't shown on GitHub UI, but you can see it via GitHub API.
https://api.github.com/repos/mozilla-spidermonkey/jsparagus/git/refs/ci_generated/master (doesn't yet exist)

Just to fetch it:
```
git fetch {remote_name} +refs/ci_generated/master
```
where `{remote_name}` is `origin` or `upstream` or something.

To checkout, you need to map it to an usual branch, and then checkout:
```
git fetch {remote_name} +refs/ci_generated/master:refs/remotes/{remote_name}/ci_generated/master
git checkout {remote_name}/ci_generated/master
```

To see the HEAD of the branch without fetching:
```
git ls-remote {remote_name} | grep refs/ci_generated/master
```