### PR TITLE
Enable support for CallElem

### DIFF
--- a/crates/emitter/src/reference_op_emitter.rs
+++ b/crates/emitter/src/reference_op_emitter.rs
@@ -294,7 +294,6 @@ where
 }
 
 // Struct for emitting bytecode for `obj[key]` reference.
-#[allow(dead_code)]
 pub struct ElemReferenceEmitter<F1, F2>
 where
     F1: Fn(&mut AstEmitter) -> Result<(), EmitError>,
@@ -308,7 +307,6 @@ where
     F1: Fn(&mut AstEmitter) -> Result<(), EmitError>,
     F2: Fn(&mut AstEmitter) -> Result<(), EmitError>,
 {
-    #[allow(dead_code)]
     pub fn emit_for_call(self, emitter: &mut AstEmitter) -> Result<CallReference, EmitError> {
         //              [stack]
 


### PR DESCRIPTION
This just makes it so we use the code for ComputedMemberExpression that
was already added in #257.

No new failures with jit-tests or jstests.