### PR TITLE
Use bash instead of sh for git fmt hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Simplified commit hook to format the files which were changed in the current commit
 #


### PR DESCRIPTION
Apparently under Ubuntu /bin/sh points to "dash", which does not support
substitution: https://stackoverflow.com/questions/20615217/bash-bad-substitution