### PR TITLE
Update stack depth at non-merge jump target

### DIFF
--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -153,14 +153,14 @@ impl<'alloc> AstEmitter<'alloc> {
             // ^^ part of then branch
 
             // Else branch
-            alternate_jump.patch(self);
+            alternate_jump.patch_not_merge(self);
             self.emit_statement(alternate)?;
 
             // Merge point after else
-            then_jump.patch(self);
+            then_jump.patch_merge(self);
         } else {
             // Merge point without else
-            alternate_jump.patch(self);
+            alternate_jump.patch_merge(self);
         }
 
         Ok(())
@@ -454,7 +454,7 @@ impl<'alloc> AstEmitter<'alloc> {
         let jump = ForwardJumpEmitter { jump: jump }.emit(self);
         self.emit.pop();
         self.emit_expression(right)?;
-        jump.patch(self);
+        jump.patch_merge(self);
         return Ok(());
     }
 
@@ -565,11 +565,11 @@ impl<'alloc> AstEmitter<'alloc> {
         .emit(self);
 
         // Else branch
-        else_jump.patch(self);
+        else_jump.patch_not_merge(self);
         self.emit_expression(alternate)?;
 
         // Merge point
-        finally_jump.patch(self);
+        finally_jump.patch_merge(self);
 
         Ok(())
     }

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -1179,4 +1179,8 @@ impl InstructionWriter {
     pub fn stack_depth(&self) -> usize {
         self.stack_depth
     }
+
+    pub fn set_stack_depth(&mut self, depth: usize) {
+        self.stack_depth = depth;
+    }
 }

--- a/crates/emitter/src/forward_jump_emitter.rs
+++ b/crates/emitter/src/forward_jump_emitter.rs
@@ -1,4 +1,4 @@
-use super::emitter::{BytecodeOffset};
+use super::emitter::BytecodeOffset;
 use crate::ast_emitter::AstEmitter;
 
 #[derive(Debug)]
@@ -14,14 +14,31 @@ pub enum JumpKind {
 #[must_use]
 pub struct JumpPatchEmitter {
     offset: BytecodeOffset,
+    depth: usize,
 }
 impl JumpPatchEmitter {
-    pub fn patch(self, emitter: &mut AstEmitter) {
+    pub fn patch_merge(self, emitter: &mut AstEmitter) {
         // TODO: if multiple jumps arrive at same point, only single JumpTarget
         // should be emitted. See:
         // https://searchfox.org/mozilla-central/rev/49ed791eec93335abfe6c2880f84c324e73e47e6/js/src/frontend/BytecodeEmitter.cpp#371-377
         emitter.emit.patch_jump_target(vec![self.offset]);
         emitter.emit.jump_target();
+
+        // If the previous opcode fall-through, it should have the same stack
+        // depth.
+        debug_assert!(emitter.emit.stack_depth() == self.depth);
+    }
+
+    pub fn patch_not_merge(self, emitter: &mut AstEmitter) {
+        // TODO: if multiple jumps arrive at same point, only single JumpTarget
+        // should be emitted. See:
+        // https://searchfox.org/mozilla-central/rev/49ed791eec93335abfe6c2880f84c324e73e47e6/js/src/frontend/BytecodeEmitter.cpp#371-377
+        emitter.emit.patch_jump_target(vec![self.offset]);
+        emitter.emit.jump_target();
+
+        // If the previous opcode doesn't fall-through, overwrite the stack
+        // depth.
+        emitter.emit.set_stack_depth(self.depth);
     }
 }
 
@@ -32,15 +49,16 @@ pub struct ForwardJumpEmitter {
 }
 impl ForwardJumpEmitter {
     pub fn emit(&mut self, emitter: &mut AstEmitter) -> JumpPatchEmitter {
-        let offset: BytecodeOffset = emitter.emit.bytecode_offset();
+        let offset = emitter.emit.bytecode_offset();
         self.emit_jump(emitter);
+        let depth = emitter.emit.stack_depth();
 
         // The JITs rely on a jump target being emitted after the
         // conditional jump
         if self.should_fallthrough() {
             emitter.emit.jump_target();
         }
-        JumpPatchEmitter { offset: offset }
+        JumpPatchEmitter { offset, depth }
     }
 
     fn should_fallthrough(&mut self) -> bool {


### PR DESCRIPTION
There are 2 cases for jump target.

If the previous opcode falls-through, means, the jump target is a merge point, those 2 branches should have same stack depth.

If the previous opcode doesn't fall-through, the previous stack depth is unrelated, but it should overwrite the depth to the jump origin.
