### PR TITLE
Provide the input of opcode.rs to consumer (fixes #348)

### DIFF
--- a/crates/emitter/scripts/update_opcodes.py
+++ b/crates/emitter/scripts/update_opcodes.py
@@ -9,6 +9,7 @@ then paste it into opcode.rs.
 import argparse
 import os
 import re
+import shutil
 import sys
 
 parser = argparse.ArgumentParser(description='Update opcode.rs')
@@ -49,6 +50,11 @@ if not os.path.exists(emitter_dest_path):
     print('{} does not exist'.format(emitter_dest_path),
           file=sys.stderr)
     sys.exit(1)
+
+copy_dir = os.path.join(args.PATH_TO_JSPARAGUS,
+                        'crates/emitter/src/copy')
+if not os.path.exists(copy_dir):
+    os.makedirs(copy_dir)
 
 
 def extract_opcodes(path):
@@ -290,3 +296,8 @@ flags = extract_flags(util_path)
 
 update_opcode(opcode_dest_path, opcodes, flags)
 update_emit(emitter_dest_path)
+
+shutil.copyfile(opcodes_path,
+                os.path.join(copy_dir, os.path.basename(opcodes_path)))
+shutil.copyfile(util_path,
+                os.path.join(copy_dir, os.path.basename(util_path)))

--- a/crates/emitter/src/copy/BytecodeUtil.h
+++ b/crates/emitter/src/copy/BytecodeUtil.h
@@ -1,0 +1,734 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: set ts=8 sts=2 et sw=2 tw=80:
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef vm_BytecodeUtil_h
+#define vm_BytecodeUtil_h
+
+/*
+ * JS bytecode definitions.
+ */
+
+#include "mozilla/Attributes.h"
+#include "mozilla/EndianUtils.h"
+
+#include <algorithm>
+
+#include "jstypes.h"
+#include "NamespaceImports.h"
+
+#include "frontend/SourceNotes.h"
+#include "js/TypeDecls.h"
+#include "js/UniquePtr.h"
+#include "vm/Opcodes.h"
+#include "vm/Printer.h"
+
+/*
+ * JS operation bytecodes.
+ */
+enum class JSOp : uint8_t {
+#define ENUMERATE_OPCODE(op, ...) op,
+  FOR_EACH_OPCODE(ENUMERATE_OPCODE)
+#undef ENUMERATE_OPCODE
+};
+
+/*
+ * [SMDOC] Bytecode Format flags (JOF_*)
+ */
+enum {
+  JOF_BYTE = 0,         /* single bytecode, no immediates */
+  JOF_UINT8 = 1,        /* unspecified uint8_t argument */
+  JOF_UINT16 = 2,       /* unspecified uint16_t argument */
+  JOF_UINT24 = 3,       /* unspecified uint24_t argument */
+  JOF_UINT32 = 4,       /* unspecified uint32_t argument */
+  JOF_INT8 = 5,         /* int8_t literal */
+  JOF_INT32 = 6,        /* int32_t literal */
+  JOF_JUMP = 7,         /* int32_t jump offset */
+  JOF_TABLESWITCH = 8,  /* table switch */
+  JOF_ENVCOORD = 9,     /* embedded ScopeCoordinate immediate */
+  JOF_ARGC = 10,        /* uint16_t argument count */
+  JOF_QARG = 11,        /* function argument index */
+  JOF_LOCAL = 12,       /* var or block-local variable */
+  JOF_RESUMEINDEX = 13, /* yield, await, or gosub resume index */
+  JOF_ATOM = 14,        /* uint32_t constant index */
+  JOF_OBJECT = 15,      /* uint32_t object index */
+  JOF_REGEXP = 16,      /* uint32_t regexp index */
+  JOF_DOUBLE = 17,      /* inline DoubleValue */
+  JOF_SCOPE = 18,       /* uint32_t scope index */
+  JOF_ICINDEX = 19,     /* uint32_t IC index */
+  JOF_LOOPHEAD = 20,    /* JSOp::LoopHead, combines JOF_ICINDEX and JOF_UINT8 */
+  JOF_BIGINT = 21,      /* uint32_t index for BigInt value */
+  JOF_CLASS_CTOR = 22,  /* uint32_t atom index, sourceStart, sourceEnd */
+  JOF_CODE_OFFSET = 23, /* int32_t bytecode offset */
+  JOF_TYPEMASK = 0x001f, /* mask for above immediate types */
+
+  JOF_NAME = 1 << 5,     /* name operation */
+  JOF_PROP = 2 << 5,     /* obj.prop operation */
+  JOF_ELEM = 3 << 5,     /* obj[index] operation */
+  JOF_MODEMASK = 3 << 5, /* mask for above addressing modes */
+
+  JOF_PROPSET = 1 << 7,      /* property/element/name set operation */
+  JOF_PROPINIT = 1 << 8,     /* property/element/name init operation */
+  JOF_DETECTING = 1 << 9,    /* object detection for warning-quelling */
+  JOF_CHECKSLOPPY = 1 << 10, /* op can only be generated in sloppy mode */
+  JOF_CHECKSTRICT = 1 << 11, /* op can only be generated in strict mode */
+  JOF_INVOKE = 1 << 12,      /* any call, construct, or eval instruction */
+  JOF_CONSTRUCT = 1 << 13,   /* invoke instruction using [[Construct]] entry */
+  JOF_SPREAD = 1 << 14,      /* invoke instruction using spread argument */
+  JOF_GNAME = 1 << 15,       /* predicted global name */
+  JOF_TYPESET = 1 << 16,     /* has an entry in a script's type sets */
+  JOF_IC = 1 << 17,          /* baseline may use an IC for this op */
+};
+
+/* Shorthand for type from format. */
+
+static inline uint32_t JOF_TYPE(uint32_t fmt) { return fmt & JOF_TYPEMASK; }
+
+/* Shorthand for mode from format. */
+
+static inline uint32_t JOF_MODE(uint32_t fmt) { return fmt & JOF_MODEMASK; }
+
+/*
+ * Immediate operand getters, setters, and bounds.
+ */
+
+static MOZ_ALWAYS_INLINE uint8_t GET_UINT8(jsbytecode* pc) {
+  return uint8_t(pc[1]);
+}
+
+static MOZ_ALWAYS_INLINE void SET_UINT8(jsbytecode* pc, uint8_t u) {
+  pc[1] = jsbytecode(u);
+}
+
+/* Common uint16_t immediate format helpers. */
+
+static inline jsbytecode UINT16_HI(uint16_t i) { return jsbytecode(i >> 8); }
+
+static inline jsbytecode UINT16_LO(uint16_t i) { return jsbytecode(i); }
+
+static MOZ_ALWAYS_INLINE uint16_t GET_UINT16(const jsbytecode* pc) {
+  uint16_t result;
+  mozilla::NativeEndian::copyAndSwapFromLittleEndian(&result, pc + 1, 1);
+  return result;
+}
+
+static MOZ_ALWAYS_INLINE void SET_UINT16(jsbytecode* pc, uint16_t i) {
+  mozilla::NativeEndian::copyAndSwapToLittleEndian(pc + 1, &i, 1);
+}
+
+static const unsigned UINT16_LIMIT = 1 << 16;
+
+/* Helpers for accessing the offsets of jump opcodes. */
+static const unsigned JUMP_OFFSET_LEN = 4;
+static const int32_t JUMP_OFFSET_MIN = INT32_MIN;
+static const int32_t JUMP_OFFSET_MAX = INT32_MAX;
+
+static MOZ_ALWAYS_INLINE uint32_t GET_UINT24(const jsbytecode* pc) {
+#if MOZ_LITTLE_ENDIAN()
+  // Do a single 32-bit load (for opcode and operand), then shift off the
+  // opcode.
+  uint32_t result;
+  memcpy(&result, pc, 4);
+  return result >> 8;
+#else
+  return uint32_t((pc[3] << 16) | (pc[2] << 8) | pc[1]);
+#endif
+}
+
+static MOZ_ALWAYS_INLINE void SET_UINT24(jsbytecode* pc, uint32_t i) {
+  MOZ_ASSERT(i < (1 << 24));
+
+#if MOZ_LITTLE_ENDIAN()
+  memcpy(pc + 1, &i, 3);
+#else
+  pc[1] = jsbytecode(i);
+  pc[2] = jsbytecode(i >> 8);
+  pc[3] = jsbytecode(i >> 16);
+#endif
+}
+
+static MOZ_ALWAYS_INLINE int8_t GET_INT8(const jsbytecode* pc) {
+  return int8_t(pc[1]);
+}
+
+static MOZ_ALWAYS_INLINE uint32_t GET_UINT32(const jsbytecode* pc) {
+  uint32_t result;
+  mozilla::NativeEndian::copyAndSwapFromLittleEndian(&result, pc + 1, 1);
+  return result;
+}
+
+static MOZ_ALWAYS_INLINE void SET_UINT32(jsbytecode* pc, uint32_t u) {
+  mozilla::NativeEndian::copyAndSwapToLittleEndian(pc + 1, &u, 1);
+}
+
+static MOZ_ALWAYS_INLINE JS::Value GET_INLINE_VALUE(const jsbytecode* pc) {
+  uint64_t raw;
+  mozilla::NativeEndian::copyAndSwapFromLittleEndian(&raw, pc + 1, 1);
+  return JS::Value::fromRawBits(raw);
+}
+
+static MOZ_ALWAYS_INLINE void SET_INLINE_VALUE(jsbytecode* pc,
+                                               const JS::Value& v) {
+  uint64_t raw = v.asRawBits();
+  mozilla::NativeEndian::copyAndSwapToLittleEndian(pc + 1, &raw, 1);
+}
+
+static MOZ_ALWAYS_INLINE int32_t GET_INT32(const jsbytecode* pc) {
+  return static_cast<int32_t>(GET_UINT32(pc));
+}
+
+static MOZ_ALWAYS_INLINE void SET_INT32(jsbytecode* pc, int32_t i) {
+  SET_UINT32(pc, static_cast<uint32_t>(i));
+}
+
+static MOZ_ALWAYS_INLINE int32_t GET_JUMP_OFFSET(jsbytecode* pc) {
+  return GET_INT32(pc);
+}
+
+static MOZ_ALWAYS_INLINE void SET_JUMP_OFFSET(jsbytecode* pc, int32_t off) {
+  SET_INT32(pc, off);
+}
+
+static MOZ_ALWAYS_INLINE int32_t GET_CODE_OFFSET(jsbytecode* pc) {
+  return GET_INT32(pc);
+}
+
+static MOZ_ALWAYS_INLINE void SET_CODE_OFFSET(jsbytecode* pc, int32_t off) {
+  SET_INT32(pc, off);
+}
+
+static const unsigned UINT32_INDEX_LEN = 4;
+
+static MOZ_ALWAYS_INLINE uint32_t GET_UINT32_INDEX(const jsbytecode* pc) {
+  return GET_UINT32(pc);
+}
+
+static MOZ_ALWAYS_INLINE void SET_UINT32_INDEX(jsbytecode* pc, uint32_t index) {
+  SET_UINT32(pc, index);
+}
+
+// Index limit is determined by SN_4BYTE_OFFSET_FLAG, see
+// frontend/BytecodeEmitter.h.
+static const unsigned INDEX_LIMIT_LOG2 = 31;
+static const uint32_t INDEX_LIMIT = uint32_t(1) << INDEX_LIMIT_LOG2;
+
+static inline jsbytecode ARGC_HI(uint16_t argc) { return UINT16_HI(argc); }
+
+static inline jsbytecode ARGC_LO(uint16_t argc) { return UINT16_LO(argc); }
+
+static inline uint16_t GET_ARGC(const jsbytecode* pc) { return GET_UINT16(pc); }
+
+static const unsigned ARGC_LIMIT = UINT16_LIMIT;
+
+static inline uint16_t GET_ARGNO(const jsbytecode* pc) {
+  return GET_UINT16(pc);
+}
+
+static inline void SET_ARGNO(jsbytecode* pc, uint16_t argno) {
+  SET_UINT16(pc, argno);
+}
+
+static const unsigned ARGNO_LEN = 2;
+static const unsigned ARGNO_LIMIT = UINT16_LIMIT;
+
+static inline uint32_t GET_LOCALNO(const jsbytecode* pc) {
+  return GET_UINT24(pc);
+}
+
+static inline void SET_LOCALNO(jsbytecode* pc, uint32_t varno) {
+  SET_UINT24(pc, varno);
+}
+
+static const unsigned LOCALNO_LEN = 3;
+static const unsigned LOCALNO_BITS = 24;
+static const uint32_t LOCALNO_LIMIT = 1 << LOCALNO_BITS;
+
+static inline uint32_t GET_RESUMEINDEX(const jsbytecode* pc) {
+  return GET_UINT24(pc);
+}
+
+static inline void SET_RESUMEINDEX(jsbytecode* pc, uint32_t resumeIndex) {
+  SET_UINT24(pc, resumeIndex);
+}
+
+static inline uint32_t GET_ICINDEX(const jsbytecode* pc) {
+  return GET_UINT32(pc);
+}
+
+static inline void SET_ICINDEX(jsbytecode* pc, uint32_t icIndex) {
+  SET_UINT32(pc, icIndex);
+}
+
+static inline unsigned LoopHeadDepthHint(jsbytecode* pc) {
+  MOZ_ASSERT(JSOp(*pc) == JSOp::LoopHead);
+  return GET_UINT8(pc + 4);
+}
+
+static inline void SetLoopHeadDepthHint(jsbytecode* pc, unsigned loopDepth) {
+  MOZ_ASSERT(JSOp(*pc) == JSOp::LoopHead);
+  uint8_t data = std::min(loopDepth, unsigned(UINT8_MAX));
+  SET_UINT8(pc + 4, data);
+}
+
+static inline bool IsBackedgePC(jsbytecode* pc) {
+  switch (JSOp(*pc)) {
+    case JSOp::Goto:
+    case JSOp::IfNe:
+      return GET_JUMP_OFFSET(pc) < 0;
+    default:
+      return false;
+  }
+}
+
+static inline bool IsBackedgeForLoopHead(jsbytecode* pc, jsbytecode* loopHead) {
+  MOZ_ASSERT(JSOp(*loopHead) == JSOp::LoopHead);
+  return IsBackedgePC(pc) && pc + GET_JUMP_OFFSET(pc) == loopHead;
+}
+
+static inline void SetClassConstructorOperands(jsbytecode* pc,
+                                               uint32_t atomIndex,
+                                               uint32_t sourceStart,
+                                               uint32_t sourceEnd) {
+  MOZ_ASSERT(JSOp(*pc) == JSOp::ClassConstructor ||
+             JSOp(*pc) == JSOp::DerivedConstructor);
+  SET_UINT32(pc, atomIndex);
+  SET_UINT32(pc + 4, sourceStart);
+  SET_UINT32(pc + 8, sourceEnd);
+}
+
+static inline void GetClassConstructorOperands(jsbytecode* pc,
+                                               uint32_t* atomIndex,
+                                               uint32_t* sourceStart,
+                                               uint32_t* sourceEnd) {
+  MOZ_ASSERT(JSOp(*pc) == JSOp::ClassConstructor ||
+             JSOp(*pc) == JSOp::DerivedConstructor);
+  *atomIndex = GET_UINT32(pc);
+  *sourceStart = GET_UINT32(pc + 4);
+  *sourceEnd = GET_UINT32(pc + 8);
+}
+
+/*
+ * Describes the 'hops' component of a JOF_ENVCOORD opcode.
+ *
+ * Note: this component is only 8 bits wide, limiting the maximum number of
+ * scopes between a use and def to roughly 255. This is a pretty small limit but
+ * note that SpiderMonkey's recursive descent parser can only parse about this
+ * many functions before hitting the C-stack recursion limit so this shouldn't
+ * be a significant limitation in practice.
+ */
+
+static inline uint8_t GET_ENVCOORD_HOPS(jsbytecode* pc) {
+  return GET_UINT8(pc);
+}
+
+static inline void SET_ENVCOORD_HOPS(jsbytecode* pc, uint8_t hops) {
+  SET_UINT8(pc, hops);
+}
+
+static const unsigned ENVCOORD_HOPS_LEN = 1;
+static const unsigned ENVCOORD_HOPS_BITS = 8;
+static const unsigned ENVCOORD_HOPS_LIMIT = 1 << ENVCOORD_HOPS_BITS;
+
+/* Describes the 'slot' component of a JOF_ENVCOORD opcode. */
+static inline uint32_t GET_ENVCOORD_SLOT(const jsbytecode* pc) {
+  return GET_UINT24(pc);
+}
+
+static inline void SET_ENVCOORD_SLOT(jsbytecode* pc, uint32_t slot) {
+  SET_UINT24(pc, slot);
+}
+
+static const unsigned ENVCOORD_SLOT_LEN = 3;
+static const unsigned ENVCOORD_SLOT_BITS = 24;
+static const uint32_t ENVCOORD_SLOT_LIMIT = 1 << ENVCOORD_SLOT_BITS;
+
+struct JSCodeSpec {
+  uint8_t length;  /* length including opcode byte */
+  int8_t nuses;    /* arity, -1 if variadic */
+  int8_t ndefs;    /* number of stack results */
+  uint32_t format; /* immediate operand format */
+
+  uint32_t type() const { return JOF_TYPE(format); }
+};
+
+namespace js {
+
+extern const JSCodeSpec CodeSpecTable[];
+
+inline const JSCodeSpec& CodeSpec(JSOp op) {
+  return CodeSpecTable[uint8_t(op)];
+}
+
+extern const char* const CodeNameTable[];
+
+inline const char* CodeName(JSOp op) { return CodeNameTable[uint8_t(op)]; }
+
+/* Shorthand for type from opcode. */
+
+static inline uint32_t JOF_OPTYPE(JSOp op) {
+  return JOF_TYPE(CodeSpec(op).format);
+}
+
+static inline bool IsJumpOpcode(JSOp op) { return JOF_OPTYPE(op) == JOF_JUMP; }
+
+static inline bool BytecodeFallsThrough(JSOp op) {
+  // Note:
+  // * JSOp::Yield/JSOp::Await is considered to fall through, like JSOp::Call.
+  // * JSOp::Gosub falls through indirectly, after executing a 'finally'.
+  switch (op) {
+    case JSOp::Goto:
+    case JSOp::Default:
+    case JSOp::Return:
+    case JSOp::RetRval:
+    case JSOp::Retsub:
+    case JSOp::FinalYieldRval:
+    case JSOp::Throw:
+    case JSOp::ThrowMsg:
+    case JSOp::TableSwitch:
+      return false;
+    default:
+      return true;
+  }
+}
+
+static inline bool BytecodeIsJumpTarget(JSOp op) {
+  switch (op) {
+    case JSOp::JumpTarget:
+    case JSOp::LoopHead:
+    case JSOp::AfterYield:
+      return true;
+    default:
+      return false;
+  }
+}
+
+MOZ_ALWAYS_INLINE unsigned StackUses(jsbytecode* pc) {
+  JSOp op = JSOp(*pc);
+  int nuses = CodeSpec(op).nuses;
+  if (nuses >= 0) {
+    return nuses;
+  }
+
+  MOZ_ASSERT(nuses == -1);
+  switch (op) {
+    case JSOp::PopN:
+      return GET_UINT16(pc);
+    case JSOp::New:
+    case JSOp::SuperCall:
+      return 2 + GET_ARGC(pc) + 1;
+    default:
+      /* stack: fun, this, [argc arguments] */
+      MOZ_ASSERT(op == JSOp::Call || op == JSOp::CallIgnoresRv ||
+                 op == JSOp::Eval || op == JSOp::CallIter ||
+                 op == JSOp::StrictEval || op == JSOp::FunCall ||
+                 op == JSOp::FunApply);
+      return 2 + GET_ARGC(pc);
+  }
+}
+
+MOZ_ALWAYS_INLINE unsigned StackDefs(jsbytecode* pc) {
+  int ndefs = CodeSpec(JSOp(*pc)).ndefs;
+  MOZ_ASSERT(ndefs >= 0);
+  return ndefs;
+}
+
+#if defined(DEBUG) || defined(JS_JITSPEW)
+/*
+ * Given bytecode address pc in script's main program code, compute the operand
+ * stack depth just before (JSOp) *pc executes.  If *pc is not reachable, return
+ * false.
+ */
+extern bool ReconstructStackDepth(JSContext* cx, JSScript* script,
+                                  jsbytecode* pc, uint32_t* depth,
+                                  bool* reachablePC);
+#endif
+
+} /* namespace js */
+
+#define JSDVG_IGNORE_STACK 0
+#define JSDVG_SEARCH_STACK 1
+
+namespace js {
+
+/*
+ * Find the source expression that resulted in v, and return a newly allocated
+ * C-string containing it.  Fall back on v's string conversion (fallback) if we
+ * can't find the bytecode that generated and pushed v on the operand stack.
+ *
+ * Search the current stack frame if spindex is JSDVG_SEARCH_STACK.  Don't
+ * look for v on the stack if spindex is JSDVG_IGNORE_STACK.  Otherwise,
+ * spindex is the negative index of v, measured from cx->fp->sp, or from a
+ * lower frame's sp if cx->fp is native.
+ *
+ * The optional argument skipStackHits can be used to skip a hit in the stack
+ * frame. This can be useful in self-hosted code that wants to report value
+ * errors containing decompiled values that are useful for the user, instead of
+ * values used internally by the self-hosted code.
+ *
+ * The caller must call JS_free on the result after a successful call.
+ */
+UniqueChars DecompileValueGenerator(JSContext* cx, int spindex, HandleValue v,
+                                    HandleString fallback,
+                                    int skipStackHits = 0);
+
+/*
+ * Decompile the formal argument at formalIndex in the nearest non-builtin
+ * stack frame, falling back with converting v to source.
+ */
+JSString* DecompileArgument(JSContext* cx, int formalIndex, HandleValue v);
+
+static inline unsigned GetOpLength(JSOp op) {
+  MOZ_ASSERT(uint8_t(op) < JSOP_LIMIT);
+  MOZ_ASSERT(CodeSpec(op).length > 0);
+  return CodeSpec(op).length;
+}
+
+static inline unsigned GetBytecodeLength(jsbytecode* pc) {
+  JSOp op = (JSOp)*pc;
+  return GetOpLength(op);
+}
+
+static inline bool BytecodeIsPopped(jsbytecode* pc) {
+  jsbytecode* next = pc + GetBytecodeLength(pc);
+  return JSOp(*next) == JSOp::Pop;
+}
+
+static inline bool BytecodeFlowsToBitop(jsbytecode* pc) {
+  // Look for simple bytecode for integer conversions like (x | 0) or (x & -1).
+  jsbytecode* next = pc + GetBytecodeLength(pc);
+  if (JSOp(*next) == JSOp::BitOr || JSOp(*next) == JSOp::BitAnd) {
+    return true;
+  }
+  if (JSOp(*next) == JSOp::Int8 && GET_INT8(next) == -1) {
+    next += GetBytecodeLength(next);
+    if (JSOp(*next) == JSOp::BitAnd) {
+      return true;
+    }
+    return false;
+  }
+  if (JSOp(*next) == JSOp::One) {
+    next += GetBytecodeLength(next);
+    if (JSOp(*next) == JSOp::Neg) {
+      next += GetBytecodeLength(next);
+      if (JSOp(*next) == JSOp::BitAnd) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (JSOp(*next) == JSOp::Zero) {
+    next += GetBytecodeLength(next);
+    if (JSOp(*next) == JSOp::BitOr) {
+      return true;
+    }
+    return false;
+  }
+  return false;
+}
+
+extern bool IsValidBytecodeOffset(JSContext* cx, JSScript* script,
+                                  size_t offset);
+
+inline bool IsArgOp(JSOp op) { return JOF_OPTYPE(op) == JOF_QARG; }
+
+inline bool IsLocalOp(JSOp op) { return JOF_OPTYPE(op) == JOF_LOCAL; }
+
+inline bool IsAliasedVarOp(JSOp op) { return JOF_OPTYPE(op) == JOF_ENVCOORD; }
+
+inline bool IsGlobalOp(JSOp op) { return CodeSpec(op).format & JOF_GNAME; }
+
+inline bool IsPropertySetOp(JSOp op) {
+  return CodeSpec(op).format & JOF_PROPSET;
+}
+
+inline bool IsPropertyInitOp(JSOp op) {
+  return CodeSpec(op).format & JOF_PROPINIT;
+}
+
+inline bool IsLooseEqualityOp(JSOp op) {
+  return op == JSOp::Eq || op == JSOp::Ne;
+}
+
+inline bool IsStrictEqualityOp(JSOp op) {
+  return op == JSOp::StrictEq || op == JSOp::StrictNe;
+}
+
+inline bool IsEqualityOp(JSOp op) {
+  return IsLooseEqualityOp(op) || IsStrictEqualityOp(op);
+}
+
+inline bool IsRelationalOp(JSOp op) {
+  return op == JSOp::Lt || op == JSOp::Le || op == JSOp::Gt || op == JSOp::Ge;
+}
+
+inline bool IsCheckStrictOp(JSOp op) {
+  return CodeSpec(op).format & JOF_CHECKSTRICT;
+}
+
+inline bool IsDetecting(JSOp op) { return CodeSpec(op).format & JOF_DETECTING; }
+
+inline bool IsNameOp(JSOp op) { return CodeSpec(op).format & JOF_NAME; }
+
+#ifdef DEBUG
+inline bool IsCheckSloppyOp(JSOp op) {
+  return CodeSpec(op).format & JOF_CHECKSLOPPY;
+}
+#endif
+
+inline bool IsAtomOp(JSOp op) { return JOF_OPTYPE(op) == JOF_ATOM; }
+
+inline bool IsGetPropOp(JSOp op) {
+  return op == JSOp::Length || op == JSOp::GetProp || op == JSOp::CallProp;
+}
+
+inline bool IsGetPropPC(const jsbytecode* pc) { return IsGetPropOp(JSOp(*pc)); }
+
+inline bool IsHiddenInitOp(JSOp op) {
+  return op == JSOp::InitHiddenProp || op == JSOp::InitHiddenElem ||
+         op == JSOp::InitHiddenPropGetter || op == JSOp::InitHiddenElemGetter ||
+         op == JSOp::InitHiddenPropSetter || op == JSOp::InitHiddenElemSetter;
+}
+
+inline bool IsStrictSetPC(jsbytecode* pc) {
+  JSOp op = JSOp(*pc);
+  return op == JSOp::StrictSetProp || op == JSOp::StrictSetName ||
+         op == JSOp::StrictSetGName || op == JSOp::StrictSetElem;
+}
+
+inline bool IsSetPropOp(JSOp op) {
+  return op == JSOp::SetProp || op == JSOp::StrictSetProp ||
+         op == JSOp::SetName || op == JSOp::StrictSetName ||
+         op == JSOp::SetGName || op == JSOp::StrictSetGName;
+}
+
+inline bool IsSetPropPC(const jsbytecode* pc) { return IsSetPropOp(JSOp(*pc)); }
+
+inline bool IsGetElemOp(JSOp op) {
+  return op == JSOp::GetElem || op == JSOp::CallElem;
+}
+
+inline bool IsGetElemPC(const jsbytecode* pc) { return IsGetElemOp(JSOp(*pc)); }
+
+inline bool IsSetElemOp(JSOp op) {
+  return op == JSOp::SetElem || op == JSOp::StrictSetElem;
+}
+
+inline bool IsSetElemPC(const jsbytecode* pc) { return IsSetElemOp(JSOp(*pc)); }
+
+inline bool IsElemPC(const jsbytecode* pc) {
+  return CodeSpec(JSOp(*pc)).format & JOF_ELEM;
+}
+
+inline bool IsInvokeOp(JSOp op) { return CodeSpec(op).format & JOF_INVOKE; }
+
+inline bool IsInvokePC(jsbytecode* pc) { return IsInvokeOp(JSOp(*pc)); }
+
+inline bool IsStrictEvalPC(jsbytecode* pc) {
+  JSOp op = JSOp(*pc);
+  return op == JSOp::StrictEval || op == JSOp::StrictSpreadEval;
+}
+
+inline bool IsConstructOp(JSOp op) {
+  return CodeSpec(op).format & JOF_CONSTRUCT;
+}
+inline bool IsConstructPC(const jsbytecode* pc) {
+  return IsConstructOp(JSOp(*pc));
+}
+
+inline bool IsSpreadOp(JSOp op) { return CodeSpec(op).format & JOF_SPREAD; }
+
+inline bool IsSpreadPC(const jsbytecode* pc) { return IsSpreadOp(JSOp(*pc)); }
+
+static inline int32_t GetBytecodeInteger(jsbytecode* pc) {
+  switch (JSOp(*pc)) {
+    case JSOp::Zero:
+      return 0;
+    case JSOp::One:
+      return 1;
+    case JSOp::Uint16:
+      return GET_UINT16(pc);
+    case JSOp::Uint24:
+      return GET_UINT24(pc);
+    case JSOp::Int8:
+      return GET_INT8(pc);
+    case JSOp::Int32:
+      return GET_INT32(pc);
+    default:
+      MOZ_CRASH("Bad op");
+  }
+}
+
+inline bool BytecodeOpHasIC(JSOp op) { return CodeSpec(op).format & JOF_IC; }
+
+inline bool BytecodeOpHasTypeSet(JSOp op) {
+  return CodeSpec(op).format & JOF_TYPESET;
+}
+
+/*
+ * Counts accumulated for a single opcode in a script. The counts tracked vary
+ * between opcodes, and this structure ensures that counts are accessed in a
+ * coherent fashion.
+ */
+class PCCounts {
+  /*
+   * Offset of the pc inside the script. This fields is used to lookup opcode
+   * which have annotations.
+   */
+  size_t pcOffset_;
+
+  /*
+   * Record the number of execution of one instruction, or the number of
+   * throws executed.
+   */
+  uint64_t numExec_;
+
+ public:
+  explicit PCCounts(size_t off) : pcOffset_(off), numExec_(0) {}
+
+  size_t pcOffset() const { return pcOffset_; }
+
+  // Used for sorting and searching.
+  bool operator<(const PCCounts& rhs) const {
+    return pcOffset_ < rhs.pcOffset_;
+  }
+
+  uint64_t& numExec() { return numExec_; }
+  uint64_t numExec() const { return numExec_; }
+
+  static const char numExecName[];
+};
+
+static inline jsbytecode* GetNextPc(jsbytecode* pc) {
+  return pc + GetBytecodeLength(pc);
+}
+
+typedef Vector<jsbytecode*, 4, SystemAllocPolicy> PcVector;
+
+bool GetSuccessorBytecodes(JSScript* script, jsbytecode* pc,
+                           PcVector& successors);
+bool GetPredecessorBytecodes(JSScript* script, jsbytecode* pc,
+                             PcVector& predecessors);
+
+#if defined(DEBUG) || defined(JS_JITSPEW)
+
+enum class DisassembleSkeptically { No, Yes };
+
+/*
+ * Disassemblers, for debugging only.
+ */
+extern MOZ_MUST_USE bool Disassemble(
+    JSContext* cx, JS::Handle<JSScript*> script, bool lines, Sprinter* sp,
+    DisassembleSkeptically skeptically = DisassembleSkeptically::No);
+
+unsigned Disassemble1(JSContext* cx, JS::Handle<JSScript*> script,
+                      jsbytecode* pc, unsigned loc, bool lines, Sprinter* sp);
+
+#endif
+
+extern MOZ_MUST_USE bool DumpRealmPCCounts(JSContext* cx);
+
+}  // namespace js
+
+#endif /* vm_BytecodeUtil_h */

--- a/crates/emitter/src/copy/Opcodes.h
+++ b/crates/emitter/src/copy/Opcodes.h
@@ -1,0 +1,3514 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: set ts=8 sw=2 et tw=0 ft=c:
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef vm_Opcodes_h
+#define vm_Opcodes_h
+
+#include "mozilla/Attributes.h"
+
+#include <stddef.h>
+
+// clang-format off
+/*
+ * [SMDOC] Bytecode Definitions
+ *
+ * SpiderMonkey bytecode instructions.
+ *
+ * To use this header, define a macro of the form:
+ *
+ *     #define MACRO(op, op_snake, token, length, nuses, ndefs, format) ...
+ *
+ * Then `FOR_EACH_OPCODE(MACRO)` invokes `MACRO` for every opcode.
+ *
+ * Field        Description
+ * -----        -----------
+ * op           UpperCamelCase form of opcode id
+ * op_snake     snake_case form of opcode id
+ * token        Pretty-printer string, or null if ugly
+ * length       Number of bytes including any immediate operands
+ * nuses        Number of stack slots consumed by bytecode, -1 if variadic
+ * ndefs        Number of stack slots produced by bytecode
+ * format       JOF_ flags describing instruction operand layout, etc.
+ *
+ * For more about `format`, see the comments on the `JOF_` constants defined in
+ * BytecodeUtil.h.
+ *
+ *
+ * [SMDOC] Bytecode Invariants
+ *
+ * Creating scripts that do not follow the rules can lead to undefined
+ * behavior. Bytecode has many consumers, not just the interpreter: JITs,
+ * analyses, the debugger. That's why the rules below apply even to code that
+ * can't be reached in ordinary execution (such as code after an infinite loop
+ * or inside an `if (false)` block).
+ *
+ * The `code()` of a script must be a packed (not aligned) sequence of valid
+ * instructions from start to end. Each instruction has a single byte opcode
+ * followed by a number of operand bytes based on the opcode.
+ *
+ * ## Jump instructions
+ *
+ * Operands named `offset`, `forwardOffset`, or `defaultOffset` are jump
+ * offsets, the distance in bytes from the start of the current instruction to
+ * the start of another instruction in the same script. Operands named
+ * `forwardOffset` or `defaultOffset` must be positive.
+ *
+ * Forward jumps must jump to a `JSOp::JumpTarget` instruction.  Backward jumps,
+ * indicated by negative offsets, must jump to a `JSOp::LoopHead` instruction.
+ * Jump offsets can't be zero.
+ *
+ * Needless to say, scripts must not contain overlapping instruction sequences
+ * (in the sense of <https://en.wikipedia.org/wiki/Overlapping_gene>).
+ *
+ * A script's `trynotes` and `scopeNotes` impose further constraints. Each try
+ * note and each scope note marks a region of the bytecode where some invariant
+ * holds, or some cleanup behavior is needed--that there's a for-in iterator in
+ * a particular stack slot, for instance, which must be closed on error. All
+ * paths into the span must establish that invariant. In practice, this means
+ * other code never jumps into the span: the only way in is to execute the
+ * bytecode instruction that sets up the invariant (in our example,
+ * `JSOp::Iter`).
+ *
+ * If a script's `trynotes` (see "Try Notes" in JSScript.h) contain a
+ * `JSTRY_CATCH` or `JSTRY_FINALLY` span, there must be a `JSOp::Try`
+ * instruction immediately before the span and a `JSOp::JumpTarget immediately
+ * after it. Instructions must not jump to this `JSOp::JumpTarget`. (The VM puts
+ * us there on exception.) Furthermore, the instruction sequence immediately
+ * following a `JSTRY_CATCH` span must read `JumpTarget; Exception` or, in
+ * non-function scripts, `JumpTarget; Undefined; SetRval; Exception`. (These
+ * instructions run with an exception pending; other instructions aren't
+ * designed to handle that.)
+ *
+ * Unreachable instructions are allowed, but they have to follow all the rules.
+ *
+ * Control must not reach the end of a script. (Currently, the last instruction
+ * is always JSOp::RetRval.)
+ *
+ * ## Other operands
+ *
+ * Operands named `nameIndex` or `atomIndex` (which appear on instructions that
+ * have `JOF_ATOM` in the `format` field) must be valid indexes into
+ * `script->atoms()`.
+ *
+ * Operands named `argc` (`JOF_ARGC`) are argument counts for call
+ * instructions. `argc` must be small enough that the instruction's nuses is <=
+ * the current stack depth (see "Stack depth" below).
+ *
+ * Operands named `argno` (`JOF_QARG`) refer to an argument of the current
+ * function. `argno` must be in the range `0..script->function()->nargs()`.
+ * Instructions with these operands must appear only in function scripts.
+ *
+ * Operands named `localno` (`JOF_LOCAL`) refer to a local variable stored in
+ * the stack frame. `localno` must be in the range `0..script->nfixed()`.
+ *
+ * Operands named `resumeIndex` (`JOF_RESUMEINDEX`) refer to a resume point in
+ * the current script. `resumeIndex` must be a valid index into
+ * `script->resumeOffsets()`.
+ *
+ * Operands named `hops` and `slot` (`JOF_ENVCOORD`) refer a slot in an
+ * `EnvironmentObject`. At run time, they must point to a fixed slot in an
+ * object on the current environment chain. See `EnvironmentCoordinates`.
+ *
+ * Operands with the following names must be valid indexes into
+ * `script->gcthings()`, and the pointer in the vector must point to the right
+ * type of thing:
+ *
+ * -   `objectIndex` (`JOF_OBJECT`): `PlainObject*` or `ArrayObject*`
+ * -   `baseobjIndex` (`JOF_OBJECT`): `PlainObject*`
+ * -   `funcIndex` (`JOF_OBJECT`): `JSFunction*`
+ * -   `regexpIndex` (`JOF_REGEXP`): `RegExpObject*`
+ * -   `scopeIndex` (`JOF_SCOPE`): `Scope*`
+ * -   `lexicalScopeIndex` (`JOF_SCOPE`): `LexicalScope*`
+ * -   `withScopeIndex` (`JOF_SCOPE`): `WithScope*`
+ * -   `bigIntIndex` (`JOF_BIGINT`): `BigInt*`
+ *
+ * Operands named `icIndex` (`JOF_ICINDEX`) must be exactly the number of
+ * preceding instructions in the script that have the JOF_IC flag.
+ * (Rationale: Each JOF_IC instruction has a unique entry in
+ * `script->jitScript()->icEntries()`.  At run time, in the bytecode
+ * interpreter, we have to find that entry. We could store the IC index as an
+ * operand to each JOF_IC instruction, but it's more memory-efficient to use a
+ * counter and reset the counter to `icIndex` after each jump.)
+ *
+ * ## Stack depth
+ *
+ * Each instruction has a compile-time stack depth, the number of values on the
+ * interpreter stack just before executing the instruction. It isn't explicitly
+ * present in the bytecode itself, but (for reachable instructions, anyway)
+ * it's a function of the bytecode.
+ *
+ * -   The first instruction has stack depth 0.
+ *
+ * -   Each successor of an instruction X has a stack depth equal to
+ *
+ *         X's stack depth - `js::StackUses(X)` + `js::StackDefs(X)`
+ *
+ *     except for `JSOp::Case` (below).
+ *
+ *     X's "successors" are: the next instruction in the script, if
+ *     `js::FlowsIntoNext(op)` is true for X's opcode; one or more
+ *     `JSOp::JumpTarget`s elsewhere, if X is a forward jump or
+ *     `JSOp::TableSwitch`; and/or a `JSOp::LoopHead` if it's a backward jump.
+ *
+ * -   `JSOp::Case` is a special case because its stack behavior is eccentric.
+ *     The formula above is correct for the next instruction. The jump target
+ *     has a stack depth that is 1 less.
+ *
+ * -   See `JSOp::Gosub` for another special case.
+ *
+ * -   The `JSOp::JumpTarget` instruction immediately following a `JSTRY_CATCH`
+ *     or `JSTRY_FINALLY` span has the same stack depth as the `JSOp::Try`
+ *     instruction that precedes the span.
+ *
+ *     Every instruction covered by the `JSTRY_CATCH` or `JSTRY_FINALLY` span
+ *     must have a stack depth >= that value, so that error recovery is
+ *     guaranteed to find enough values on the stack to resume there.
+ *
+ * -   `script->nslots() - script->nfixed()` must be >= the maximum stack
+ *     depth of any instruction in `script`.  (The stack frame must be big
+ *     enough to run the code.)
+ *
+ * `BytecodeParser::parse()` computes stack depths for every reachable
+ * instruction in a script.
+ *
+ * ## Scopes and environments
+ *
+ * As with stack depth, each instruction has a static scope, which is a
+ * compile-time characterization of the eventual run-time environment chain
+ * when that instruction executes. Just as every instruction has a stack budget
+ * (nuses/ndefs), every instruction either pushes a scope, pops a scope, or
+ * neither. The same successor relation applies as above.
+ *
+ * Every scope used in a script is stored in the `JSScript::gcthings()` vector.
+ * They can be accessed using `getScope(index)` if you know what `index` to
+ * pass.
+ *
+ * The scope of every instruction (that's reachable via the successor relation)
+ * is given in two independent ways: by the bytecode itself and by the scope
+ * notes. The two sources must agree.
+ *
+ * ## Further rules
+ *
+ * All reachable instructions must be reachable without taking any backward
+ * edges.
+ *
+ * Instructions with the `JOF_CHECKSLOPPY` flag must not be used in strict mode
+ * code. `JOF_CHECKSTRICT` instructions must not be used in nonstrict code.
+ *
+ * Many instructions have their own additional rules. These are documented on
+ * the various opcodes below (look for the word "must").
+ */
+// clang-format on
+
+// clang-format off
+/*
+ * SpiderMonkey bytecode categorization (as used in generated documentation):
+ *
+ * [Index]
+ *   [Constants]
+ *   [Expressions]
+ *     Unary operators
+ *     Binary operators
+ *     Conversions
+ *     Other expressions
+ *   [Objects]
+ *     Creating objects
+ *     Defining properties
+ *     Accessing properties
+ *     Super
+ *     Enumeration
+ *     Iteration
+ *     SetPrototype
+ *     Array literals
+ *     RegExp literals
+ *   [Functions]
+ *     Creating functions
+ *     Creating constructors
+ *     Calls
+ *     Generators and async functions
+ *   [Control flow]
+ *     Jump targets
+ *     Jumps
+ *     Return
+ *     Exceptions
+ *   [Variables and scopes]
+ *     Initialization
+ *     Looking up bindings
+ *     Getting binding values
+ *     Setting binding values
+ *     Entering and leaving environments
+ *     Creating and deleting bindings
+ *     Function environment setup
+ *   [Stack operations]
+ *   [Other]
+ */
+// clang-format on
+
+// clang-format off
+#define FOR_EACH_OPCODE(MACRO) \
+    /*
+     * Push `undefined`.
+     *
+     *   Category: Constants
+     *   Operands:
+     *   Stack: => undefined
+     */ \
+    MACRO(Undefined, undefined, "", 1, 0, 1, JOF_BYTE) \
+    /*
+     * Push `null`.
+     *
+     *   Category: Constants
+     *   Operands:
+     *   Stack: => null
+     */ \
+    MACRO(Null, null, js_null_str, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Push a boolean constant.
+     *
+     *   Category: Constants
+     *   Operands:
+     *   Stack: => true/false
+     */ \
+    MACRO(False, false_, js_false_str, 1, 0, 1, JOF_BYTE) \
+    MACRO(True, true_, js_true_str, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Push the `int32_t` immediate operand as an `Int32Value`.
+     *
+     * `JSOp::Zero`, `JSOp::One`, `JSOp::Int8`, `JSOp::Uint16`, and `JSOp::Uint24`
+     * are all compact encodings for `JSOp::Int32`.
+     *
+     *   Category: Constants
+     *   Operands: int32_t val
+     *   Stack: => val
+     */ \
+    MACRO(Int32, int32, NULL, 5, 0, 1, JOF_INT32) \
+    /*
+     * Push the number `0`.
+     *
+     *   Category: Constants
+     *   Operands:
+     *   Stack: => 0
+     */ \
+    MACRO(Zero, zero, "0", 1, 0, 1, JOF_BYTE) \
+    /*
+     * Push the number `1`.
+     *
+     *   Category: Constants
+     *   Operands:
+     *   Stack: => 1
+     */ \
+    MACRO(One, one, "1", 1, 0, 1, JOF_BYTE) \
+    /*
+     * Push the `int8_t` immediate operand as an `Int32Value`.
+     *
+     *   Category: Constants
+     *   Operands: int8_t val
+     *   Stack: => val
+     */ \
+    MACRO(Int8, int8, NULL, 2, 0, 1, JOF_INT8) \
+    /*
+     * Push the `uint16_t` immediate operand as an `Int32Value`.
+     *
+     *   Category: Constants
+     *   Operands: uint16_t val
+     *   Stack: => val
+     */ \
+    MACRO(Uint16, uint16, NULL, 3, 0, 1, JOF_UINT16) \
+    /*
+     * Push the `uint24_t` immediate operand as an `Int32Value`.
+     *
+     *   Category: Constants
+     *   Operands: uint24_t val
+     *   Stack: => val
+     */ \
+    MACRO(Uint24, uint24, NULL, 4, 0, 1, JOF_UINT24) \
+    /*
+     * Push the 64-bit floating-point immediate operand as a `DoubleValue`.
+     *
+     * If the operand is a NaN, it must be the canonical NaN (see
+     * `JS::detail::CanonicalizeNaN`).
+     *
+     *   Category: Constants
+     *   Operands: double val
+     *   Stack: => val
+     */ \
+    MACRO(Double, double_, NULL, 9, 0, 1, JOF_DOUBLE) \
+    /*
+     * Push the BigInt constant `script->getBigInt(bigIntIndex)`.
+     *
+     *   Category: Constants
+     *   Operands: uint32_t bigIntIndex
+     *   Stack: => bigint
+     */ \
+    MACRO(BigInt, big_int, NULL, 5, 0, 1, JOF_BIGINT) \
+    /*
+     * Push the string constant `script->getAtom(atomIndex)`.
+     *
+     *   Category: Constants
+     *   Operands: uint32_t atomIndex
+     *   Stack: => string
+     */ \
+    MACRO(String, string, NULL, 5, 0, 1, JOF_ATOM) \
+    /*
+     * Push a well-known symbol.
+     *
+     * `symbol` must be in range for `JS::SymbolCode`.
+     *
+     *   Category: Constants
+     *   Operands: uint8_t symbol (the JS::SymbolCode of the symbol to use)
+     *   Stack: => symbol
+     */ \
+    MACRO(Symbol, symbol, NULL, 2, 0, 1, JOF_UINT8) \
+    /*
+     * Pop the top value on the stack, discard it, and push `undefined`.
+     *
+     * Implements: [The `void` operator][1], step 3.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-void-operator
+     *
+     *   Category: Expressions
+     *   Type: Unary operators
+     *   Operands:
+     *   Stack: val => undefined
+     */ \
+    MACRO(Void, void_, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * [The `typeof` operator][1].
+     *
+     * Infallible. The result is always a string that depends on the [type][2]
+     * of `val`.
+     *
+     * `JSOp::Typeof` and `JSOp::TypeofExpr` are the same except
+     * that--amazingly--`JSOp::Typeof` affects the behavior of an immediately
+     * *preceding* `JSOp::GetName` or `JSOp::GetGName` instruction! This is how
+     * we implement [`typeof`][1] step 2, making `typeof nonExistingVariable`
+     * return `"undefined"` instead of throwing a ReferenceError.
+     *
+     * In a global scope:
+     *
+     * -   `typeof x` compiles to `GetGName "x"; Typeof`.
+     * -   `typeof (0, x)` compiles to `GetGName "x"; TypeofExpr`.
+     *
+     * Emitting the same bytecode for these two expressions would be a bug.
+     * Per spec, the latter throws a ReferenceError if `x` doesn't exist.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-typeof-operator
+     * [2]: https://tc39.es/ecma262/#sec-ecmascript-language-types
+     *
+     *   Category: Expressions
+     *   Type: Unary operators
+     *   Operands:
+     *   Stack: val => (typeof val)
+     */ \
+    MACRO(Typeof, typeof_, NULL, 1, 1, 1, JOF_BYTE|JOF_DETECTING|JOF_IC) \
+    MACRO(TypeofExpr, typeof_expr, NULL, 1, 1, 1, JOF_BYTE|JOF_DETECTING|JOF_IC) \
+    /*
+     * [The unary `+` operator][1].
+     *
+     * `+val` doesn't do any actual math. It just calls [ToNumber][2](val).
+     *
+     * The conversion can call `.toString()`/`.valueOf()` methods and can
+     * throw. The result on success is always a Number. (Per spec, unary `-`
+     * supports BigInts, but unary `+` does not.)
+     *
+     * [1]: https://tc39.es/ecma262/#sec-unary-plus-operator
+     * [2]: https://tc39.es/ecma262/#sec-tonumber
+     *
+     *   Category: Expressions
+     *   Type: Unary operators
+     *   Operands:
+     *   Stack: val => (+val)
+     */ \
+    MACRO(Pos, pos, "+ ", 1, 1, 1, JOF_BYTE) \
+    /*
+     * [The unary `-` operator][1].
+     *
+     * Convert `val` to a numeric value, then push `-val`. The conversion can
+     * call `.toString()`/`.valueOf()` methods and can throw. The result on
+     * success is always numeric.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-unary-minus-operator
+     *
+     *   Category: Expressions
+     *   Type: Unary operators
+     *   Operands:
+     *   Stack: val => (-val)
+     */ \
+    MACRO(Neg, neg, "- ", 1, 1, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * [The bitwise NOT operator][1] (`~`).
+     *
+     * `val` is converted to an integer, then bitwise negated. The conversion
+     * can call `.toString()`/`.valueOf()` methods and can throw. The result on
+     * success is always an Int32 or BigInt value.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-bitwise-not-operator
+     *
+     *   Category: Expressions
+     *   Type: Unary operators
+     *   Operands:
+     *   Stack: val => (~val)
+     */ \
+    MACRO(BitNot, bit_not, "~", 1, 1, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * [The logical NOT operator][1] (`!`).
+     *
+     * `val` is first converted with [ToBoolean][2], then logically
+     * negated. The result is always a boolean value. This does not call
+     * user-defined methods and can't throw.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-logical-not-operator
+     * [2]: https://tc39.es/ecma262/#sec-toboolean
+     *
+     *   Category: Expressions
+     *   Type: Unary operators
+     *   Operands:
+     *   Stack: val => (!val)
+     */ \
+    MACRO(Not, not_, "!", 1, 1, 1, JOF_BYTE|JOF_DETECTING|JOF_IC) \
+    /*
+     * [Binary bitwise operations][1] (`|`, `^`, `&`).
+     *
+     * The arguments are converted to integers first. The conversion can call
+     * `.toString()`/`.valueOf()` methods and can throw. The result on success
+     * is always an Int32 or BigInt Value.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-binary-bitwise-operators
+     *
+     *   Category: Expressions
+     *   Type: Binary operators
+     *   Operands:
+     *   Stack: lval, rval => (lval OP rval)
+     */ \
+    MACRO(BitOr, bit_or, "|",  1, 2, 1, JOF_BYTE|JOF_IC) \
+    MACRO(BitXor, bit_xor, "^", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    MACRO(BitAnd, bit_and, "&", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * Loose equality operators (`==` and `!=`).
+     *
+     * Pop two values, compare them, and push the boolean result. The
+     * comparison may perform conversions that call `.toString()`/`.valueOf()`
+     * methods and can throw.
+     *
+     * Implements: [Abstract Equality Comparison][1].
+     *
+     * [1]: https://tc39.es/ecma262/#sec-abstract-equality-comparison
+     *
+     *   Category: Expressions
+     *   Type: Binary operators
+     *   Operands:
+     *   Stack: lval, rval => (lval OP rval)
+     */ \
+    MACRO(Eq, eq, "==", 1, 2, 1, JOF_BYTE|JOF_DETECTING|JOF_IC) \
+    MACRO(Ne, ne, "!=", 1, 2, 1, JOF_BYTE|JOF_DETECTING|JOF_IC) \
+    /*
+     * Strict equality operators (`===` and `!==`).
+     *
+     * Pop two values, check whether they're equal, and push the boolean
+     * result. This does not call user-defined methods and can't throw
+     * (except possibly due to OOM while flattening a string).
+     *
+     * Implements: [Strict Equality Comparison][1].
+     *
+     * [1]: https://tc39.es/ecma262/#sec-strict-equality-comparison
+     *
+     *   Category: Expressions
+     *   Type: Binary operators
+     *   Operands:
+     *   Stack: lval, rval => (lval OP rval)
+     */ \
+    MACRO(StrictEq, strict_eq, "===", 1, 2, 1, JOF_BYTE|JOF_DETECTING|JOF_IC) \
+    MACRO(StrictNe, strict_ne, "!==", 1, 2, 1, JOF_BYTE|JOF_DETECTING|JOF_IC) \
+    /*
+     * Relative operators (`<`, `>`, `<=`, `>=`).
+     *
+     * Pop two values, compare them, and push the boolean result. The
+     * comparison may perform conversions that call `.toString()`/`.valueOf()`
+     * methods and can throw.
+     *
+     * Implements: [Relational Operators: Evaluation][1].
+     *
+     * [1]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
+     *
+     *   Category: Expressions
+     *   Type: Binary operators
+     *   Operands:
+     *   Stack: lval, rval => (lval OP rval)
+     */ \
+    MACRO(Lt, lt, "<",  1, 2, 1, JOF_BYTE|JOF_IC) \
+    MACRO(Gt, gt, ">",  1, 2, 1, JOF_BYTE|JOF_IC) \
+    MACRO(Le, le, "<=", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    MACRO(Ge, ge, ">=", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * [The `instanceof` operator][1].
+     *
+     * This throws a `TypeError` if `target` is not an object. It calls
+     * `target[Symbol.hasInstance](value)` if the method exists. On success,
+     * the result is always a boolean value.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-instanceofoperator
+     *
+     *   Category: Expressions
+     *   Type: Binary operators
+     *   Operands:
+     *   Stack: value, target => (value instanceof target)
+     */ \
+    MACRO(Instanceof, instanceof, js_instanceof_str, 1, 2, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * [The `in` operator][1].
+     *
+     * Push `true` if `obj` has a property with the key `id`. Otherwise push `false`.
+     *
+     * This throws a `TypeError` if `obj` is not an object. This can fire
+     * proxy hooks and can throw. On success, the result is always a boolean
+     * value.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
+     *
+     *   Category: Expressions
+     *   Type: Binary operators
+     *   Operands:
+     *   Stack: id, obj => (id in obj)
+     */ \
+    MACRO(In, in_, js_in_str, 1, 2, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * [Bitwise shift operators][1] (`<<`, `>>`, `>>>`).
+     *
+     * Pop two values, convert them to integers, perform a bitwise shift, and
+     * push the result.
+     *
+     * Conversion can call `.toString()`/`.valueOf()` methods and can throw.
+     * The result on success is always an Int32 or BigInt Value.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-bitwise-shift-operators
+     *
+     *   Category: Expressions
+     *   Type: Binary operators
+     *   Operands:
+     *   Stack: lval, rval => (lval OP rval)
+     */ \
+    MACRO(Lsh, lsh, "<<", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    MACRO(Rsh, rsh, ">>", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    MACRO(Ursh, ursh, ">>>", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * [The binary `+` operator][1].
+     *
+     * Pop two values, convert them to primitive values, add them, and push the
+     * result. If both values are numeric, add them; if either is a
+     * string, do string concatenation instead.
+     *
+     * The conversion can call `.toString()`/`.valueOf()` methods and can throw.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-addition-operator-plus-runtime-semantics-evaluation
+     *
+     *   Category: Expressions
+     *   Type: Binary operators
+     *   Operands:
+     *   Stack: lval, rval => (lval + rval)
+     */ \
+    MACRO(Add, add, "+", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * [The binary `-` operator][1].
+     *
+     * Pop two values, convert them to numeric values, subtract the top value
+     * from the other one, and push the result.
+     *
+     * The conversion can call `.toString()`/`.valueOf()` methods and can
+     * throw. On success, the result is always numeric.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-subtraction-operator-minus-runtime-semantics-evaluation
+     *
+     *   Category: Expressions
+     *   Type: Binary operators
+     *   Operands:
+     *   Stack: lval, rval => (lval - rval)
+     */ \
+    MACRO(Sub, sub, "-", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * Add or subtract 1.
+     *
+     * `val` must already be a numeric value, such as the result of
+     * `JSOp::ToNumeric`.
+     *
+     * Implements: [The `++` and `--` operators][1], step 3 of each algorithm.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-postfix-increment-operator
+     *
+     *   Category: Expressions
+     *   Type: Binary operators
+     *   Operands:
+     *   Stack: val => (val +/- 1)
+     */ \
+    MACRO(Inc, inc, NULL, 1, 1, 1, JOF_BYTE|JOF_IC) \
+    MACRO(Dec, dec, NULL, 1, 1, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * [The multiplicative operators][1] (`*`, `/`, `%`).
+     *
+     * Pop two values, convert them to numeric values, do math, and push the
+     * result.
+     *
+     * The conversion can call `.toString()`/`.valueOf()` methods and can
+     * throw. On success, the result is always numeric.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-multiplicative-operators-runtime-semantics-evaluation
+     *
+     *   Category: Expressions
+     *   Type: Binary operators
+     *   Operands:
+     *   Stack: lval, rval => (lval OP rval)
+     */ \
+    MACRO(Mul, mul, "*", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    MACRO(Div, div, "/", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    MACRO(Mod, mod, "%", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * [The exponentiation operator][1] (`**`).
+     *
+     * Pop two values, convert them to numeric values, do exponentiation, and
+     * push the result. The top value is the exponent.
+     *
+     * The conversion can call `.toString()`/`.valueOf()` methods and can
+     * throw. This throws a RangeError if both values are BigInts and the
+     * exponent is negative.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-exp-operator
+     *
+     *   Category: Expressions
+     *   Type: Binary operators
+     *   Operands:
+     *   Stack: lval, rval => (lval ** rval)
+     */ \
+    MACRO(Pow, pow, "**", 1, 2, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * Convert a value to a property key.
+     *
+     * Implements: [ToPropertyKey][1], except that if the result would be the
+     * string representation of some integer in the range 0..2^31, we push the
+     * corresponding Int32 value instead. This is because the spec insists that
+     * array indices are strings, whereas for us they are integers.
+     *
+     * This is used for code like `++obj[index]`, which must do both a
+     * `JSOp::GetElem` and a `JSOp::SetElem` with the same property key. Both
+     * instructions would convert `index` to a property key for us, but the
+     * spec says to convert it only once.
+     *
+     * The conversion can call `.toString()`/`.valueOf()` methods and can
+     * throw.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-topropertykey
+     *
+     *   Category: Expressions
+     *   Type: Conversions
+     *   Operands:
+     *   Stack: propertyNameValue => propertyKey
+     */ \
+    MACRO(ToId, to_id, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Convert a value to a numeric value (a Number or BigInt).
+     *
+     * Implements: [ToNumeric][1](val).
+     *
+     * Note: This is used to implement [`++` and `--`][2]. Surprisingly, it's
+     * not possible to get the right behavior using `JSOp::Add` and `JSOp::Sub`
+     * alone. For one thing, `JSOp::Add` sometimes does string concatenation,
+     * while `++` always does numeric addition. More fundamentally, the result
+     * of evaluating `--x` is ToNumeric(old value of `x`), a value that the
+     * sequence `GetLocal "x"; One; Sub; SetLocal "x"` does not give us.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-tonumeric
+     * [2]: https://tc39.es/ecma262/#sec-postfix-increment-operator
+     *
+     *   Category: Expressions
+     *   Type: Conversions
+     *   Operands:
+     *   Stack: val => ToNumeric(val)
+     */ \
+    MACRO(ToNumeric, to_numeric, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Convert a value to a string.
+     *
+     * Implements: [ToString][1](val).
+     *
+     * Note: This is used in code for template literals, like `${x}${y}`. Each
+     * substituted value must be converted using ToString. `JSOp::Add` by itself
+     * would do a slightly wrong kind of conversion (hint="number" rather than
+     * hint="string").
+     *
+     * [1]: https://tc39.es/ecma262/#sec-tostring
+     *
+     *   Category: Expressions
+     *   Type: Conversions
+     *   Stack: val => ToString(val)
+     */ \
+    MACRO(ToString, to_string, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Push the global `this` value. Not to be confused with the `globalThis`
+     * property on the global.
+     *
+     * This must be used only in scopes where `this` refers to the global
+     * `this`.
+     *
+     *   Category: Expressions
+     *   Type: Other expressions
+     *   Operands:
+     *   Stack: => this
+     */ \
+    MACRO(GlobalThis, global_this, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Push the value of `new.target`.
+     *
+     * The result is a constructor or `undefined`.
+     *
+     * This must be used only in scripts where `new.target` is allowed:
+     * non-arrow function scripts and other scripts that have a non-arrow
+     * function script on the scope chain.
+     *
+     * Implements: [GetNewTarget][1].
+     *
+     * [1]: https://tc39.es/ecma262/#sec-getnewtarget
+     *
+     *   Category: Expressions
+     *   Type: Other expressions
+     *   Operands:
+     *   Stack: => new.target
+     */ \
+    MACRO(NewTarget, new_target, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Dynamic import of the module specified by the string value on the top of
+     * the stack.
+     *
+     * Implements: [Import Calls][1].
+     *
+     * [1]: https://tc39.es/ecma262/#sec-import-calls
+     *
+     *   Category: Expressions
+     *   Type: Other expressions
+     *   Operands:
+     *   Stack: moduleId => promise
+     */ \
+    MACRO(DynamicImport, dynamic_import, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Push the `import.meta` object.
+     *
+     * This must be used only in module code.
+     *
+     *   Category: Expressions
+     *   Type: Other expressions
+     *   Operands:
+     *   Stack: => import.meta
+     */ \
+    MACRO(ImportMeta, import_meta, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Create and push a new object with no properties.
+     *
+     *   Category: Objects
+     *   Type: Creating objects
+     *   Operands:
+     *   Stack: => obj
+     */ \
+    MACRO(NewInit, new_init, NULL, 1, 0, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * Create and push a new object of a predetermined shape.
+     *
+     * The new object has the shape of the template object
+     * `script->getObject(baseobjIndex)`. Subsequent `InitProp` instructions
+     * must fill in all slots of the new object before it is used in any other
+     * way.
+     *
+     * For `JSOp::NewObject`, the new object has a group based on the allocation
+     * site (or a new group if the template's group is a singleton). For
+     * `JSOp::NewObjectWithGroup`, the new object has the same group as the
+     * template object.
+     *
+     *   Category: Objects
+     *   Type: Creating objects
+     *   Operands: uint32_t baseobjIndex
+     *   Stack: => obj
+     */ \
+    MACRO(NewObject, new_object, NULL, 5, 0, 1, JOF_OBJECT|JOF_IC) \
+    MACRO(NewObjectWithGroup, new_object_with_group, NULL, 5, 0, 1, JOF_OBJECT|JOF_IC) \
+    /*
+     * Push a preconstructed object.
+     *
+     * Going one step further than `JSOp::NewObject`, this instruction doesn't
+     * just reuse the shape--it actually pushes the preconstructed object
+     * `script->getObject(objectIndex)` right onto the stack. The object must
+     * be a singleton `PlainObject` or `ArrayObject`.
+     *
+     * The spec requires that an *ObjectLiteral* or *ArrayLiteral* creates a
+     * new object every time it's evaluated, so this instruction must not be
+     * used anywhere it might be executed more than once.
+     *
+     * There's a shell-only option, `newGlobal({cloneSingletons: true})`, that
+     * makes this instruction do a deep copy of the object. A few tests use it.
+     *
+     *   Category: Objects
+     *   Type: Creating objects
+     *   Operands: uint32_t objectIndex
+     *   Stack: => obj
+     */ \
+    MACRO(Object, object, NULL, 5, 0, 1, JOF_OBJECT) \
+    /*
+     * Create and push a new ordinary object with the provided [[Prototype]].
+     *
+     * This is used to create the `.prototype` object for derived classes.
+     *
+     *   Category: Objects
+     *   Type: Creating objects
+     *   Operands:
+     *   Stack: proto => obj
+     */ \
+    MACRO(ObjWithProto, obj_with_proto, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Define a data property on an object.
+     *
+     * `obj` must be an object.
+     *
+     * Implements: [CreateDataPropertyOrThrow][1] as used in
+     * [PropertyDefinitionEvaluation][2] of regular and shorthand
+     * *PropertyDefinition*s.
+     *
+     *    [1]: https://tc39.es/ecma262/#sec-createdatapropertyorthrow
+     *    [2]: https://tc39.es/ecma262/#sec-object-initializer-runtime-semantics-propertydefinitionevaluation
+     *
+     *   Category: Objects
+     *   Type: Defining properties
+     *   Operands: uint32_t nameIndex
+     *   Stack: obj, val => obj
+     */ \
+    MACRO(InitProp, init_prop, NULL, 5, 2, 1, JOF_ATOM|JOF_PROP|JOF_PROPINIT|JOF_DETECTING|JOF_IC) \
+    /*
+     * Like `JSOp::InitProp`, but define a non-enumerable property.
+     *
+     * This is used to define class methods.
+     *
+     * Implements: [PropertyDefinitionEvaluation][1] for methods, steps 3 and
+     * 4, when *enumerable* is false.
+     *
+     *    [1]: https://tc39.es/ecma262/#sec-method-definitions-runtime-semantics-propertydefinitionevaluation
+     *
+     *   Category: Objects
+     *   Type: Defining properties
+     *   Operands: uint32_t nameIndex
+     *   Stack: obj, val => obj
+     */ \
+    MACRO(InitHiddenProp, init_hidden_prop, NULL, 5, 2, 1, JOF_ATOM|JOF_PROP|JOF_PROPINIT|JOF_DETECTING|JOF_IC) \
+    /*
+     * Like `JSOp::InitProp`, but define a non-enumerable, non-writable,
+     * non-configurable property.
+     *
+     * This is used to define the `.prototype` property on classes.
+     *
+     * Implements: [MakeConstructor][1], step 8, when *writablePrototype* is
+     * false.
+     *
+     *    [1]: https://tc39.es/ecma262/#sec-makeconstructor
+     *
+     *   Category: Objects
+     *   Type: Defining properties
+     *   Operands: uint32_t nameIndex
+     *   Stack: obj, val => obj
+     */ \
+    MACRO(InitLockedProp, init_locked_prop, NULL, 5, 2, 1, JOF_ATOM|JOF_PROP|JOF_PROPINIT|JOF_DETECTING|JOF_IC) \
+    /*
+     * Define a data property on `obj` with property key `id` and value `val`.
+     *
+     * Implements: [CreateDataPropertyOrThrow][1]. This instruction is used for
+     * object literals like `{0: val}` and `{[id]: val}`, and methods like
+     * `*[Symbol.iterator]() {}`.
+     *
+     * `JSOp::InitHiddenElem` is the same but defines a non-enumerable property,
+     * for class methods.
+     *
+     *    [1]: https://tc39.es/ecma262/#sec-createdatapropertyorthrow
+     *
+     *   Category: Objects
+     *   Type: Defining properties
+     *   Operands:
+     *   Stack: obj, id, val => obj
+     */ \
+    MACRO(InitElem, init_elem, NULL, 1, 3, 1, JOF_BYTE|JOF_ELEM|JOF_PROPINIT|JOF_DETECTING|JOF_IC) \
+    MACRO(InitHiddenElem, init_hidden_elem, NULL, 1, 3, 1, JOF_BYTE|JOF_ELEM|JOF_PROPINIT|JOF_DETECTING|JOF_IC) \
+    /*
+     * Define an accessor property on `obj` with the given `getter`.
+     * `nameIndex` gives the property name.
+     *
+     * `JSOp::InitHiddenPropGetter` is the same but defines a non-enumerable
+     * property, for getters in classes.
+     *
+     *   Category: Objects
+     *   Type: Defining properties
+     *   Operands: uint32_t nameIndex
+     *   Stack: obj, getter => obj
+     */ \
+    MACRO(InitPropGetter, init_prop_getter, NULL, 5, 2, 1, JOF_ATOM|JOF_PROP|JOF_PROPINIT|JOF_DETECTING) \
+    MACRO(InitHiddenPropGetter, init_hidden_prop_getter, NULL, 5, 2, 1, JOF_ATOM|JOF_PROP|JOF_PROPINIT|JOF_DETECTING) \
+    /*
+     * Define an accessor property on `obj` with property key `id` and the given `getter`.
+     *
+     * This is used to implement getters like `get [id]() {}` or `get 0() {}`.
+     *
+     * `JSOp::InitHiddenElemGetter` is the same but defines a non-enumerable
+     * property, for getters in classes.
+     *
+     *   Category: Objects
+     *   Type: Defining properties
+     *   Operands:
+     *   Stack: obj, id, getter => obj
+     */ \
+    MACRO(InitElemGetter, init_elem_getter, NULL, 1, 3, 1, JOF_BYTE|JOF_ELEM|JOF_PROPINIT|JOF_DETECTING) \
+    MACRO(InitHiddenElemGetter, init_hidden_elem_getter, NULL, 1, 3, 1, JOF_BYTE|JOF_ELEM|JOF_PROPINIT|JOF_DETECTING) \
+    /*
+     * Define an accessor property on `obj` with the given `setter`.
+     *
+     * This is used to implement ordinary setters like `set foo(v) {}`.
+     *
+     * `JSOp::InitHiddenPropSetter` is the same but defines a non-enumerable
+     * property, for setters in classes.
+     *
+     *   Category: Objects
+     *   Type: Defining properties
+     *   Operands: uint32_t nameIndex
+     *   Stack: obj, setter => obj
+     */ \
+    MACRO(InitPropSetter, init_prop_setter, NULL, 5, 2, 1, JOF_ATOM|JOF_PROP|JOF_PROPINIT|JOF_DETECTING) \
+    MACRO(InitHiddenPropSetter, init_hidden_prop_setter, NULL, 5, 2, 1, JOF_ATOM|JOF_PROP|JOF_PROPINIT|JOF_DETECTING) \
+    /*
+     * Define an accesssor property on `obj` with property key `id` and the
+     * given `setter`.
+     *
+     * This is used to implement setters with computed property keys or numeric
+     * keys.
+     *
+     * `JSOp::InitHiddenElemSetter` is the same but defines a non-enumerable
+     * property, for setters in classes.
+     *
+     *   Category: Objects
+     *   Type: Defining properties
+     *   Operands:
+     *   Stack: obj, id, setter => obj
+     */ \
+    MACRO(InitElemSetter, init_elem_setter, NULL, 1, 3, 1, JOF_BYTE|JOF_ELEM|JOF_PROPINIT|JOF_DETECTING) \
+    MACRO(InitHiddenElemSetter, init_hidden_elem_setter, NULL, 1, 3, 1, JOF_BYTE|JOF_ELEM|JOF_PROPINIT|JOF_DETECTING) \
+    /*
+     * Get the value of the property `obj.name`. This can call getters and
+     * proxy traps.
+     *
+     * `JSOp::CallProp` is exactly like `JSOp::GetProp` but hints to the VM that we're
+     * getting a method in order to call it.
+     *
+     * Implements: [GetV][1], [GetValue][2] step 5.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-getv
+     * [2]: https://tc39.es/ecma262/#sec-getvalue
+     *
+     *   Category: Objects
+     *   Type: Accessing properties
+     *   Operands: uint32_t nameIndex
+     *   Stack: obj => obj[name]
+     */ \
+    MACRO(GetProp, get_prop, NULL, 5, 1, 1, JOF_ATOM|JOF_PROP|JOF_TYPESET|JOF_IC) \
+    MACRO(CallProp, call_prop, NULL, 5, 1, 1, JOF_ATOM|JOF_PROP|JOF_TYPESET|JOF_IC) \
+    /*
+     * Get the value of the property `obj[key]`.
+     *
+     * `JSOp::CallElem` is exactly like `JSOp::GetElem` but hints to the VM that
+     * we're getting a method in order to call it.
+     *
+     * Implements: [GetV][1], [GetValue][2] step 5.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-getv
+     * [2]: https://tc39.es/ecma262/#sec-getvalue
+     *
+     *   Category: Objects
+     *   Type: Accessing properties
+     *   Operands:
+     *   Stack: obj, key => obj[key]
+     */ \
+    MACRO(GetElem, get_elem, NULL, 1, 2, 1, JOF_BYTE|JOF_ELEM|JOF_TYPESET|JOF_IC) \
+    MACRO(CallElem, call_elem, NULL, 1, 2, 1, JOF_BYTE|JOF_ELEM|JOF_TYPESET|JOF_IC) \
+    /*
+     * Push the value of `obj.length`.
+     *
+     * `nameIndex` must be the index of the atom `"length"`. This then behaves
+     * exactly like `JSOp::GetProp`.
+     *
+     *   Category: Objects
+     *   Type: Accessing properties
+     *   Operands: uint32_t nameIndex
+     *   Stack: obj => obj.length
+     */ \
+    MACRO(Length, length, NULL, 5, 1, 1, JOF_ATOM|JOF_PROP|JOF_TYPESET|JOF_IC) \
+    /*
+     * Non-strict assignment to a property, `obj.name = val`.
+     *
+     * This throws a TypeError if `obj` is null or undefined. If it's a
+     * primitive value, the property is set on ToObject(`obj`), typically with
+     * no effect.
+     *
+     * Implements: [PutValue][1] step 6 for non-strict code.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-putvalue
+     *
+     *   Category: Objects
+     *   Type: Accessing properties
+     *   Operands: uint32_t nameIndex
+     *   Stack: obj, val => val
+     */ \
+    MACRO(SetProp, set_prop, NULL, 5, 2, 1, JOF_ATOM|JOF_PROP|JOF_PROPSET|JOF_DETECTING|JOF_CHECKSLOPPY|JOF_IC) \
+    /*
+     * Like `JSOp::SetProp`, but for strict mode code. Throw a TypeError if
+     * `obj[key]` exists but is non-writable, if it's an accessor property with
+     * no setter, or if `obj` is a primitive value.
+     *
+     *   Category: Objects
+     *   Type: Accessing properties
+     *   Operands: uint32_t nameIndex
+     *   Stack: obj, val => val
+     */ \
+    MACRO(StrictSetProp, strict_set_prop, NULL, 5, 2, 1, JOF_ATOM|JOF_PROP|JOF_PROPSET|JOF_DETECTING|JOF_CHECKSTRICT|JOF_IC) \
+    /*
+     * Non-strict assignment to a property, `obj[key] = val`.
+     *
+     * Implements: [PutValue][1] step 6 for non-strict code.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-putvalue
+     *
+     *   Category: Objects
+     *   Type: Accessing properties
+     *   Operands:
+     *   Stack: obj, key, val => val
+     */ \
+    MACRO(SetElem, set_elem, NULL, 1, 3, 1, JOF_BYTE|JOF_ELEM|JOF_PROPSET|JOF_DETECTING|JOF_CHECKSLOPPY|JOF_IC) \
+    /*
+     * Like `JSOp::SetElem`, but for strict mode code. Throw a TypeError if
+     * `obj[key]` exists but is non-writable, if it's an accessor property with
+     * no setter, or if `obj` is a primitive value.
+     *
+     *   Category: Objects
+     *   Type: Accessing properties
+     *   Operands:
+     *   Stack: obj, key, val => val
+     */ \
+    MACRO(StrictSetElem, strict_set_elem, NULL, 1, 3, 1, JOF_BYTE|JOF_ELEM|JOF_PROPSET|JOF_DETECTING|JOF_CHECKSTRICT|JOF_IC) \
+    /*
+     * Delete a property from `obj`. Push true on success, false if the
+     * property existed but could not be deleted. This implements `delete
+     * obj.name` in non-strict code.
+     *
+     * Throws if `obj` is null or undefined. Can call proxy traps.
+     *
+     * Implements: [`delete obj.propname`][1] step 5 in non-strict code.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-delete-operator-runtime-semantics-evaluation
+     *
+     *   Category: Objects
+     *   Type: Accessing properties
+     *   Operands: uint32_t nameIndex
+     *   Stack: obj => succeeded
+     */ \
+    MACRO(DelProp, del_prop, NULL, 5, 1, 1, JOF_ATOM|JOF_PROP|JOF_CHECKSLOPPY) \
+    /*
+     * Like `JSOp::DelProp`, but for strict mode code. Push `true` on success,
+     * else throw a TypeError.
+     *
+     *   Category: Objects
+     *   Type: Accessing properties
+     *   Operands: uint32_t nameIndex
+     *   Stack: obj => succeeded
+     */ \
+    MACRO(StrictDelProp, strict_del_prop, NULL, 5, 1, 1, JOF_ATOM|JOF_PROP|JOF_CHECKSTRICT) \
+    /*
+     * Delete the property `obj[key]` and push `true` on success, `false`
+     * if the property existed but could not be deleted.
+     *
+     * This throws if `obj` is null or undefined. Can call proxy traps.
+     *
+     * Implements: [`delete obj[key]`][1] step 5 in non-strict code.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-delete-operator-runtime-semantics-evaluation
+     *
+     *   Category: Objects
+     *   Type: Accessing properties
+     *   Operands:
+     *   Stack: obj, key => succeeded
+     */ \
+    MACRO(DelElem, del_elem, NULL, 1, 2, 1, JOF_BYTE|JOF_ELEM|JOF_CHECKSLOPPY) \
+    /*
+     * Like `JSOp::DelElem, but for strict mode code. Push `true` on success,
+     * else throw a TypeError.
+     *
+     *   Category: Objects
+     *   Type: Accessing properties
+     *   Operands:
+     *   Stack: obj, key => succeeded
+     */ \
+    MACRO(StrictDelElem, strict_del_elem, NULL, 1, 2, 1, JOF_BYTE|JOF_ELEM|JOF_CHECKSTRICT) \
+    /*
+     * Push true if `obj` has an own property `id`.
+     *
+     * Note that `obj` is the top value, like `JSOp::In`.
+     *
+     * This opcode is not used for normal JS. Self-hosted code uses it by
+     * calling the intrinsic `hasOwn(id, obj)`. For example,
+     * `Object.prototype.hasOwnProperty` is implemented this way (see
+     * js/src/builtin/Object.js).
+     *
+     *   Category: Objects
+     *   Type: Accessing properties
+     *   Operands:
+     *   Stack: id, obj => (obj.hasOwnProperty(id))
+     */ \
+    MACRO(HasOwn, has_own, NULL, 1, 2, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * Push the SuperBase of the method `callee`. The SuperBase is
+     * `callee.[[HomeObject]].[[GetPrototypeOf]]()`, the object where `super`
+     * property lookups should begin.
+     *
+     * `callee` must be a function that has a HomeObject that's an object,
+     * typically produced by `JSOp::Callee` or `JSOp::EnvCallee`.
+     *
+     * Implements: [GetSuperBase][1], except that instead of the environment,
+     * the argument supplies the callee.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-getsuperbase
+     *
+     *   Category: Objects
+     *   Type: Super
+     *   Operands:
+     *   Stack: callee => superBase
+     */ \
+    MACRO(SuperBase, super_base, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Get the value of `receiver.name`, starting the property search at `obj`.
+     * In spec terms, `obj.[[Get]](name, receiver)`.
+     *
+     * Implements: [GetValue][1] for references created by [`super.name`][2].
+     * The `receiver` is `this` and `obj` is the SuperBase of the enclosing
+     * method.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-getvalue
+     * [2]: https://tc39.es/ecma262/#sec-super-keyword-runtime-semantics-evaluation
+     *
+     *   Category: Objects
+     *   Type: Super
+     *   Operands: uint32_t nameIndex
+     *   Stack: receiver, obj => super.name
+     */ \
+    MACRO(GetPropSuper, get_prop_super, NULL, 5, 2, 1, JOF_ATOM|JOF_PROP|JOF_TYPESET|JOF_IC) \
+    /*
+     * Get the value of `receiver[key]`, starting the property search at `obj`.
+     * In spec terms, `obj.[[Get]](key, receiver)`.
+     *
+     * Implements: [GetValue][1] for references created by [`super[key]`][2]
+     * (where the `receiver` is `this` and `obj` is the SuperBase of the enclosing
+     * method); [`Reflect.get(obj, key, receiver)`][3].
+     *
+     * [1]: https://tc39.es/ecma262/#sec-getvalue
+     * [2]: https://tc39.es/ecma262/#sec-super-keyword-runtime-semantics-evaluation
+     * [3]: https://tc39.es/ecma262/#sec-reflect.get
+     *
+     *   Category: Objects
+     *   Type: Super
+     *   Operands:
+     *   Stack: receiver, key, obj => super[key]
+     */ \
+    MACRO(GetElemSuper, get_elem_super, NULL, 1, 3, 1, JOF_BYTE|JOF_ELEM|JOF_TYPESET|JOF_IC) \
+    /*
+     * Assign `val` to `receiver.name`, starting the search for an existing
+     * property at `obj`. In spec terms, `obj.[[Set]](name, val, receiver)`.
+     *
+     * Implements: [PutValue][1] for references created by [`super.name`][2] in
+     * non-strict code. The `receiver` is `this` and `obj` is the SuperBase of
+     * the enclosing method.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-putvalue
+     * [2]: https://tc39.es/ecma262/#sec-super-keyword-runtime-semantics-evaluation
+     *
+     *   Category: Objects
+     *   Type: Super
+     *   Operands: uint32_t nameIndex
+     *   Stack: receiver, obj, val => val
+     */ \
+    MACRO(SetPropSuper, set_prop_super, NULL, 5, 3, 1, JOF_ATOM|JOF_PROP|JOF_PROPSET|JOF_DETECTING|JOF_CHECKSLOPPY) \
+    /*
+     * Like `JSOp::SetPropSuper`, but for strict mode code.
+     *
+     *   Category: Objects
+     *   Type: Super
+     *   Operands: uint32_t nameIndex
+     *   Stack: receiver, obj, val => val
+     */ \
+    MACRO(StrictSetPropSuper, strict_set_prop_super, NULL, 5, 3, 1, JOF_ATOM|JOF_PROP|JOF_PROPSET|JOF_DETECTING|JOF_CHECKSTRICT) \
+    /*
+     * Assign `val` to `receiver[key]`, strating the search for an existing
+     * property at `obj`. In spec terms, `obj.[[Set]](key, val, receiver)`.
+     *
+     * Implements: [PutValue][1] for references created by [`super[key]`][2] in
+     * non-strict code. The `receiver` is `this` and `obj` is the SuperBase of
+     * the enclosing method.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-putvalue
+     * [2]: https://tc39.es/ecma262/#sec-super-keyword-runtime-semantics-evaluation
+     *
+     *   Category: Objects
+     *   Type: Super
+     *   Operands:
+     *   Stack: receiver, key, obj, val => val
+     */ \
+    MACRO(SetElemSuper, set_elem_super, NULL, 1, 4, 1, JOF_BYTE|JOF_ELEM|JOF_PROPSET|JOF_DETECTING|JOF_CHECKSLOPPY) \
+    /*
+     * Like `JSOp::SetElemSuper`, but for strict mode code.
+     *
+     *   Category: Objects
+     *   Type: Super
+     *   Operands:
+     *   Stack: receiver, key, obj, val => val
+     */ \
+    MACRO(StrictSetElemSuper, strict_set_elem_super, NULL, 1, 4, 1, JOF_BYTE|JOF_ELEM|JOF_PROPSET|JOF_DETECTING|JOF_CHECKSTRICT) \
+    /*
+     * Set up a for-in loop by pushing a `PropertyIteratorObject` over the
+     * enumerable properties of `val`.
+     *
+     * Implements: [ForIn/OfHeadEvaluation][1] step 6,
+     * [EnumerateObjectProperties][1]. (The spec refers to an "Iterator object"
+     * with a `next` method, but notes that it "is never directly accessible"
+     * to scripts. The object we use for this has no public methods.)
+     *
+     * If `val` is null or undefined, this pushes an empty iterator.
+     *
+     * The `iter` object pushed by this instruction must not be used or removed
+     * from the stack except by `JSOp::MoreIter` and `JSOp::EndIter`, or by error
+     * handling.
+     *
+     * The script's `JSScript::trynotes()` must mark the body of the `for-in`
+     * loop, i.e. exactly those instructions that begin executing with `iter`
+     * on the stack, starting with the next instruction (always
+     * `JSOp::LoopHead`). Code must not jump into or out of this region: control
+     * can enter only by executing `JSOp::Iter` and can exit only by executing a
+     * `JSOp::EndIter` or by exception unwinding. (A `JSOp::EndIter` is always
+     * emitted at the end of the loop, and extra copies are emitted on "exit
+     * slides", where a `break`, `continue`, or `return` statement exits the
+     * loop.)
+     *
+     * Typically a single try note entry marks the contiguous chunk of bytecode
+     * from the instruction after `JSOp::Iter` to `JSOp::EndIter` (inclusive);
+     * but if that range contains any instructions on exit slides, after a
+     * `JSOp::EndIter`, then those must be correctly noted as *outside* the
+     * loop.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind
+     * [2]: https://tc39.es/ecma262/#sec-enumerate-object-properties
+     *
+     *   Category: Objects
+     *   Type: Enumeration
+     *   Operands:
+     *   Stack: val => iter
+     */ \
+    MACRO(Iter, iter, NULL, 1, 1, 1, JOF_BYTE|JOF_IC) \
+    /*
+     * Get the next property name for a for-in loop.
+     *
+     * `iter` must be a `PropertyIteratorObject` produced by `JSOp::Iter`.  This
+     * pushes the property name for the next loop iteration, or
+     * `MagicValue(JS_NO_ITER_VALUE)` if there are no more enumerable
+     * properties to iterate over. The magic value must be used only by
+     * `JSOp::IsNoIter` and `JSOp::EndIter`.
+     *
+     *   Category: Objects
+     *   Type: Enumeration
+     *   Operands:
+     *   Stack: iter => iter, name
+     */ \
+    MACRO(MoreIter, more_iter, NULL, 1, 1, 2, JOF_BYTE) \
+    /*
+     * Test whether the value on top of the stack is
+     * `MagicValue(JS_NO_ITER_VALUE)` and push the boolean result.
+     *
+     *   Category: Objects
+     *   Type: Enumeration
+     *   Operands:
+     *   Stack: val => val, done
+     */ \
+    MACRO(IsNoIter, is_no_iter, NULL, 1, 1, 2, JOF_BYTE) \
+    /*
+     * No-op instruction to hint to IonBuilder that the value on top of the
+     * stack is the (likely string) key in a for-in loop.
+     *
+     *   Category: Objects
+     *   Type: Enumeration
+     *   Operands:
+     *   Stack: val => val
+     */ \
+    MACRO(IterNext, iter_next, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Exit a for-in loop, closing the iterator.
+     *
+     * `iter` must be a `PropertyIteratorObject` pushed by `JSOp::Iter`.
+     *
+     *   Category: Objects
+     *   Type: Enumeration
+     *   Operands:
+     *   Stack: iter, iterval =>
+     */ \
+    MACRO(EndIter, end_iter, NULL, 1, 2, 0, JOF_BYTE) \
+    /*
+     * Check that the top value on the stack is an object, and throw a
+     * TypeError if not. `kind` is used only to generate an appropriate error
+     * message. It must be in range for `js::CheckIsObjectKind`.
+     *
+     * Implements: [GetIterator][1] step 5, [IteratorNext][2] step 3. Both
+     * operations call a JS method which scripts can define however they want,
+     * so they check afterwards that the method returned an object.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-getiterator
+     * [2]: https://tc39.es/ecma262/#sec-iteratornext
+     *
+     *   Category: Objects
+     *   Type: Iteration
+     *   Operands: uint8_t kind
+     *   Stack: result => result
+     */ \
+    MACRO(CheckIsObj, check_is_obj, NULL, 2, 1, 1, JOF_UINT8) \
+    /*
+     * Check that the top value on the stack is callable, and throw a TypeError
+     * if not. The operand `kind` is used only to generate an appropriate error
+     * message. It must be in range for `js::CheckIsCallableKind`.
+     *
+     *   Category: Objects
+     *   Type: Iteration
+     *   Operands: uint8_t kind
+     *   Stack: obj => obj
+     */ \
+    MACRO(CheckIsCallable, check_is_callable, NULL, 2, 1, 1, JOF_UINT8) \
+    /*
+     * Throw a TypeError if `val` is `null` or `undefined`.
+     *
+     * Implements: [RequireObjectCoercible][1]. But most instructions that
+     * require an object will perform this check for us, so of the dozens of
+     * calls to RequireObjectCoercible in the spec, we need this instruction
+     * only for [destructuring assignment][2] and [initialization][3].
+     *
+     * [1]: https://tc39.es/ecma262/#sec-requireobjectcoercible
+     * [2]: https://tc39.es/ecma262/#sec-runtime-semantics-destructuringassignmentevaluation
+     * [3]: https://tc39.es/ecma262/#sec-destructuring-binding-patterns-runtime-semantics-bindinginitialization
+     *
+     *   Category: Objects
+     *   Type: Iteration
+     *   Operands:
+     *   Stack: val => val
+     */ \
+    MACRO(CheckObjCoercible, check_obj_coercible, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Create and push an async iterator wrapping the sync iterator `iter`.
+     * `next` should be `iter`'s `.next` method.
+     *
+     * Implements: [CreateAsyncToSyncIterator][1]. The spec says this operation
+     * takes one argument, but that argument is a Record with two relevant
+     * fields, `[[Iterator]]` and `[[NextMethod]]`.
+     *
+     * Used for `for await` loops.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-createasyncfromsynciterator
+     *
+     *   Category: Objects
+     *   Type: Iteration
+     *   Operands:
+     *   Stack: iter, next => asynciter
+     */ \
+    MACRO(ToAsyncIter, to_async_iter, NULL, 1, 2, 1, JOF_BYTE) \
+    /*
+     * Set the prototype of `obj`.
+     *
+     * `obj` must be an object.
+     *
+     * Implements: [B.3.1 __proto__ Property Names in Object Initializers][1], step 7.a.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-__proto__-property-names-in-object-initializers
+     *
+     *   Category: Objects
+     *   Type: SetPrototype
+     *   Operands:
+     *   Stack: obj, protoVal => obj
+     */ \
+    MACRO(MutateProto, mutate_proto, NULL, 1, 2, 1, JOF_BYTE) \
+    /*
+     * Create and push a new Array object with the given `length`,
+     * preallocating enough memory to hold that many elements.
+     *
+     *   Category: Objects
+     *   Type: Array literals
+     *   Operands: uint32_t length
+     *   Stack: => array
+     */ \
+    MACRO(NewArray, new_array, NULL, 5, 0, 1, JOF_UINT32|JOF_IC) \
+    /*
+     * Initialize an array element `array[index]` with value `val`.
+     *
+     * `val` may be `MagicValue(JS_ELEMENTS_HOLE)`. If it is, this does nothing.
+     *
+     * This never calls setters or proxy traps.
+     *
+     * `array` must be an Array object created by `JSOp::NewArray` with length >
+     * `index`, and never used except by `JSOp::InitElemArray`.
+     *
+     * Implements: [ArrayAccumulation][1], the third algorithm, step 4, in the
+     * common case where *nextIndex* is known.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-runtime-semantics-arrayaccumulation
+     *
+     *   Category: Objects
+     *   Type: Array literals
+     *   Operands: uint32_t index
+     *   Stack: array, val => array
+     */ \
+    MACRO(InitElemArray, init_elem_array, NULL, 5, 2, 1, JOF_UINT32|JOF_ELEM|JOF_PROPINIT|JOF_DETECTING|JOF_IC) \
+    /*
+     * Initialize an array element `array[index++]` with value `val`.
+     *
+     * `val` may be `MagicValue(JS_ELEMENTS_HOLE)`. If it is, no element is
+     * defined, but the array length and the stack value `index` are still
+     * incremented.
+     *
+     * This never calls setters or proxy traps.
+     *
+     * `array` must be an Array object created by `JSOp::NewArray` and never used
+     * except by `JSOp::InitElemArray` and `JSOp::InitElemInc`.
+     *
+     * `index` must be an integer, `0 <= index <= INT32_MAX`. If `index` is
+     * `INT32_MAX`, this throws a RangeError.
+     *
+     * This instruction is used when an array literal contains a
+     * *SpreadElement*. In `[a, ...b, c]`, `InitElemArray 0` is used to put
+     * `a` into the array, but `InitElemInc` is used for the elements of `b`
+     * and for `c`.
+     *
+     * Implements: Several steps in [ArrayAccumulation][1] that call
+     * CreateDataProperty, set the array length, and/or increment *nextIndex*.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-runtime-semantics-arrayaccumulation
+     *
+     *   Category: Objects
+     *   Type: Array literals
+     *   Operands:
+     *   Stack: array, index, val => array, (index + 1)
+     */ \
+    MACRO(InitElemInc, init_elem_inc, NULL, 1, 3, 2, JOF_BYTE|JOF_ELEM|JOF_PROPINIT|JOF_IC) \
+    /*
+     * Push `MagicValue(JS_ELEMENTS_HOLE)`, representing an *Elision* in an
+     * array literal (like the missing property 0 in the array `[, 1]`).
+     *
+     * This magic value must be used only by `JSOp::InitElemArray` or
+     * `JSOp::InitElemInc`.
+     *
+     *   Category: Objects
+     *   Type: Array literals
+     *   Operands:
+     *   Stack: => hole
+     */ \
+    MACRO(Hole, hole, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Create and push a new array that shares the elements of a template
+     * object.
+     *
+     * `script->getObject(objectIndex)` must be a copy-on-write array whose
+     * elements are all primitive values.
+     *
+     * This is an optimization. This single instruction implements an entire
+     * array literal, saving run time, code, and memory compared to
+     * `JSOp::NewArray` and a series of `JSOp::InitElem` instructions.
+     *
+     *   Category: Objects
+     *   Type: Array literals
+     *   Operands: uint32_t objectIndex
+     *   Stack: => array
+     */ \
+    MACRO(NewArrayCopyOnWrite, new_array_copy_on_write, NULL, 5, 0, 1, JOF_OBJECT) \
+    /*
+     * Clone and push a new RegExp object.
+     *
+     * Implements: [Evaluation for *RegularExpressionLiteral*][1].
+     *
+     * [1]: https://tc39.es/ecma262/#sec-regular-expression-literals-runtime-semantics-evaluation
+     *
+     *   Category: Objects
+     *   Type: RegExp literals
+     *   Operands: uint32_t regexpIndex
+     *   Stack: => regexp
+     */ \
+    MACRO(RegExp, reg_exp, NULL, 5, 0, 1, JOF_REGEXP) \
+    /*
+     * Push a function object.
+     *
+     * This clones the function unless it's a singleton; see
+     * `CanReuseFunctionForClone`. The new function inherits the current
+     * environment chain.
+     *
+     * Used to create most JS functions. Notable exceptions are arrow functions
+     * and derived or default class constructors.
+     *
+     * The function indicated by `funcIndex` must be a non-arrow function.
+     *
+     * Implements: [InstantiateFunctionObject][1], [Evaluation for
+     * *FunctionExpression*][2], and so on.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-function-definitions-runtime-semantics-instantiatefunctionobject
+     * [2]: https://tc39.es/ecma262/#sec-function-definitions-runtime-semantics-evaluation
+     *
+     *   Category: Functions
+     *   Type: Creating functions
+     *   Operands: uint32_t funcIndex
+     *   Stack: => fn
+     */ \
+    MACRO(Lambda, lambda, NULL, 5, 0, 1, JOF_OBJECT) \
+    /*
+     * Push a new arrow function.
+     *
+     * `newTarget` matters only if the arrow function uses the expression
+     * `new.target`. It should be the current value of `new.target`, so that
+     * the arrow function inherits `new.target` from the enclosing scope. (If
+     * `new.target` is illegal here, the value doesn't matter; use `null`.)
+     *
+     * The function indicated by `funcIndex` must be an arrow function.
+     *
+     *   Category: Functions
+     *   Type: Creating functions
+     *   Operands: uint32_t funcIndex
+     *   Stack: newTarget => arrowFn
+     */ \
+    MACRO(LambdaArrow, lambda_arrow, NULL, 5, 1, 1, JOF_OBJECT) \
+    /*
+     * Set the name of a function.
+     *
+     * `fun` must be a function object. `name` must be a string, Int32 value,
+     * or symbol (like the result of `JSOp::ToId`).
+     *
+     * Implements: [SetFunctionName][1], used e.g. to name methods with
+     * computed property names.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-setfunctionname
+     *
+     *   Category: Functions
+     *   Type: Creating functions
+     *   Operands: uint8_t prefixKind
+     *   Stack: fun, name => fun
+     */ \
+    MACRO(SetFunName, set_fun_name, NULL, 2, 2, 1, JOF_UINT8) \
+    /*
+     * Initialize the home object for functions with super bindings.
+     *
+     *   Category: Functions
+     *   Type: Creating functions
+     *   Operands:
+     *   Stack: fun, homeObject => fun
+     */ \
+    MACRO(InitHomeObject, init_home_object, NULL, 1, 2, 1, JOF_BYTE) \
+    /*
+     * Throw a TypeError if `baseClass` isn't either `null` or a constructor.
+     *
+     * Implements: [ClassDefinitionEvaluation][1] step 6.f.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation
+     *
+     *   Category: Functions
+     *   Type: Creating constructors
+     *   Operands:
+     *   Stack: baseClass => baseClass
+     */ \
+    MACRO(CheckClassHeritage, check_class_heritage, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Like `JSOp::Lambda`, but using `proto` as the new function's
+     * `[[Prototype]]` (or `%FunctionPrototype%` if `proto` is `null`).
+     *
+     * `proto` must be either a constructor or `null`. We use
+     * `JSOp::CheckClassHeritage` to check.
+     *
+     * This is used to create the constructor for a derived class.
+     *
+     * Implements: [ClassDefinitionEvaluation][1] steps 6.e.ii, 6.g.iii, and
+     * 12 for derived classes.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation
+     *
+     *   Category: Functions
+     *   Type: Creating constructors
+     *   Operands: uint32_t funcIndex
+     *   Stack: proto => obj
+     */ \
+    MACRO(FunWithProto, fun_with_proto, NULL, 5, 1, 1, JOF_OBJECT) \
+    /*
+     * Create and push a default constructor for a base class.
+     *
+     * A default constructor behaves like `constructor() {}`.
+     *
+     * Implements: [ClassDefinitionEvaluation for *ClassTail*][1], steps
+     * 10.b. and 12-17.
+     *
+     * The `sourceStart`/`sourceEnd` offsets are the start/end offsets of the
+     * class definition in the source buffer and are used for `toString()`.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation
+     *
+     *   Category: Functions
+     *   Type: Creating constructors
+     *   Operands: uint32_t nameIndex, uint32_t sourceStart, uint32_t sourceEnd
+     *   Stack: => constructor
+     */ \
+    MACRO(ClassConstructor, class_constructor, NULL, 13, 0, 1, JOF_CLASS_CTOR) \
+    /*
+     * Create and push a default constructor for a derived class.
+     *
+     * A default derived-class constructor behaves like
+     * `constructor(...args) { super(...args); }`.
+     *
+     * Implements: [ClassDefinitionEvaluation for *ClassTail*][1], steps
+     * 10.a. and 12-17.
+     *
+     * The `sourceStart`/`sourceEnd` offsets are the start/end offsets of the
+     * class definition in the source buffer and are used for `toString()`.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation
+     *
+     *   Category: Functions
+     *   Type: Creating constructors
+     *   Operands: uint32_t nameIndex, uint32_t sourceStart, uint32_t sourceEnd
+     *   Stack: proto => constructor
+     */ \
+    MACRO(DerivedConstructor, derived_constructor, NULL, 13, 1, 1, JOF_CLASS_CTOR) \
+    /*
+     * Pushes the current global's builtin prototype for a given proto key.
+     *
+     *   Category: Functions
+     *   Type: Creating constructors
+     *   Operands: uint8_t kind
+     *   Stack: => %BuiltinPrototype%
+     */ \
+    MACRO(BuiltinProto, builtin_proto, NULL, 2, 0, 1, JOF_UINT8) \
+    /*
+     * Invoke `callee` with `this` and `args`, and push the return value. Throw
+     * a TypeError if `callee` isn't a function.
+     *
+     * `JSOp::CallIter` is used for implicit calls to @@iterator methods, to
+     * ensure error messages are formatted with `JSMSG_NOT_ITERABLE` ("x is not
+     * iterable") rather than `JSMSG_NOT_FUNCTION` ("x[Symbol.iterator] is not
+     * a function"). The `argc` operand must be 0 for this variation.
+     *
+     * `JSOp::FunApply` hints to the VM that this is likely a call to the
+     * builtin method `Function.prototype.apply`, an easy optimization target.
+     *
+     * `JSOp::FunCall` similarly hints to the VM that the callee is likely
+     * `Function.prototype.call`.
+     *
+     * `JSOp::CallIgnoresRv` hints to the VM that the return value is ignored.
+     * This allows alternate faster implementations to be used that avoid
+     * unnecesary allocations.
+     *
+     * Implements: [EvaluateCall][1] steps 4, 5, and 7.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-evaluatecall
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands: uint16_t argc
+     *   Stack: callee, this, args[0], ..., args[argc-1] => rval
+     */ \
+    MACRO(Call, call, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_TYPESET|JOF_IC) \
+    MACRO(CallIter, call_iter, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_TYPESET|JOF_IC) \
+    MACRO(FunApply, fun_apply, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_TYPESET|JOF_IC) \
+    MACRO(FunCall, fun_call, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_TYPESET|JOF_IC) \
+    MACRO(CallIgnoresRv, call_ignores_rv, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_TYPESET|JOF_IC) \
+    /*
+     * Like `JSOp::Call`, but the arguments are provided in an array rather than
+     * a span of stack slots. Used to implement spread-call syntax:
+     * `f(...args)`.
+     *
+     * `args` must be an Array object containing the actual arguments. The
+     * array must be packed (dense and free of holes; see IsPackedArray).
+     * This can be ensured by creating the array with `JSOp::NewArray` and
+     * populating it using `JSOp::InitElemArray`.
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands:
+     *   Stack: callee, this, args => rval
+     */ \
+    MACRO(SpreadCall, spread_call, NULL, 1, 3, 1, JOF_BYTE|JOF_INVOKE|JOF_SPREAD|JOF_TYPESET|JOF_IC) \
+    /*
+     * Push true if `arr` is an array object that can be passed directly as the
+     * `args` argument to `JSOp::SpreadCall`.
+     *
+     * This instruction and the branch around the iterator loop are emitted
+     * only when `arr` is itself a rest parameter, as in `(...arr) =>
+     * f(...arr)`, a strong hint that it's a packed Array whose prototype is
+     * `Array.prototype`.
+     *
+     * See `js::OptimizeSpreadCall`.
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands:
+     *   Stack: arr => arr, optimized
+     */ \
+    MACRO(OptimizeSpreadCall, optimize_spread_call, NULL, 1, 1, 2, JOF_BYTE) \
+    /*
+     * Perform a direct eval in the current environment if `callee` is the
+     * builtin `eval` function, otherwise follow same behaviour as `JSOp::Call`.
+     *
+     * All direct evals use one of the JSOp::*Eval instructions here and these
+     * opcodes are only used when the syntactic conditions for a direct eval
+     * are met. If the builtin `eval` function is called though other means, it
+     * becomes an indirect eval.
+     *
+     * Direct eval causes all bindings in *enclosing* non-global scopes to be
+     * marked "aliased". The optimization that puts bindings in stack slots has
+     * to prove that the bindings won't need to be captured by closures or
+     * accessed using `JSOp::{Get,Bind,Set,Del}Name` instructions. Direct eval
+     * makes that analysis impossible.
+     *
+     * Implements: [Function Call Evaluation][1], steps 5-7 and 9, when the
+     * syntactic critera for direct eval in step 6 are all met.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-function-calls-runtime-semantics-evaluation
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands: uint16_t argc
+     *   Stack: callee, this, args[0], ..., args[argc-1] => rval
+     */ \
+    MACRO(Eval, eval, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_TYPESET|JOF_CHECKSLOPPY|JOF_IC) \
+    /*
+     * Spread-call variant of `JSOp::Eval`.
+     *
+     * See `JSOp::SpreadCall` for restrictions on `args`.
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands:
+     *   Stack: callee, this, args => rval
+     */ \
+    MACRO(SpreadEval, spread_eval, NULL, 1, 3, 1, JOF_BYTE|JOF_INVOKE|JOF_SPREAD|JOF_TYPESET|JOF_CHECKSLOPPY|JOF_IC) \
+    /*
+     * Like `JSOp::Eval`, but for strict mode code.
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands: uint16_t argc
+     *   Stack: evalFn, this, args[0], ..., args[argc-1] => rval
+     */ \
+    MACRO(StrictEval, strict_eval, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_TYPESET|JOF_CHECKSTRICT|JOF_IC) \
+    /*
+     * Spread-call variant of `JSOp::StrictEval`.
+     *
+     * See `JSOp::SpreadCall` for restrictions on `args`.
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands:
+     *   Stack: callee, this, args => rval
+     */ \
+    MACRO(StrictSpreadEval, strict_spread_eval, NULL, 1, 3, 1, JOF_BYTE|JOF_INVOKE|JOF_SPREAD|JOF_TYPESET|JOF_CHECKSTRICT|JOF_IC) \
+    /*
+     * Push the implicit `this` value for an unqualified function call, like
+     * `foo()`. `nameIndex` gives the name of the function we're calling.
+     *
+     * The result is always `undefined` except when the name refers to a `with`
+     * binding.  For example, in `with (date) { getFullYear(); }`, the
+     * implicit `this` passed to `getFullYear` is `date`, not `undefined`.
+     *
+     * This walks the run-time environment chain looking for the environment
+     * record that contains the function. If the function call is not inside a
+     * `with` statement, use `JSOp::GImplicitThis` instead. If the function call
+     * definitely refers to a local binding, use `JSOp::Undefined`.
+     *
+     * Implements: [EvaluateCall][1] step 1.b. But not entirely correctly.
+     * See [bug 1166408][2].
+     *
+     * [1]: https://tc39.es/ecma262/#sec-evaluatecall
+     * [2]: https://bugzilla.mozilla.org/show_bug.cgi?id=1166408
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands: uint32_t nameIndex
+     *   Stack: => this
+     */ \
+    MACRO(ImplicitThis, implicit_this, "", 5, 0, 1, JOF_ATOM) \
+    /*
+     * Like `JSOp::ImplicitThis`, but the name must not be bound in any local
+     * environments.
+     *
+     * The result is always `undefined` except when the name refers to a
+     * binding in a non-syntactic `with` environment.
+     *
+     * Note: The frontend has to emit `JSOp::GImplicitThis` (and not
+     * `JSOp::Undefined`) for global unqualified function calls, even when
+     * `CompileOptions::nonSyntacticScope == false`, because later
+     * `js::CloneGlobalScript` can be called with `ScopeKind::NonSyntactic` to
+     * clone the script into a non-syntactic environment, with the bytecode
+     * reused, unchanged.
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands: uint32_t nameIndex
+     *   Stack: => this
+     */ \
+    MACRO(GImplicitThis, g_implicit_this, "", 5, 0, 1, JOF_ATOM) \
+    /*
+     * Push the call site object for a tagged template call.
+     *
+     * `script->getObject(objectIndex)` is the call site object;
+     * `script->getObject(objectIndex + 1)` is the raw object.
+     *
+     * The first time this instruction runs for a given template, it assembles
+     * the final value, defining the `.raw` property on the call site object
+     * and freezing both objects.
+     *
+     * Implements: [GetTemplateObject][1], steps 4 and 12-16.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-gettemplateobject
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands: uint32_t objectIndex
+     *   Stack: => callSiteObj
+     */ \
+    MACRO(CallSiteObj, call_site_obj, NULL, 5, 0, 1, JOF_OBJECT) \
+    /*
+     * Push `MagicValue(JS_IS_CONSTRUCTING)`.
+     *
+     * This magic value is a required argument to the `JSOp::New` and
+     * `JSOp::SuperCall` instructions and must not be used any other way.
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands:
+     *   Stack: => JS_IS_CONSTRUCTING
+     */ \
+    MACRO(IsConstructing, is_constructing, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Invoke `callee` as a constructor with `args` and `newTarget`, and push
+     * the return value. Throw a TypeError if `callee` isn't a constructor.
+     *
+     * `isConstructing` must be the value pushed by `JSOp::IsConstructing`.
+     *
+     * `JSOp::SuperCall` behaves exactly like `JSOp::New`, but is used for
+     * *SuperCall* expressions, to allow JITs to distinguish them from `new`
+     * expressions.
+     *
+     * Implements: [EvaluateConstruct][1] steps 7 and 8.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-evaluatenew
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands: uint16_t argc
+     *   Stack: callee, isConstructing, args[0], ..., args[argc-1], newTarget => rval
+     */ \
+    MACRO(New, new_, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_CONSTRUCT|JOF_TYPESET|JOF_IC|JOF_IC) \
+    MACRO(SuperCall, super_call, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_CONSTRUCT|JOF_TYPESET|JOF_IC) \
+    /*
+     * Spread-call variant of `JSOp::New`.
+     *
+     * Invokes `callee` as a constructor with `args` and `newTarget`, and
+     * pushes the return value onto the stack.
+     *
+     * `isConstructing` must be the value pushed by `JSOp::IsConstructing`.
+     * See `JSOp::SpreadCall` for restrictions on `args`.
+     *
+     * `JSOp::SpreadSuperCall` behaves exactly like `JSOp::SpreadNew`, but is
+     * used for *SuperCall* expressions.
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands:
+     *   Stack: callee, isConstructing, args, newTarget => rval
+     */ \
+    MACRO(SpreadNew, spread_new, NULL, 1, 4, 1, JOF_BYTE|JOF_INVOKE|JOF_CONSTRUCT|JOF_SPREAD|JOF_TYPESET|JOF_IC) \
+    MACRO(SpreadSuperCall, spread_super_call, NULL, 1, 4, 1, JOF_BYTE|JOF_INVOKE|JOF_CONSTRUCT|JOF_SPREAD|JOF_TYPESET|JOF_IC) \
+    /*
+     * Push the prototype of `callee` in preparation for calling `super()`.
+     *
+     * `callee` must be a derived class constructor.
+     *
+     * Implements: [GetSuperConstructor][1], steps 4-7.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-getsuperconstructor
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands:
+     *   Stack: callee => superFun
+     */ \
+    MACRO(SuperFun, super_fun, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Throw a ReferenceError if `thisval` is not
+     * `MagicValue(JS_UNINITIALIZED_LEXICAL)`. Used in derived class
+     * constructors to prohibit calling `super` more than once.
+     *
+     * Implements: [BindThisValue][1], step 3.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-bindthisvalue
+     *
+     *   Category: Functions
+     *   Type: Calls
+     *   Operands:
+     *   Stack: thisval => thisval
+     */ \
+    MACRO(CheckThisReinit, check_this_reinit, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Initializes generator frame, creates a generator and pushes it on the
+     * stack.
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands:
+     *   Stack: => generator
+     */ \
+    MACRO(Generator, generator, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Pops the generator from the top of the stack, suspends it and stops
+     * execution.
+     *
+     * When resuming execution, JSOp::Resume pushes the rval, gen and resumeKind
+     * values. resumeKind is the GeneratorResumeKind stored as int32.
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands: uint24_t resumeIndex
+     *   Stack: gen => rval, gen, resumeKind
+     */ \
+    MACRO(InitialYield, initial_yield, NULL, 4, 1, 3, JOF_RESUMEINDEX) \
+    /*
+     * Bytecode emitted after 'yield' expressions. This is useful for the
+     * Debugger and `AbstractGeneratorObject::isAfterYieldOrAwait`. It's
+     * treated as jump target op so that the Baseline Interpreter can
+     * efficiently restore the frame's interpreterICEntry when resuming a
+     * generator.
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands: uint32_t icIndex
+     *   Stack: =>
+     */ \
+    MACRO(AfterYield, after_yield, NULL, 5, 0, 0, JOF_ICINDEX) \
+    /*
+     * Pops the generator and suspends and closes it. Yields the value in the
+     * frame's return value slot.
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands:
+     *   Stack: gen =>
+     */ \
+    MACRO(FinalYieldRval, final_yield_rval, NULL, 1, 1, 0, JOF_BYTE) \
+    /*
+     * Pops the generator and the return value 'rval1', stops execution and
+     * returns 'rval1'.
+     *
+     * When resuming execution, JSOp::Resume pushes the rval2, gen and resumeKind
+     * values.
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands: uint24_t resumeIndex
+     *   Stack: rval1, gen => rval2, gen, resumeKind
+     */ \
+    MACRO(Yield, yield, NULL, 4, 2, 3, JOF_RESUMEINDEX) \
+    /*
+     * Pushes a boolean indicating whether the top of the stack is
+     * `MagicValue(JS_GENERATOR_CLOSING)`.
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands:
+     *   Stack: val => val, res
+     */ \
+    MACRO(IsGenClosing, is_gen_closing, NULL, 1, 1, 2, JOF_BYTE) \
+    /*
+     * Pops the top two values 'value' and 'gen' from the stack, then starts
+     * "awaiting" for 'value' to be resolved, which will then resume the
+     * execution of 'gen'. Pushes the async function promise on the stack, so
+     * that it'll be returned to the caller on the very first "await".
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands:
+     *   Stack: value, gen => promise
+     */ \
+    MACRO(AsyncAwait, async_await, NULL, 1, 2, 1, JOF_BYTE) \
+    /*
+     * Pops the top two values 'valueOrReason' and 'gen' from the stack, then
+     * pushes the promise resolved with 'valueOrReason'. `gen` must be the
+     * internal generator object created in async functions. The pushed promise
+     * is the async function's result promise, which is stored in `gen`.
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands: uint8_t fulfillOrReject
+     *   Stack: valueOrReason, gen => promise
+     */ \
+    MACRO(AsyncResolve, async_resolve, NULL, 2, 2, 1, JOF_UINT8) \
+    /*
+     * Pops the generator and the return value 'promise', stops execution and
+     * returns 'promise'.
+     *
+     * When resuming execution, JSOp::Resume pushes the resolved, gen and
+     * resumeKind values. resumeKind is the GeneratorResumeKind stored as int32.
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands: uint24_t resumeIndex
+     *   Stack: promise, gen => resolved, gen, resumeKind
+     */ \
+    MACRO(Await, await, NULL, 4, 2, 3, JOF_RESUMEINDEX) \
+    /*
+     * Pops the top of stack value as 'value', checks if the await for 'value'
+     * can be skipped. If the await operation can be skipped and the resolution
+     * value for 'value' can be acquired, pushes the resolution value and
+     * 'true' onto the stack. Otherwise, pushes 'value' and 'false' on the
+     * stack.
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands:
+     *   Stack: value => value_or_resolved, canskip
+     */ \
+    MACRO(TrySkipAwait, try_skip_await, NULL, 1, 1, 2, JOF_BYTE) \
+    /*
+     * Pushes one of the GeneratorResumeKind values as Int32Value.
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands: GeneratorResumeKind resumeKind (encoded as uint8_t)
+     *   Stack: => resumeKind
+     */ \
+    MACRO(ResumeKind, resume_kind, NULL, 2, 0, 1, JOF_UINT8) \
+    /*
+     * Pops the generator and resumeKind values. resumeKind is the
+     * GeneratorResumeKind stored as int32. If resumeKind is Next, continue
+     * execution. If resumeKind is Throw or Return, these completions are
+     * handled by throwing an exception. See GeneratorThrowOrReturn.
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands:
+     *   Stack: rval, gen, resumeKind => rval
+     */ \
+    MACRO(CheckResumeKind, check_resume_kind, NULL, 1, 3, 1, JOF_BYTE) \
+    /*
+     * Pops the generator, argument and resumeKind from the stack, pushes a new
+     * generator frame and resumes execution of it. Pushes the return value
+     * after the generator yields.
+     *
+     *   Category: Functions
+     *   Type: Generators and async functions
+     *   Operands:
+     *   Stack: gen, val, resumeKind => rval
+     */ \
+    MACRO(Resume, resume, NULL, 1, 3, 1, JOF_BYTE|JOF_INVOKE) \
+    /*
+     * No-op instruction marking the target of a jump instruction.
+     *
+     * This instruction and a few others (see `js::BytecodeIsJumpTarget`) are
+     * jump target instructions. The Baseline Interpreter uses these
+     * instructions to sync the frame's `interpreterICEntry` after a jump. Ion
+     * uses them to find block boundaries when translating bytecode to MIR.
+     *
+     *   Category: Control flow
+     *   Type: Jump targets
+     *   Operands: uint32_t icIndex
+     *   Stack: =>
+     */ \
+    MACRO(JumpTarget, jump_target, NULL, 5, 0, 0, JOF_ICINDEX) \
+    /*
+     * Marks the target of the backwards jump for some loop.
+     *
+     * This is a jump target instruction (see `JSOp::JumpTarget`). Additionally,
+     * it checks for interrupts and handles JIT tiering.
+     *
+     * The `depthHint` operand is a loop depth hint for Ion. It starts at 1 and
+     * deeply nested loops all have the same value.
+     *
+     * For the convenience of the JITs, scripts must not start with this
+     * instruction. See bug 1602390.
+     *
+     *   Category: Control flow
+     *   Type: Jump targets
+     *   Operands: uint32_t icIndex, uint8_t depthHint
+     *   Stack: =>
+     */ \
+    MACRO(LoopHead, loop_head, NULL, 6, 0, 0, JOF_LOOPHEAD) \
+    /*
+     * Jump to a 32-bit offset from the current bytecode.
+     *
+     * See "Jump instructions" above for details.
+     *
+     *   Category: Control flow
+     *   Type: Jumps
+     *   Operands: int32_t offset
+     *   Stack: =>
+     */ \
+    MACRO(Goto, goto_, NULL, 5, 0, 0, JOF_JUMP) \
+    /*
+     * If ToBoolean(`cond`) is false, jumps to a 32-bit offset from the current
+     * instruction.
+     *
+     *   Category: Control flow
+     *   Type: Jumps
+     *   Operands: int32_t forwardOffset
+     *   Stack: cond =>
+     */ \
+    MACRO(IfEq, if_eq, NULL, 5, 1, 0, JOF_JUMP|JOF_DETECTING|JOF_IC) \
+    /*
+     * If ToBoolean(`cond`) is true, jump to a 32-bit offset from the current
+     * instruction.
+     *
+     * `offset` may be positive or negative. This is the instruction used at the
+     * end of a do-while loop to jump back to the top.
+     *
+     *   Category: Control flow
+     *   Type: Jumps
+     *   Operands: int32_t offset
+     *   Stack: cond =>
+     */ \
+    MACRO(IfNe, if_ne, NULL, 5, 1, 0, JOF_JUMP|JOF_IC) \
+    /*
+     * Short-circuit for logical AND.
+     *
+     * If ToBoolean(`cond`) is false, jump to a 32-bit offset from the current
+     * instruction. The value remains on the stack.
+     *
+     *   Category: Control flow
+     *   Type: Jumps
+     *   Operands: int32_t forwardOffset
+     *   Stack: cond => cond
+     */ \
+    MACRO(And, and_, NULL, 5, 1, 1, JOF_JUMP|JOF_DETECTING|JOF_IC) \
+    /*
+     * Short-circuit for logical OR.
+     *
+     * If ToBoolean(`cond`) is true, jump to a 32-bit offset from the current
+     * instruction. The value remains on the stack.
+     *
+     *   Category: Control flow
+     *   Type: Jumps
+     *   Operands: int32_t forwardOffset
+     *   Stack: cond => cond
+     */ \
+    MACRO(Or, or_, NULL, 5, 1, 1, JOF_JUMP|JOF_DETECTING|JOF_IC) \
+    /*
+     * Short-circuiting for nullish coalescing.
+     *
+     * If `val` is not null or undefined, jump to a 32-bit offset from the
+     * current instruction.
+     *
+     *   Category: Control flow
+     *   Type: Jumps
+     *   Operands: int32_t forwardOffset
+     *   Stack: val => val
+     */ \
+    MACRO(Coalesce, coalesce, NULL, 5, 1, 1, JOF_JUMP|JOF_DETECTING) \
+     /*
+     * Like `JSOp::IfNe` ("jump if true"), but if the branch is taken,
+     * pop and discard an additional stack value.
+     *
+     * This is used to implement `switch` statements when the
+     * `JSOp::TableSwitch` optimization is not possible. The switch statement
+     *
+     *     switch (expr) {
+     *         case A: stmt1;
+     *         case B: stmt2;
+     *     }
+     *
+     * compiles to this bytecode:
+     *
+     *         # dispatch code - evaluate expr, check it against each `case`,
+     *         # jump to the right place in the body or to the end.
+     *         <expr>
+     *         Dup; <A>; StrictEq; Case L1; JumpTarget
+     *         Dup; <B>; StrictEq; Case L2; JumpTarget
+     *         Default LE
+     *
+     *         # body code
+     *     L1: JumpTarget; <stmt1>
+     *     L2: JumpTarget; <stmt2>
+     *     LE: JumpTarget
+     *
+     * This opcode is weird: it's the only one whose ndefs varies depending on
+     * which way a conditional branch goes. We could implement switch
+     * statements using `JSOp::IfNe` and `JSOp::Pop`, but that would also be
+     * awkward--putting the `JSOp::Pop` inside the `switch` body would
+     * complicate fallthrough.
+     *
+     *   Category: Control flow
+     *   Type: Jumps
+     *   Operands: int32_t forwardOffset
+     *   Stack: val, cond => val (if !cond)
+     */ \
+    MACRO(Case, case_, NULL, 5, 2, 1, JOF_JUMP) \
+    /*
+     * Like `JSOp::Goto`, but pop and discard an additional stack value.
+     *
+     * This appears after all cases for a non-optimized `switch` statement. If
+     * there's a `default:` label, it jumps to that point in the body;
+     * otherwise it jumps to the next statement.
+     *
+     *   Category: Control flow
+     *   Type: Jumps
+     *   Operands: int32_t forwardOffset
+     *   Stack: lval =>
+     */ \
+    MACRO(Default, default_, NULL, 5, 1, 0, JOF_JUMP) \
+    /*
+     * Optimized switch-statement dispatch, used when all `case` labels are
+     * small integer constants.
+     *
+     * If `low <= i <= high`, jump to the instruction at the offset given by
+     * `script->resumeOffsets()[firstResumeIndex + i - low]`, in bytes from the
+     * start of the current script's bytecode. Otherwise, jump to the
+     * instruction at `defaultOffset` from the current instruction. All of
+     * these offsets must be in range for the current script and must point to
+     * `JSOp::JumpTarget` instructions.
+     *
+     * The following inequalities must hold: `low <= high` and
+     * `firstResumeIndex + high - low < resumeOffsets().size()`.
+     *
+     *   Category: Control flow
+     *   Type: Jumps
+     *   Operands: int32_t defaultOffset, int32_t low, int32_t high,
+     *             uint24_t firstResumeIndex
+     *   Stack: i =>
+     */ \
+    MACRO(TableSwitch, table_switch, NULL, 16, 1, 0, JOF_TABLESWITCH|JOF_DETECTING) \
+    /*
+     * Return `rval`.
+     *
+     * This must not be used in derived class constructors. Instead use
+     * `JSOp::SetRval`, `JSOp::CheckReturn`, and `JSOp::RetRval`.
+     *
+     *   Category: Control flow
+     *   Type: Return
+     *   Operands:
+     *   Stack: rval =>
+     */ \
+    MACRO(Return, return_, NULL, 1, 1, 0, JOF_BYTE) \
+    /*
+     * Push the current stack frame's `returnValue`. If no `JSOp::SetRval`
+     * instruction has been executed in this stack frame, this is `undefined`.
+     *
+     * Every stack frame has a `returnValue` slot, used by top-level scripts,
+     * generators, async functions, and derived class constructors. Plain
+     * functions usually use `JSOp::Return` instead.
+     *
+     *   Category: Control flow
+     *   Type: Return
+     *   Operands:
+     *   Stack: => rval
+     */ \
+    MACRO(GetRval, get_rval, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Store `rval` in the current stack frame's `returnValue` slot.
+     *
+     *   Category: Control flow
+     *   Type: Return
+     *   Operands:
+     *   Stack: rval =>
+     */ \
+    MACRO(SetRval, set_rval, NULL, 1, 1, 0, JOF_BYTE) \
+    /*
+     * Stop execution and return the current stack frame's `returnValue`. If no
+     * `JSOp::SetRval` instruction has been executed in this stack frame, this
+     * is `undefined`.
+     *
+     * Also emitted at end of every script so consumers don't need to worry
+     * about running off the end.
+     *
+     * If the current script is a derived class constructor, `returnValue` must
+     * be an object. The script can use `JSOp::CheckReturn` to ensure this.
+     *
+     *   Category: Control flow
+     *   Type: Return
+     *   Operands:
+     *   Stack: =>
+     */ \
+    MACRO(RetRval, ret_rval, NULL, 1, 0, 0, JOF_BYTE) \
+    /*
+     * Check the return value in a derived class constructor.
+     *
+     * -   If the current stack frame's `returnValue` is an object, do nothing.
+     *
+     * -   Otherwise, if the `returnValue` is undefined and `thisval` is an
+     *     object, store `thisval` in the `returnValue` slot.
+     *
+     * -   Otherwise, throw a TypeError.
+     *
+     * This is exactly what has to happen when a derived class constructor
+     * returns. `thisval` should be the current value of `this`, or
+     * `MagicValue(JS_UNINITIALIZED_LEXICAL)` if `this` is uninitialized.
+     *
+     * Implements: [The [[Construct]] internal method of JS functions][1],
+     * steps 13 and 15.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget
+     *
+     *   Category: Control flow
+     *   Type: Return
+     *   Operands:
+     *   Stack: thisval =>
+     */ \
+    MACRO(CheckReturn, check_return, NULL, 1, 1, 0, JOF_BYTE) \
+    /*
+     * Throw `exc`. (ノಠ益ಠ)ノ彡┴──┴
+     *
+     * This sets the pending exception to `exc` and jumps to error-handling
+     * code. If we're in a `try` block, error handling adjusts the stack and
+     * environment chain and resumes execution at the top of the `catch` or
+     * `finally` block. Otherwise it starts unwinding the stack.
+     *
+     * Implements: [*ThrowStatement* Evaluation][1], step 3.
+     *
+     * This is also used in for-of loops. If the body of the loop throws an
+     * exception, we catch it, close the iterator, then use `JSOp::Throw` to
+     * rethrow.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-throw-statement-runtime-semantics-evaluation
+     *
+     *   Category: Control flow
+     *   Type: Exceptions
+     *   Operands:
+     *   Stack: exc =>
+     */ \
+    MACRO(Throw, throw_, NULL, 1, 1, 0, JOF_BYTE) \
+    /*
+     * Create and throw an Error object.
+     *
+     * Sometimes we know at emit time that an operation always throws. For
+     * example, `delete super.prop;` is allowed in methods, but always throws a
+     * ReferenceError.
+     *
+     * `msgNumber` must be one of the error codes listed in js/src/js.msg; it
+     * determines the `.message` and [[Prototype]] of the new Error object. The
+     * number of arguments in the error message must be 0.
+     *
+     *   Category: Control flow
+     *   Type: Exceptions
+     *   Operands: uint16_t msgNumber
+     *   Stack: =>
+     */ \
+    MACRO(ThrowMsg, throw_msg, NULL, 3, 0, 0, JOF_UINT16) \
+    /*
+     * Throws a runtime TypeError for invalid assignment to a `const` binding.
+     *
+     *   Category: Control flow
+     *   Type: Exceptions
+     *   Operands: uint32_t nameIndex
+     *   Stack:
+     */ \
+    MACRO(ThrowSetConst, throw_set_const, NULL, 5, 0, 0, JOF_ATOM|JOF_NAME|JOF_DETECTING) \
+    /*
+     * No-op instruction that marks the top of the bytecode for a
+     * *TryStatement*.
+     *
+     * The `jumpAtEndOffset` operand is the offset (relative to the current op)
+     * of the `JSOp::Goto` at the end of the try-block body. This is used by
+     * bytecode analysis and JIT compilation.
+     *
+     * Location information for catch/finally blocks is stored in a side table,
+     * `script->trynotes()`.
+     *
+     *   Category: Control flow
+     *   Type: Exceptions
+     *   Operands: int32_t jumpAtEndOffset
+     *   Stack: =>
+     */ \
+    MACRO(Try, try_, NULL, 5, 0, 0, JOF_CODE_OFFSET) \
+    /*
+     * No-op instruction used by the exception unwinder to determine the
+     * correct environment to unwind to when performing IteratorClose due to
+     * destructuring.
+     *
+     *   Category: Control flow
+     *   Type: Exceptions
+     *   Operands:
+     *   Stack: =>
+     */ \
+    MACRO(TryDestructuring, try_destructuring, NULL, 1, 0, 0, JOF_BYTE) \
+    /*
+     * Push and clear the pending exception. ┬──┬◡ﾉ(° -°ﾉ)
+     *
+     * This must be used only in the fixed sequence of instructions following a
+     * `JSTRY_CATCH` span (see "Bytecode Invariants" above), as that's the only
+     * way instructions would run with an exception pending.
+     *
+     * Used to implement catch-blocks, including the implicit ones generated as
+     * part of for-of iteration.
+     *
+     *   Category: Control flow
+     *   Type: Exceptions
+     *   Operands:
+     *   Stack: => exception
+     */ \
+    MACRO(Exception, exception, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Push `resumeIndex`.
+     *
+     * This value must be used only by `JSOp::Gosub`, `JSOp::Finally`, and `JSOp::Retsub`.
+     *
+     *   Category: Control flow
+     *   Type: Exceptions
+     *   Operands: uint24_t resumeIndex
+     *   Stack: => resumeIndex
+     */ \
+    MACRO(ResumeIndex, resume_index, NULL, 4, 0, 1, JOF_RESUMEINDEX) \
+    /*
+     * Jump to the start of a `finally` block.
+     *
+     * `JSOp::Gosub` is unusual: if the finally block finishes normally, it will
+     * reach the `JSOp::Retsub` instruction at the end, and control then
+     * "returns" to the `JSOp::Gosub` and picks up at the next instruction, like
+     * a function call but within a single script and stack frame. (It's named
+     * after the thing in BASIC.)
+     *
+     * We need this because a `try` block can terminate in several different
+     * ways: control can flow off the end, return, throw an exception, `break`
+     * with or without a label, or `continue`. Exceptions are handled
+     * separately; but all those success paths are written as bytecode, and
+     * each one needs to run the `finally` block before continuing with
+     * whatever they were doing. They use `JSOp::Gosub` for this. It is thus
+     * normal for multiple `Gosub` instructions in a script to target the same
+     * `finally` block.
+     *
+     * Rules: `forwardOffset` must be positive and must target a
+     * `JSOp::JumpTarget` instruction followed by `JSOp::Finally`. The
+     * instruction immediately following `JSOp::Gosub` in the script must be a
+     * `JSOp::JumpTarget` instruction, and `resumeIndex` must be the index into
+     * `script->resumeOffsets()` that points to that instruction.
+     *
+     * Note: This op doesn't actually push or pop any values. Its use count of
+     * 2 is a lie to make the stack depth math work for this very odd control
+     * flow instruction.
+     *
+     * `JSOp::Gosub` is considered to have two "successors": the target of
+     * `offset`, which is the actual next instruction to run; and the
+     * instruction immediately following `JSOp::Gosub`, even though it won't run
+     * until later. We define the successor graph this way in order to support
+     * knowing the stack depth at that instruction without first reading the
+     * whole `finally` block.
+     *
+     * The stack depth at that instruction is, as it happens, the current stack
+     * depth minus 2. So this instruction gets nuses == 2.
+     *
+     * Unfortunately there is a price to be paid in horribleness. When
+     * `JSOp::Gosub` runs, it leaves two values on the stack that the stack
+     * depth math doesn't know about. It jumps to the finally block, where
+     * `JSOp::Finally` again does nothing to the stack, but with a bogus def
+     * count of 2, restoring balance to the accounting. If `JSOp::Retsub` is
+     * reached, it pops the two values (for real this time) and control
+     * resumes at the instruction that follows JSOp::Gosub in memory.
+     *
+     *   Category: Control flow
+     *   Type: Exceptions
+     *   Operands: int32_t forwardOffset
+     *   Stack: false, resumeIndex =>
+     */ \
+    MACRO(Gosub, gosub, NULL, 5, 2, 0, JOF_JUMP) \
+    /*
+     * No-op instruction that marks the start of a `finally` block. This has a
+     * def count of 2, but the values are already on the stack (they're
+     * actually left on the stack by `JSOp::Gosub`).
+     *
+     * These two values must not be used except by `JSOp::Retsub`.
+     *
+     *   Category: Control flow
+     *   Type: Exceptions
+     *   Operands:
+     *   Stack: => false, resumeIndex
+     */ \
+    MACRO(Finally, finally, NULL, 1, 0, 2, JOF_BYTE) \
+    /*
+     * Jump back to the next instruction, or rethrow an exception, at the end
+     * of a `finally` block. See `JSOp::Gosub` for the explanation.
+     *
+     * If `throwing` is true, throw `v`. Otherwise, `v` must be a resume index;
+     * jump to the corresponding offset within the script.
+     *
+     * The two values popped must be the ones notionally pushed by
+     * `JSOp::Finally`.
+     *
+     *   Category: Control flow
+     *   Type: Exceptions
+     *   Operands:
+     *   Stack: throwing, v =>
+     */ \
+    MACRO(Retsub, retsub, NULL, 1, 2, 0, JOF_BYTE) \
+    /*
+     * Push `MagicValue(JS_UNINITIALIZED_LEXICAL)`, a magic value used to mark
+     * a binding as uninitialized.
+     *
+     * This magic value must be used only by `JSOp::Init*Lexical`.
+     *
+     *   Category: Variables and scopes
+     *   Type: Initialization
+     *   Operands:
+     *   Stack: => uninitialized
+     */ \
+    MACRO(Uninitialized, uninitialized, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Initialize an optimized local lexical binding; or mark it as
+     * uninitialized.
+     *
+     * This stores the value `v` in the fixed slot `localno` in the current
+     * stack frame. If `v` is the magic value produced by `JSOp::Uninitialized`,
+     * this marks the binding as uninitialized. Otherwise this initializes the
+     * binding with value `v`.
+     *
+     * Implements: [CreateMutableBinding][1] step 3, substep "record that it is
+     * uninitialized", and [InitializeBinding][2], for optimized locals. (Note:
+     * this is how `const` bindings are initialized.)
+     *
+     * [1]: https://tc39.es/ecma262/#sec-declarative-environment-records-createmutablebinding-n-d
+     * [2]: https://tc39.es/ecma262/#sec-declarative-environment-records-initializebinding-n-v
+     *
+     *   Category: Variables and scopes
+     *   Type: Initialization
+     *   Operands: uint24_t localno
+     *   Stack: v => v
+     */ \
+    MACRO(InitLexical, init_lexical, NULL, 4, 1, 1, JOF_LOCAL|JOF_NAME|JOF_DETECTING) \
+    /*
+     * Initialize a global lexical binding; or mark it as uninitialized.
+     *
+     * Like `JSOp::InitLexical` but for global lexicals.
+     *
+     *   Category: Variables and scopes
+     *   Type: Initialization
+     *   Operands: uint32_t nameIndex
+     *   Stack: val => val
+     */ \
+    MACRO(InitGLexical, init_g_lexical, NULL, 5, 1, 1, JOF_ATOM|JOF_NAME|JOF_PROPINIT|JOF_GNAME|JOF_IC) \
+    /*
+     * Initialize an aliased lexical binding; or mark it as uninitialized.
+     *
+     * Like `JSOp::InitLexical` but for aliased bindings.
+     *
+     * Note: There is no even-less-optimized `InitName` instruction because JS
+     * doesn't need it. We always know statically which binding we're
+     * initializing.
+     *
+     * `hops` is usually 0, but in `function f(a=eval("var b;")) { }`, the
+     * argument `a` is initialized from inside a nested scope, so `hops == 1`.
+     *
+     *   Category: Variables and scopes
+     *   Type: Initialization
+     *   Operands: uint8_t hops, uint24_t slot
+     *   Stack: v => v
+     */ \
+    MACRO(InitAliasedLexical, init_aliased_lexical, NULL, 5, 1, 1, JOF_ENVCOORD|JOF_NAME|JOF_PROPINIT|JOF_DETECTING) \
+    /*
+     * Throw a ReferenceError if the value on top of the stack is uninitialized.
+     *
+     * Typically used after `JSOp::GetLocal` or `JSOp::GetAliasedVar`.
+     *
+     * Implements: [GetBindingValue][1] step 3 and [SetMutableBinding][2] step
+     * 4 for declarative Environment Records.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-declarative-environment-records-getbindingvalue-n-s
+     * [2]: https://tc39.es/ecma262/#sec-declarative-environment-records-setmutablebinding-n-v-s
+     *
+     *   Category: Variables and scopes
+     *   Type: Initialization
+     *   Operands: uint32_t nameIndex
+     *   Stack: v => v
+     */ \
+    MACRO(CheckLexical, check_lexical, NULL, 5, 1, 1, JOF_ATOM|JOF_NAME) \
+    /*
+     * Throw a ReferenceError if the value on top of the stack is
+     * `MagicValue(JS_UNINITIALIZED_LEXICAL)`. Used in derived class
+     * constructors to check `this` (which needs to be initialized before use,
+     * by calling `super()`).
+     *
+     * Implements: [GetThisBinding][1] step 3.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-function-environment-records-getthisbinding
+     *
+     *   Category: Variables and scopes
+     *   Type: Initialization
+     *   Operands:
+     *   Stack: this => this
+     */ \
+    MACRO(CheckThis, check_this, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Push the global environment onto the stack, unless the script has a
+     * non-syntactic global scope. In that case, this acts like JSOp::BindName.
+     *
+     * `nameIndex` is only used when acting like JSOp::BindName.
+     *
+     *   Category: Variables and scopes
+     *   Type: Looking up bindings
+     *   Operands: uint32_t nameIndex
+     *   Stack: => global
+     */ \
+    MACRO(BindGName, bind_g_name, NULL, 5, 0, 1, JOF_ATOM|JOF_NAME|JOF_GNAME|JOF_IC) \
+    /*
+     * Look up a name on the environment chain and push the environment which
+     * contains a binding for that name. If no such binding exists, push the
+     * global lexical environment.
+     *
+     *   Category: Variables and scopes
+     *   Type: Looking up bindings
+     *   Operands: uint32_t nameIndex
+     *   Stack: => env
+     */ \
+    MACRO(BindName, bind_name, NULL, 5, 0, 1, JOF_ATOM|JOF_NAME|JOF_IC) \
+    /*
+     * Find a binding on the environment chain and push its value.
+     *
+     * If the binding is an uninitialized lexical, throw a ReferenceError. If
+     * no such binding exists, throw a ReferenceError unless the next
+     * instruction is `JSOp::Typeof`, in which case push `undefined`.
+     *
+     * Implements: [ResolveBinding][1] followed by [GetValue][2]
+     * (adjusted hackily for `typeof`).
+     *
+     * This is the fallback `Get` instruction that handles all unoptimized
+     * cases. Optimized instructions follow.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-resolvebinding
+     * [2]: https://tc39.es/ecma262/#sec-getvalue
+     *
+     *   Category: Variables and scopes
+     *   Type: Getting binding values
+     *   Operands: uint32_t nameIndex
+     *   Stack: => val
+     */ \
+    MACRO(GetName, get_name, NULL, 5, 0, 1, JOF_ATOM|JOF_NAME|JOF_TYPESET|JOF_IC) \
+    /*
+     * Find a global binding and push its value.
+     *
+     * This searches the global lexical environment and, failing that, the
+     * global object. (Unlike most declarative environments, the global lexical
+     * environment can gain more bindings after compilation, possibly shadowing
+     * global object properties.)
+     *
+     * This is an optimized version of `JSOp::GetName` that skips all local
+     * scopes, for use when the name doesn't refer to any local binding.
+     * `NonSyntacticVariablesObject`s break this optimization, so if the
+     * current script has a non-syntactic global scope, this acts like
+     * `JSOp::GetName`.
+     *
+     * Like `JSOp::GetName`, this throws a ReferenceError if no such binding is
+     * found (unless the next instruction is `JSOp::Typeof`) or if the binding
+     * is an uninitialized lexical.
+     *
+     *   Category: Variables and scopes
+     *   Type: Getting binding values
+     *   Operands: uint32_t nameIndex
+     *   Stack: => val
+     */ \
+    MACRO(GetGName, get_g_name, NULL, 5, 0, 1, JOF_ATOM|JOF_NAME|JOF_TYPESET|JOF_GNAME|JOF_IC) \
+    /*
+     * Push the value of an argument that is stored in the stack frame
+     * or in an `ArgumentsObject`.
+     *
+     *   Category: Variables and scopes
+     *   Type: Getting binding values
+     *   Operands: uint16_t argno
+     *   Stack: => arguments[argno]
+     */ \
+    MACRO(GetArg, get_arg, NULL, 3, 0, 1, JOF_QARG|JOF_NAME) \
+    /*
+     * Push the value of an optimized local variable.
+     *
+     * If the variable is an uninitialized lexical, push
+     * `MagicValue(JS_UNINIITALIZED_LEXICAL)`.
+     *
+     *   Category: Variables and scopes
+     *   Type: Getting binding values
+     *   Operands: uint24_t localno
+     *   Stack: => val
+     */ \
+    MACRO(GetLocal, get_local, NULL, 4, 0, 1, JOF_LOCAL|JOF_NAME) \
+    /*
+     * Push the value of an aliased binding.
+     *
+     * Local bindings that aren't closed over or dynamically accessed are
+     * stored in stack slots. Global and `with` bindings are object properties.
+     * All other bindings are called "aliased" and stored in
+     * `EnvironmentObject`s.
+     *
+     * Where possible, `Aliased` instructions are used to access aliased
+     * bindings.  (There's no difference in meaning between `AliasedVar` and
+     * `AliasedLexical`.) Each of these instructions has operands `hops` and
+     * `slot` that encode an [`EnvironmentCoordinate`][1], directions to the
+     * binding from the current environment object.
+     *
+     * `hops` and `slot` must be valid for the current scope.
+     *
+     * `Aliased` instructions can't be used when there's a dynamic scope (due
+     * to non-strict `eval` or `with`) that might shadow the aliased binding.
+     *
+     * [1]: https://searchfox.org/mozilla-central/search?q=symbol:T_js%3A%3AEnvironmentCoordinate
+     *
+     *   Category: Variables and scopes
+     *   Type: Getting binding values
+     *   Operands: uint8_t hops, uint24_t slot
+     *   Stack: => aliasedVar
+     */ \
+    MACRO(GetAliasedVar, get_aliased_var, NULL, 5, 0, 1, JOF_ENVCOORD|JOF_NAME|JOF_TYPESET|JOF_IC) \
+    /*
+     * Get the value of a module import by name and pushes it onto the stack.
+     *
+     *   Category: Variables and scopes
+     *   Type: Getting binding values
+     *   Operands: uint32_t nameIndex
+     *   Stack: => val
+     */ \
+    MACRO(GetImport, get_import, NULL, 5, 0, 1, JOF_ATOM|JOF_NAME|JOF_TYPESET|JOF_IC) \
+    /*
+     * Get the value of a binding from the environment `env`. If the name is
+     * not bound in `env`, throw a ReferenceError.
+     *
+     * `env` must be an environment currently on the environment chain, pushed
+     * by `JSOp::BindName`.
+     *
+     * Note: `JSOp::BindName` and `JSOp::GetBoundName` are the two halves of the
+     * `JSOp::GetName` operation: finding and reading a variable. This
+     * decomposed version is needed to implement the compound assignment and
+     * increment/decrement operators, which get and then set a variable. The
+     * spec says the variable lookup is done only once. If we did the lookup
+     * twice, there would be observable bugs, thanks to dynamic scoping. We
+     * could set the wrong variable or call proxy traps incorrectly.
+     *
+     * Implements: [GetValue][1] steps 4 and 6.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-getvalue
+     *
+     *   Category: Variables and scopes
+     *   Type: Getting binding values
+     *   Operands: uint32_t nameIndex
+     *   Stack: env => v
+     */ \
+    MACRO(GetBoundName, get_bound_name, NULL, 5, 1, 1, JOF_ATOM|JOF_NAME|JOF_TYPESET|JOF_IC) \
+    /*
+     * Push the value of an intrinsic onto the stack.
+     *
+     * Non-standard. Intrinsics are slots in the intrinsics holder object (see
+     * `GlobalObject::getIntrinsicsHolder`), which is used in lieu of global
+     * bindings in self-hosting code.
+     *
+     *   Category: Variables and scopes
+     *   Type: Getting binding values
+     *   Operands: uint32_t nameIndex
+     *   Stack: => intrinsic[name]
+     */ \
+    MACRO(GetIntrinsic, get_intrinsic, NULL, 5, 0, 1, JOF_ATOM|JOF_NAME|JOF_TYPESET|JOF_IC) \
+    /*
+     * Pushes the currently executing function onto the stack.
+     *
+     * The current script must be a function script.
+     *
+     * Used to implement `super`. This is also used sometimes as a minor
+     * optimization when a named function expression refers to itself by name:
+     *
+     *     f = function fac(n) {  ... fac(n - 1) ... };
+     *
+     * This lets us optimize away a lexical environment that contains only the
+     * binding for `fac`, unless it's otherwise observable (via `with`, `eval`,
+     * or a nested closure).
+     *
+     *   Category: Variables and scopes
+     *   Type: Getting binding values
+     *   Operands:
+     *   Stack: => callee
+     */ \
+    MACRO(Callee, callee, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Load the callee stored in a CallObject on the environment chain. The
+     * numHops operand is the number of environment objects to skip on the
+     * environment chain.
+     *
+     *   Category: Variables and scopes
+     *   Type: Getting binding values
+     *   Operands: uint8_t numHops
+     *   Stack: => callee
+     */ \
+    MACRO(EnvCallee, env_callee, NULL, 2, 0, 1, JOF_UINT8) \
+    /*
+     * Assign `val` to the binding in `env` with the name given by `nameIndex`.
+     * Throw a ReferenceError if the binding is an uninitialized lexical.
+     * This can call setters and/or proxy traps.
+     *
+     * `env` must be an environment currently on the environment chain,
+     * pushed by `JSOp::BindName`.
+     *
+     * This is the fallback `Set` instruction that handles all unoptimized
+     * cases. Optimized instructions follow.
+     *
+     * Implements: [PutValue][1] steps 5 and 7 for unoptimized bindings.
+     *
+     * Note: `JSOp::BindName` and `JSOp::SetName` are the two halves of simple
+     * assignment: finding and setting a variable. They are two separate
+     * instructions because, per spec, the "finding" part happens before
+     * evaluating the right-hand side of the assignment, and the "setting" part
+     * after. Optimized cases don't need a `Bind` instruction because the
+     * "finding" is done statically.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-putvalue
+     *
+     *   Category: Variables and scopes
+     *   Type: Setting binding values
+     *   Operands: uint32_t nameIndex
+     *   Stack: env, val => val
+     */ \
+    MACRO(SetName, set_name, NULL, 5, 2, 1, JOF_ATOM|JOF_NAME|JOF_PROPSET|JOF_DETECTING|JOF_CHECKSLOPPY|JOF_IC) \
+    /*
+     * Like `JSOp::SetName`, but throw a TypeError if there is no binding for
+     * the specified name in `env`, or if the binding is immutable (a `const`
+     * or read-only property).
+     *
+     * Implements: [PutValue][1] steps 5 and 7 for strict mode code.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-putvalue
+     *
+     *   Category: Variables and scopes
+     *   Type: Setting binding values
+     *   Operands: uint32_t nameIndex
+     *   Stack: env, val => val
+     */ \
+    MACRO(StrictSetName, strict_set_name, NULL, 5, 2, 1, JOF_ATOM|JOF_NAME|JOF_PROPSET|JOF_DETECTING|JOF_CHECKSTRICT|JOF_IC) \
+    /*
+     * Like `JSOp::SetName`, but for assigning to globals. `env` must be an
+     * environment pushed by `JSOp::BindGName`.
+     *
+     *   Category: Variables and scopes
+     *   Type: Setting binding values
+     *   Operands: uint32_t nameIndex
+     *   Stack: env, val => val
+     */ \
+    MACRO(SetGName, set_g_name, NULL, 5, 2, 1, JOF_ATOM|JOF_NAME|JOF_PROPSET|JOF_DETECTING|JOF_GNAME|JOF_CHECKSLOPPY|JOF_IC) \
+    /*
+     * Like `JSOp::StrictSetGName`, but for assigning to globals. `env` must be
+     * an environment pushed by `JSOp::BindGName`.
+     *
+     *   Category: Variables and scopes
+     *   Type: Setting binding values
+     *   Operands: uint32_t nameIndex
+     *   Stack: env, val => val
+     */ \
+    MACRO(StrictSetGName, strict_set_g_name, NULL, 5, 2, 1, JOF_ATOM|JOF_NAME|JOF_PROPSET|JOF_DETECTING|JOF_GNAME|JOF_CHECKSTRICT|JOF_IC) \
+    /*
+     * Assign `val` to an argument binding that's stored in the stack frame or
+     * in an `ArgumentsObject`.
+     *
+     *   Category: Variables and scopes
+     *   Type: Setting binding values
+     *   Operands: uint16_t argno
+     *   Stack: val => val
+     */ \
+    MACRO(SetArg, set_arg, NULL, 3, 1, 1, JOF_QARG|JOF_NAME) \
+    /*
+     * Assign to an optimized local binding.
+     *
+     *   Category: Variables and scopes
+     *   Type: Setting binding values
+     *   Operands: uint24_t localno
+     *   Stack: v => v
+     */ \
+    MACRO(SetLocal, set_local, NULL, 4, 1, 1, JOF_LOCAL|JOF_NAME|JOF_DETECTING) \
+    /*
+     * Assign to an aliased binding.
+     *
+     * Implements: [SetMutableBinding for declarative Environment Records][1],
+     * in certain cases where it's known that the binding exists, is mutable,
+     * and has been initialized.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-declarative-environment-records-setmutablebinding-n-v-s
+     *
+     *   Category: Variables and scopes
+     *   Type: Setting binding values
+     *   Operands: uint8_t hops, uint24_t slot
+     *   Stack: val => val
+     */ \
+    MACRO(SetAliasedVar, set_aliased_var, NULL, 5, 1, 1, JOF_ENVCOORD|JOF_NAME|JOF_PROPSET|JOF_DETECTING) \
+    /*
+     * Assign to an intrinsic.
+     *
+     * Nonstandard. Intrinsics are used in lieu of global bindings in self-
+     * hosted code. The value is actually stored in the intrinsics holder
+     * object, `GlobalObject::getIntrinsicsHolder`. (Self-hosted code doesn't
+     * have many global `var`s, but it has many `function`s.)
+     *
+     *   Category: Variables and scopes
+     *   Type: Setting binding values
+     *   Operands: uint32_t nameIndex
+     *   Stack: val => val
+     */ \
+    MACRO(SetIntrinsic, set_intrinsic, NULL, 5, 1, 1, JOF_ATOM|JOF_NAME|JOF_DETECTING) \
+    /*
+     * Push a lexical environment onto the environment chain.
+     *
+     * The `LexicalScope` indicated by `lexicalScopeIndex` determines the shape
+     * of the new `LexicalEnvironmentObject`. All bindings in the new
+     * environment are marked as uninitialized.
+     *
+     * Implements: [Evaluation of *Block*][1], steps 1-4.
+     *
+     * #### Fine print for environment chain instructions
+     *
+     * The following rules for `JSOp::{Push,Pop}LexicalEnv` also apply to
+     * `JSOp::{Push,Pop}VarEnv` and `JSOp::{Enter,Leave}With`.
+     *
+     * Each `JSOp::PopLexicalEnv` instruction matches a particular
+     * `JSOp::PushLexicalEnv` instruction in the same script and must have the
+     * same scope and stack depth as the instruction immediately after that
+     * `PushLexicalEnv`.
+     *
+     * `JSOp::PushLexicalEnv` enters a scope that extends to some set of
+     * instructions in the script. Code must not jump into or out of this
+     * region: control can enter only by executing `PushLexicalEnv` and can
+     * exit only by executing a `PopLexicalEnv` or by exception unwinding. (A
+     * `JSOp::PopLexicalEnv` is always emitted at the end of the block, and
+     * extra copies are emitted on "exit slides", where a `break`, `continue`,
+     * or `return` statement exits the scope.)
+     *
+     * The script's `JSScript::scopeNotes()` must identify exactly which
+     * instructions begin executing in this scope. Typically this means a
+     * single entry marking the contiguous chunk of bytecode from the
+     * instruction after `JSOp::PushLexicalEnv` to `JSOp::PopLexicalEnv`
+     * (inclusive); but if that range contains any instructions on exit slides,
+     * after a `JSOp::PopLexicalEnv`, then those must be correctly noted as
+     * *outside* the scope.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
+     *
+     *   Category: Variables and scopes
+     *   Type: Entering and leaving environments
+     *   Operands: uint32_t lexicalScopeIndex
+     *   Stack: =>
+     */ \
+    MACRO(PushLexicalEnv, push_lexical_env, NULL, 5, 0, 0, JOF_SCOPE) \
+    /*
+     * Pop a lexical environment from the environment chain.
+     *
+     * See `JSOp::PushLexicalEnv` for the fine print.
+     *
+     *   Category: Variables and scopes
+     *   Type: Entering and leaving environments
+     *   Operands:
+     *   Stack: =>
+     */ \
+    MACRO(PopLexicalEnv, pop_lexical_env, NULL, 1, 0, 0, JOF_BYTE) \
+    /*
+     * No-op instruction that indicates leaving an optimized lexical scope.
+     *
+     * If all bindings in a lexical scope are optimized into stack slots, then
+     * the runtime environment objects for that scope are optimized away. No
+     * `JSOp::{Push,Pop}LexicalEnv` instructions are emitted. However, the
+     * debugger still needs to be notified when control exits a scope; that's
+     * what this instruction does.
+     *
+     * The last instruction in a lexical scope, as indicated by scope notes,
+     * must be either this instruction (if the scope is optimized) or
+     * `JSOp::PopLexicalEnv` (if not).
+     *
+     *   Category: Variables and scopes
+     *   Type: Entering and leaving environments
+     *   Operands:
+     *   Stack: =>
+     */ \
+    MACRO(DebugLeaveLexicalEnv, debug_leave_lexical_env, NULL, 1, 0, 0, JOF_BYTE) \
+    /*
+     * Recreate the current block on the environment chain with a fresh block
+     * with uninitialized bindings. This implements the behavior of inducing a
+     * fresh lexical environment for every iteration of a for-in/of loop whose
+     * loop-head has a (captured) lexical declaration.
+     *
+     *   Category: Variables and scopes
+     *   Type: Entering and leaving environments
+     *   Operands:
+     *   Stack: =>
+     */ \
+    MACRO(RecreateLexicalEnv, recreate_lexical_env, NULL, 1, 0, 0, JOF_BYTE) \
+    /*
+     * Replace the current block on the environment chain with a fresh block
+     * that copies all the bindings in the block. This implements the behavior
+     * of inducing a fresh lexical environment for every iteration of a
+     * `for(let ...; ...; ...)` loop, if any declarations induced by such a
+     * loop are captured within the loop.
+     *
+     *   Category: Variables and scopes
+     *   Type: Entering and leaving environments
+     *   Operands:
+     *   Stack: =>
+     */ \
+    MACRO(FreshenLexicalEnv, freshen_lexical_env, NULL, 1, 0, 0, JOF_BYTE) \
+    /*
+     * Push a var environment onto the environment chain.
+     *
+     * Like `JSOp::PushLexicalEnv`, but pushes a `VarEnvironmentObject` rather
+     * than a `LexicalEnvironmentObject`. The difference is that non-strict
+     * direct `eval` can add bindings to a var environment; see `VarScope` in
+     * Scope.h.
+     *
+     * See `JSOp::PushLexicalEnv` for the fine print.
+     *
+     * There is no corresponding `JSOp::PopVarEnv` operation, because a
+     * `VarEnvironmentObject` is never popped from the environment chain.
+     *
+     * Implements: Places in the spec where the VariableEnvironment is set:
+     *
+     * -   The bit in [PerformEval][1] where, in strict direct eval, the new
+     *     eval scope is taken as *varEnv* and becomes "*runningContext*'s
+     *     VariableEnvironment".
+     *
+     * -   The weird scoping rules for functions with default parameter
+     *     expressions, as specified in [FunctionDeclarationInstantiation][2]
+     *     step 28 ("NOTE: A separate Environment Record is needed...").
+     *
+     * Note: The spec also pushes a new VariableEnvironment on entry to every
+     * function, but the VM takes care of that as part of pushing the stack
+     * frame, before the function script starts to run, so `JSOp::PushVarEnv` is
+     * not needed.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-performeval
+     * [2]: https://tc39.es/ecma262/#sec-functiondeclarationinstantiation
+     *
+     *   Category: Variables and scopes
+     *   Type: Entering and leaving environments
+     *   Operands: uint32_t scopeIndex
+     *   Stack: =>
+     */ \
+    MACRO(PushVarEnv, push_var_env, NULL, 5, 0, 0, JOF_SCOPE) \
+    /*
+     * Push a `WithEnvironmentObject` wrapping ToObject(`val`) to the
+     * environment chain.
+     *
+     * Implements: [Evaluation of `with` statements][1], steps 2-6.
+     *
+     * Operations that may need to consult a WithEnvironment can't be correctly
+     * implemented using optimized instructions like `JSOp::GetLocal`. A script
+     * must use the deoptimized `JSOp::GetName`, `BindName`, `SetName`, and
+     * `DelName` instead. Since those instructions don't work correctly with
+     * optimized locals and arguments, all bindings in scopes enclosing a
+     * `with` statement are marked as "aliased" and deoptimized too.
+     *
+     * See `JSOp::PushLexicalEnv` for the fine print.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-with-statement-runtime-semantics-evaluation
+     *
+     *   Category: Variables and scopes
+     *   Type: Entering and leaving environments
+     *   Operands: uint32_t staticWithIndex
+     *   Stack: val =>
+     */ \
+    MACRO(EnterWith, enter_with, NULL, 5, 1, 0, JOF_SCOPE) \
+    /*
+     * Pop a `WithEnvironmentObject` from the environment chain.
+     *
+     * See `JSOp::PushLexicalEnv` for the fine print.
+     *
+     * Implements: [Evaluation of `with` statements][1], step 8.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-with-statement-runtime-semantics-evaluation
+     *
+     *   Category: Variables and scopes
+     *   Type: Entering and leaving environments
+     *   Operands:
+     *   Stack: =>
+     */ \
+    MACRO(LeaveWith, leave_with, NULL, 1, 0, 0, JOF_BYTE) \
+    /*
+     * Push the current VariableEnvironment (the environment on the environment
+     * chain designated to receive new variables).
+     *
+     * Implements: [Annex B.3.3.1, changes to FunctionDeclarationInstantiation
+     * for block-level functions][1], step 1.a.ii.3.a, and similar steps in
+     * other Annex B.3.3 algorithms, when setting the function's second binding
+     * can't be optimized.
+     *
+     * [1]: https://tc39.es/ecma262/#sec-web-compat-functiondeclarationinstantiation
+     *
+     *   Category: Variables and scopes
+     *   Type: Creating and deleting bindings
+     *   Operands:
+     *   Stack: => env
+     */ \
+    MACRO(BindVar, bind_var, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Create a new binding on the current VariableEnvironment (the environment
+     * on the environment chain designated to receive new variables).
+     *
+     * `JSOp::Def{Var,Let,Const,Fun}` instructions must appear in the script
+     * before anything else that might add bindings to the environment, and
+     * only once per binding. There must be a correct entry for the new binding
+     * in `script->bodyScope()`. (All this ensures that at run time, there is
+     * no existing conflicting binding. We check before running the script, in
+     * `js::CheckGlobalOrEvalDeclarationConflicts`.)
+     *
+     * Throw a SyntaxError if the current VariableEnvironment is the global
+     * environment and a binding with the same name exists on the global
+     * lexical environment.
+     *
+     * This is used for global scripts and also in some cases for function
+     * scripts where use of dynamic scoping inhibits optimization.
+     *
+     *   Category: Variables and scopes
+     *   Type: Creating and deleting bindings
+     *   Operands: uint32_t nameIndex
+     *   Stack: =>
+     */ \
+    MACRO(DefVar, def_var, NULL, 5, 0, 0, JOF_ATOM) \
+    /*
+     * Create a new binding for the given function on the current scope.
+     *
+     * `fun` must be a function object with an explicit name. The new
+     * variable's name is `fun->explicitName()`, and its value is `fun`. In
+     * global scope, this creates a new property on the global object.
+     *
+     * Implements: The body of the loop in [GlobalDeclarationInstantiation][1]
+     * step 17 ("For each Parse Node *f* in *functionsToInitialize*...") and
+     * the corresponding loop in [EvalDeclarationInstantiation][2].
+     *
+     * [1]: https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
+     * [2]: https://tc39.es/ecma262/#sec-evaldeclarationinstantiation
+     *
+     *   Category: Variables and scopes
+     *   Type: Creating and deleting bindings
+     *   Operands:
+     *   Stack: fun =>
+     */ \
+    MACRO(DefFun, def_fun, NULL, 1, 1, 0, JOF_BYTE) \
+    /*
+     * Create a new mutable binding in the global lexical environment. Throw a
+     * SyntaxError if a binding with the same name already exists on that
+     * environment, or if a var binding with the same name exists on the
+     * global.
+     *
+     *   Category: Variables and scopes
+     *   Type: Creating and deleting bindings
+     *   Operands: uint32_t nameIndex
+     *   Stack: =>
+     */ \
+    MACRO(DefLet, def_let, NULL, 5, 0, 0, JOF_ATOM) \
+    /*
+     * Create a new constant binding in the global lexical environment.
+     *
+     * Throw a SyntaxError if a binding with the same name already exists in
+     * that environment, or if a var binding with the same name exists on the
+     * global.
+     *
+     *   Category: Variables and scopes
+     *   Type: Creating and deleting bindings
+     *   Operands: uint32_t nameIndex
+     *   Stack: =>
+     */ \
+    MACRO(DefConst, def_const, NULL, 5, 0, 0, JOF_ATOM) \
+    /*
+     * Look up a variable on the environment chain and delete it. Push `true`
+     * on success (if a binding was deleted, or if no such binding existed in
+     * the first place), `false` otherwise (most kinds of bindings can't be
+     * deleted).
+     *
+     * Implements: [`delete` *Identifier*][1], which [is a SyntaxError][2] in
+     * strict mode code.
+     *
+     *    [1]: https://tc39.es/ecma262/#sec-delete-operator-runtime-semantics-evaluation
+     *    [2]: https://tc39.es/ecma262/#sec-delete-operator-static-semantics-early-errors
+     *
+     *   Category: Variables and scopes
+     *   Type: Creating and deleting bindings
+     *   Operands: uint32_t nameIndex
+     *   Stack: => succeeded
+     */ \
+    MACRO(DelName, del_name, NULL, 5, 0, 1, JOF_ATOM|JOF_NAME|JOF_CHECKSLOPPY) \
+    /*
+     * Create and push the `arguments` object for the current function activation.
+     *
+     * When it exists, `arguments` is stored in an ordinary local variable.
+     * `JSOp::Arguments` is used in function preludes, to populate that variable
+     * before the function body runs, *not* each time `arguments` appears in a
+     * function.
+     *
+     * If a function clearly doesn't use `arguments`, we optimize it away when
+     * emitting bytecode. The function's script won't use `JSOp::Arguments` at
+     * all.
+     *
+     * The current script must be a function script. This instruction must
+     * execute at most once per function activation.
+     *
+     * #### Optimized arguments
+     *
+     * If `script->needsArgsObj()` is false, no ArgumentsObject is created.
+     * Instead, `MagicValue(JS_OPTIMIZED_ARGUMENTS)` is pushed.
+     *
+     * This optimization imposes no restrictions on bytecode. Rather,
+     * `js::jit::AnalyzeArgumentsUsage` examines the bytecode and enables the
+     * optimization only if all uses of `arguments` are optimizable.  Each
+     * execution engine must know what the analysis considers optimizable and
+     * cope with the magic value when it is used in those ways.
+     *
+     * Example 1: `arguments[0]` is supported; therefore the interpreter's
+     * implementation of `JSOp::GetElem` checks for optimized arguments (see
+     * `GetElemOptimizedArguments`).
+     *
+     * Example 2: `f.apply(this, arguments)` is supported; therefore our
+     * implementation of `Function.prototype.apply` checks for optimized
+     * arguments (`see js::fun_apply`), and all `JSOp::FunApply` implementations
+     * must check for cases where `f.apply` turns out to be any other function
+     * (see `GuardFunApplyArgumentsOptimization`).
+     *
+     * It's not documented anywhere exactly which opcodes support
+     * `JS_OPTIMIZED_ARGUMENTS`; see the source of `AnalyzeArgumentsUsage`.
+     *
+     *   Category: Variables and scopes
+     *   Type: Function environment setup
+     *   Operands:
+     *   Stack: => arguments
+     */ \
+    MACRO(Arguments, arguments, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Create and push the rest parameter array for current function call.
+     *
+     * This must appear only in function scripts.
+     *
+     *   Category: Variables and scopes
+     *   Type: Function environment setup
+     *   Operands:
+     *   Stack: => rest
+     */ \
+    MACRO(Rest, rest, NULL, 1, 0, 1, JOF_BYTE|JOF_TYPESET|JOF_IC) \
+    /*
+     * Determines the `this` value for current function frame and pushes it
+     * onto the stack.
+     *
+     * In functions, `this` is stored in a local variable. This instruction is
+     * used in the function prologue to get the value to initialize that
+     * variable.  (This doesn't apply to arrow functions, becauses they don't
+     * have a `this` binding; also, `this` is optimized away if it's unused.)
+     *
+     * Functions that have a `this` binding have a local variable named
+     * `".this"`, which is initialized using this instruction in the function
+     * prologue.
+     *
+     *   Category: Variables and scopes
+     *   Type: Function environment setup
+     *   Operands:
+     *   Stack: => this
+     */ \
+    MACRO(FunctionThis, function_this, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Pop the top value from the stack and discard it.
+     *
+     *   Category: Stack operations
+     *   Operands:
+     *   Stack: v =>
+     */ \
+    MACRO(Pop, pop, NULL, 1, 1, 0, JOF_BYTE) \
+    /*
+     * Pop the top `n` values from the stack. `n` must be <= the current stack
+     * depth.
+     *
+     *   Category: Stack operations
+     *   Operands: uint16_t n
+     *   Stack: v[n-1], ..., v[1], v[0] =>
+     */ \
+    MACRO(PopN, pop_n, NULL, 3, -1, 0, JOF_UINT16) \
+    /*
+     * Push a copy of the top value on the stack.
+     *
+     *   Category: Stack operations
+     *   Operands:
+     *   Stack: v => v, v
+     */ \
+    MACRO(Dup, dup, NULL, 1, 1, 2, JOF_BYTE) \
+    /*
+     * Duplicate the top two values on the stack.
+     *
+     *   Category: Stack operations
+     *   Operands:
+     *   Stack: v1, v2 => v1, v2, v1, v2
+     */ \
+    MACRO(Dup2, dup2, NULL, 1, 2, 4, JOF_BYTE) \
+    /*
+     * Push a copy of the nth value from the top of the stack.
+     *
+     * `n` must be less than the current stack depth.
+     *
+     *   Category: Stack operations
+     *   Operands: uint24_t n
+     *   Stack: v[n], v[n-1], ..., v[1], v[0] =>
+     *          v[n], v[n-1], ..., v[1], v[0], v[n]
+     */ \
+    MACRO(DupAt, dup_at, NULL, 4, 0, 1, JOF_UINT24) \
+    /*
+     * Swap the top two values on the stack.
+     *
+     *   Category: Stack operations
+     *   Operands:
+     *   Stack: v1, v2 => v2, v1
+     */ \
+    MACRO(Swap, swap, NULL, 1, 2, 2, JOF_BYTE) \
+    /*
+     * Pick the nth element from the stack and move it to the top of the stack.
+     *
+     *   Category: Stack operations
+     *   Operands: uint8_t n
+     *   Stack: v[n], v[n-1], ..., v[1], v[0] => v[n-1], ..., v[1], v[0], v[n]
+     */ \
+    MACRO(Pick, pick, NULL, 2, 0, 0, JOF_UINT8) \
+    /*
+     * Move the top of the stack value under the `n`th element of the stack.
+     * `n` must not be 0.
+     *
+     *   Category: Stack operations
+     *   Operands: uint8_t n
+     *   Stack: v[n], v[n-1], ..., v[1], v[0] => v[0], v[n], v[n-1], ..., v[1]
+     */ \
+    MACRO(Unpick, unpick, NULL, 2, 0, 0, JOF_UINT8) \
+    /*
+     * Do nothing. This is used when we need distinct bytecode locations for
+     * various mechanisms.
+     *
+     *   Category: Other
+     *   Operands:
+     *   Stack: =>
+     */ \
+    MACRO(Nop, nop, NULL, 1, 0, 0, JOF_BYTE) \
+    /*
+     * No-op instruction used to speed up pc-to-line mapping.
+     *
+     *   Category: Other
+     *   Operands: uint32_t lineno
+     *   Stack: =>
+     */ \
+    MACRO(Lineno, lineno, NULL, 5, 0, 0, JOF_UINT32) \
+    /*
+     * No-op instruction used by the decompiler to produce nicer error messages
+     * about destructuring code.
+     *
+     *   Category: Other
+     *   Operands:
+     *   Stack: =>
+     */ \
+    MACRO(NopDestructuring, nop_destructuring, NULL, 1, 0, 0, JOF_BYTE) \
+    /*
+     * No-op instruction only emitted in some self-hosted functions. Not
+     * handled by the JITs or Baseline Interpreter so the script always runs in
+     * the C++ interpreter.
+     *
+     *   Category: Other
+     *   Operands:
+     *   Stack: =>
+     */ \
+    MACRO(ForceInterpreter, force_interpreter, NULL, 1, 0, 0, JOF_BYTE) \
+    /*
+     * Examine the top stack value, asserting that it's either a self-hosted
+     * function or a self-hosted intrinsic. This does nothing in a non-debug
+     * build.
+     *
+     *   Category: Other
+     *   Operands:
+     *   Stack: checkVal => checkVal
+     */ \
+    MACRO(DebugCheckSelfHosted, debug_check_self_hosted, NULL, 1, 1, 1, JOF_BYTE) \
+    /*
+     * Push a boolean indicating if instrumentation is active.
+     *
+     *   Category: Other
+     *   Operands:
+     *   Stack: => val
+     */ \
+    MACRO(InstrumentationActive, instrumentation_active, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Push the instrumentation callback for the current realm.
+     *
+     *   Category: Other
+     *   Operands:
+     *   Stack: => val
+     */ \
+    MACRO(InstrumentationCallback, instrumentation_callback, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Push the current script's instrumentation ID.
+     *
+     *   Category: Other
+     *   Operands:
+     *   Stack: => val
+     */ \
+    MACRO(InstrumentationScriptId, instrumentation_script_id, NULL, 1, 0, 1, JOF_BYTE) \
+    /*
+     * Break in the debugger, if one is attached. Otherwise this is a no-op.
+     *
+     * The [`Debugger` API][1] offers a way to hook into this instruction.
+     *
+     * Implements: [Evaluation for *DebuggerStatement*][2].
+     *
+     * [1]: https://developer.mozilla.org/en-US/docs/Tools/Debugger-API/Debugger
+     * [2]: https://tc39.es/ecma262/#sec-debugger-statement-runtime-semantics-evaluation
+     *
+     *   Category: Other
+     *   Operands:
+     *   Stack: =>
+     */ \
+    MACRO(Debugger, debugger, NULL, 1, 0, 0, JOF_BYTE)
+
+// clang-format on
+
+/*
+ * In certain circumstances it may be useful to "pad out" the opcode space to
+ * a power of two.  Use this macro to do so.
+ */
+#define FOR_EACH_TRAILING_UNUSED_OPCODE(MACRO) \
+  MACRO(236)                                   \
+  MACRO(237)                                   \
+  MACRO(238)                                   \
+  MACRO(239)                                   \
+  MACRO(240)                                   \
+  MACRO(241)                                   \
+  MACRO(242)                                   \
+  MACRO(243)                                   \
+  MACRO(244)                                   \
+  MACRO(245)                                   \
+  MACRO(246)                                   \
+  MACRO(247)                                   \
+  MACRO(248)                                   \
+  MACRO(249)                                   \
+  MACRO(250)                                   \
+  MACRO(251)                                   \
+  MACRO(252)                                   \
+  MACRO(253)                                   \
+  MACRO(254)                                   \
+  MACRO(255)
+
+namespace js {
+
+// Sanity check that opcode values and trailing unused opcodes completely cover
+// the [0, 256) range.  Avert your eyes!  You don't want to know how the
+// sausage gets made.
+
+// clang-format off
+#define PLUS_ONE(...) \
+    + 1
+constexpr int JSOP_LIMIT = 0 FOR_EACH_OPCODE(PLUS_ONE);
+#undef PLUS_ONE
+
+#define TRAILING_VALUE_AND_VALUE_PLUS_ONE(val) \
+    val) && (val + 1 ==
+static_assert((JSOP_LIMIT ==
+               FOR_EACH_TRAILING_UNUSED_OPCODE(TRAILING_VALUE_AND_VALUE_PLUS_ONE)
+               256),
+              "trailing unused opcode values monotonically increase "
+              "from JSOP_LIMIT to 255");
+#undef TRAILING_VALUE_AND_VALUE_PLUS_ONE
+// clang-format on
+
+// Define JSOpLength_* constants for all ops.
+#define DEFINE_LENGTH_CONSTANT(op, op_snake, image, len, ...) \
+  constexpr size_t JSOpLength_##op = len;
+FOR_EACH_OPCODE(DEFINE_LENGTH_CONSTANT)
+#undef DEFINE_LENGTH_CONSTANT
+
+}  // namespace js
+
+#endif  // vm_Opcodes_h

--- a/crates/emitter/src/lib.rs
+++ b/crates/emitter/src/lib.rs
@@ -4,6 +4,7 @@ mod dis;
 mod emitter;
 mod forward_jump_emitter;
 pub mod opcode;
+pub mod opcode_info;
 mod reference_op_emitter;
 mod script_atom_set;
 

--- a/crates/emitter/src/opcode_info.rs
+++ b/crates/emitter/src/opcode_info.rs
@@ -1,0 +1,7 @@
+pub fn get_opcodes_source() -> &'static str {
+    include_str!("copy/Opcodes.h")
+}
+
+pub fn get_bytecode_util_source() -> &'static str {
+    include_str!("copy/BytecodeUtil.h")
+}


### PR DESCRIPTION
So far, added a function that returns the input files of opcode.rs (by storing them in the crate)

currently the following files are stored:
  * `BytecodeUtil.h`
  * `Opcodes.h`

SmooshMonkey can use it like the following, so that if there's any change in the input files,
the build fails.

the issue here is that there's false positive of the assertion failure,
where the change doesn't affect the opcode.rs.

we can extract necessary part, but I'm wondering where to put that code.
(currently, it's in Python script in jsparagus (`update_opcodes.py`), and not sure invoking it from m-c is reasonable...
maybe we can instead put the script in m-c, and use it from jsparagus to update opcode.rs

```
diff --git a/js/src/frontend/smoosh/Cargo.toml b/js/src/frontend/smoosh/Cargo.toml
index 4f71f73828aa..080c2ffbc867 100644
--- a/js/src/frontend/smoosh/Cargo.toml
+++ b/js/src/frontend/smoosh/Cargo.toml
@@ -7,6 +7,11 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 bumpalo = "2.6.0"
-jsparagus = { git = "https://github.com/mozilla-spidermonkey/jsparagus", rev = "0b248045fda0cc9b7323c73b81cfbcab71f4a9ef" }
-# For local development, replace above with
+# jsparagus = { git = "https://github.com/mozilla-spidermonkey/jsparagus", rev = "0b248045fda0cc9b7323c73b81cfbcab71f4a9ef" }
+jsparagus = { path = "../../../../../jsparagus/" }
+
+[build-dependencies]
+# jsparagus = { git = "https://github.com/mozilla-spidermonkey/jsparagus", rev = "0b248045fda0cc9b7323c73b81cfbcab71f4a9ef" }
+jsparagus = { path = "../../../../../jsparagus/" }
+# For local development, replace above 2  with
 # jsparagus = { path = "{path to jsparagus}" }
diff --git a/js/src/frontend/smoosh/build.rs b/js/src/frontend/smoosh/build.rs
new file mode 100644
index 000000000000..9f4da5b279d2
--- /dev/null
+++ b/js/src/frontend/smoosh/build.rs
@@ -0,0 +1,35 @@
+use std::env;
+use std::fs::File;
+use std::io::Read;
+use jsparagus::emitter::opcode_info;
+
+pub fn get_source(name: &str) -> std::io::Result<String> {
+    let mut path = env::current_dir().unwrap();
+    path.pop();
+    path.pop();
+    path.push("vm");
+    path.push(name);
+
+    println!("{:?}", path);
+    let mut file = File::open(path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+
+    Ok(contents)
+}
+
+fn compare(name: &str) {
+    let copied = opcode_info::get_source(name).unwrap();
+    let orig = get_source(name).unwrap();
+
+    assert_eq!(copied, orig,
+               "{} is out of sync. \
+                It's possible that the bytecode generated by jsparagus is \
+                based on older opcodes. Please update upcode in jsparagus.",
+               name);
+}
+
+fn main() {
+    compare("Opcodes.h");
+    compare("BytecodeUtil.h");
+}
```