### PR TITLE
CheckNotOnNewLine backtracks to fallback on ASI if possible.

### DIFF
--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -71,12 +71,15 @@ impl<'alloc> ParserTrait<'alloc, StackValue<'alloc>> for Parser<'alloc> {
         self.state_stack.pop().unwrap();
         self.node_stack.pop().unwrap()
     }
-    fn check_not_on_new_line(&self, peek: usize) -> Result<bool> {
+    fn check_not_on_new_line(&mut self, peek: usize) -> Result<bool> {
         let sv = &self.node_stack[self.node_stack.len() - peek].value;
         if let StackValue::Token(ref token) = sv {
-            if token.is_on_new_line {
-                return Err(ParseError::LexerError);
+            if !token.is_on_new_line {
+                return Ok(true);
             }
+            self.rewind(peek - 1);
+            let tv = self.pop();
+            self.try_error_handling(tv)?;
             return Ok(false);
         }
         Err(ParseError::NoLineTerminatorHereExpectedToken)

--- a/crates/parser/src/simulator.rs
+++ b/crates/parser/src/simulator.rs
@@ -92,8 +92,8 @@ impl<'alloc, 'parser> ParserTrait<'alloc, ()> for Simulator<'alloc, 'parser> {
         self.sp -= 1;
         TermValue { term: t, value: () }
     }
-    fn check_not_on_new_line(&self, _peek: usize) -> Result<bool> {
-        Ok(false)
+    fn check_not_on_new_line(&mut self, _peek: usize) -> Result<bool> {
+        Ok(true)
     }
 }
 

--- a/jsparagus/lexer.py
+++ b/jsparagus/lexer.py
@@ -160,6 +160,13 @@ class Tokenizer(FlatStringLexer):
     def take(self):
         return self._current_match.group()
 
+    def saw_line_terminator(self):
+        """True if there's a LineTerminator before the current token."""
+        i = self.previous_token_end
+        j = self.current_token_start
+        ws_between = self.src[i:j]
+        return any(c in ws_between for c in '\r\n\u2028\u2029')
+
     def _match(self, closing):
         # Advance over text matching ignore_re.
         ignore_match = self.ignore_re.match(self.src, self.point)

--- a/jsparagus/parse_pgen_generated.py
+++ b/jsparagus/parse_pgen_generated.py
@@ -5,7 +5,7 @@ def state_33_actions(parser, lexer):
 
     value = None
     value = parser.stack[-1].value
-    replay = [StateTermValue(0, Nt(InitNt(goal=Nt('grammar'))), value)]
+    replay = [StateTermValue(0, Nt(InitNt(goal=Nt('grammar'))), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
     return
@@ -14,7 +14,7 @@ def state_34_actions(parser, lexer):
 
     value = None
     value = parser.methods.nt_defs_single(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('nt_defs'), value)]
+    replay = [StateTermValue(0, Nt('nt_defs'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
     return
@@ -23,7 +23,7 @@ def state_35_actions(parser, lexer):
 
     value = None
     value = parser.methods.single(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('token_defs'), value)]
+    replay = [StateTermValue(0, Nt('token_defs'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
     return
@@ -32,7 +32,7 @@ def state_36_actions(parser, lexer):
 
     value = None
     value = parser.methods.nt_defs_append(parser.stack[-2].value, parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('nt_defs'), value)]
+    replay = [StateTermValue(0, Nt('nt_defs'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
     return
@@ -41,7 +41,7 @@ def state_37_actions(parser, lexer):
 
     value = None
     value = parser.methods.append(parser.stack[-2].value, parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('token_defs'), value)]
+    replay = [StateTermValue(0, Nt('token_defs'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
     return
@@ -50,7 +50,7 @@ def state_38_actions(parser, lexer):
 
     value = None
     raise ShiftAccept()
-    replay = [StateTermValue(0, Nt(InitNt(goal=Nt('grammar'))), value)]
+    replay = [StateTermValue(0, Nt(InitNt(goal=Nt('grammar'))), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
     return
@@ -59,7 +59,7 @@ def state_39_actions(parser, lexer):
 
     value = None
     value = parser.methods.nt_def(None, parser.stack[-3].value, None)
-    replay = [StateTermValue(0, Nt('nt_def'), value)]
+    replay = [StateTermValue(0, Nt('nt_def'), value, False)]
     del parser.stack[-4:]
     parser.shift_list(replay, lexer)
     return
@@ -68,7 +68,7 @@ def state_40_actions(parser, lexer):
 
     value = None
     value = parser.methods.single(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('prods'), value)]
+    replay = [StateTermValue(0, Nt('prods'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
     return
@@ -77,7 +77,7 @@ def state_41_actions(parser, lexer):
 
     value = None
     value = parser.methods.single(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('terms'), value)]
+    replay = [StateTermValue(0, Nt('terms'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
     return
@@ -86,7 +86,7 @@ def state_42_actions(parser, lexer):
 
     value = None
     value = parser.methods.ident(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('symbol'), value)]
+    replay = [StateTermValue(0, Nt('symbol'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
     return
@@ -95,7 +95,7 @@ def state_43_actions(parser, lexer):
 
     value = None
     value = parser.methods.str(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('symbol'), value)]
+    replay = [StateTermValue(0, Nt('symbol'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
     return
@@ -104,7 +104,7 @@ def state_44_actions(parser, lexer):
 
     value = None
     value = parser.methods.var_token(parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('token_def'), value)]
+    replay = [StateTermValue(0, Nt('token_def'), value, False)]
     del parser.stack[-4:]
     parser.shift_list(replay, lexer)
     return
@@ -113,7 +113,7 @@ def state_45_actions(parser, lexer):
 
     value = None
     value = parser.methods.nt_def(None, parser.stack[-4].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('nt_def'), value)]
+    replay = [StateTermValue(0, Nt('nt_def'), value, False)]
     del parser.stack[-5:]
     parser.shift_list(replay, lexer)
     return
@@ -122,7 +122,7 @@ def state_46_actions(parser, lexer):
 
     value = None
     value = parser.methods.append(parser.stack[-2].value, parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('prods'), value)]
+    replay = [StateTermValue(0, Nt('prods'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
     return
@@ -131,7 +131,7 @@ def state_47_actions(parser, lexer):
 
     value = None
     value = parser.methods.prod(parser.stack[-2].value, None)
-    replay = [StateTermValue(0, Nt('prod'), value)]
+    replay = [StateTermValue(0, Nt('prod'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
     return
@@ -140,7 +140,7 @@ def state_48_actions(parser, lexer):
 
     value = None
     value = parser.methods.append(parser.stack[-2].value, parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('terms'), value)]
+    replay = [StateTermValue(0, Nt('terms'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
     return
@@ -149,7 +149,7 @@ def state_49_actions(parser, lexer):
 
     value = None
     value = parser.methods.optional(parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('term'), value)]
+    replay = [StateTermValue(0, Nt('term'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
     return
@@ -158,7 +158,7 @@ def state_50_actions(parser, lexer):
 
     value = None
     value = parser.methods.nt_def(parser.stack[-5].value, parser.stack[-3].value, None)
-    replay = [StateTermValue(0, Nt('nt_def'), value)]
+    replay = [StateTermValue(0, Nt('nt_def'), value, False)]
     del parser.stack[-5:]
     parser.shift_list(replay, lexer)
     return
@@ -167,7 +167,7 @@ def state_51_actions(parser, lexer):
 
     value = None
     value = parser.methods.const_token(parser.stack[-4].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('token_def'), value)]
+    replay = [StateTermValue(0, Nt('token_def'), value, False)]
     del parser.stack[-5:]
     parser.shift_list(replay, lexer)
     return
@@ -176,7 +176,7 @@ def state_52_actions(parser, lexer):
 
     value = None
     value = parser.methods.prod(parser.stack[-3].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('prod'), value)]
+    replay = [StateTermValue(0, Nt('prod'), value, False)]
     del parser.stack[-3:]
     parser.shift_list(replay, lexer)
     return
@@ -185,7 +185,7 @@ def state_53_actions(parser, lexer):
 
     value = None
     value = parser.stack[-1].value
-    replay = [StateTermValue(0, Nt('reducer'), value)]
+    replay = [StateTermValue(0, Nt('reducer'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
     return
@@ -194,7 +194,7 @@ def state_54_actions(parser, lexer):
 
     value = None
     value = parser.methods.expr_match(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('expr'), value)]
+    replay = [StateTermValue(0, Nt('expr'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
     return
@@ -203,7 +203,7 @@ def state_55_actions(parser, lexer):
 
     value = None
     value = parser.methods.expr_none()
-    replay = [StateTermValue(0, Nt('expr'), value)]
+    replay = [StateTermValue(0, Nt('expr'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
     return
@@ -212,7 +212,7 @@ def state_56_actions(parser, lexer):
 
     value = None
     value = parser.methods.nt_def(parser.stack[-6].value, parser.stack[-4].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('nt_def'), value)]
+    replay = [StateTermValue(0, Nt('nt_def'), value, False)]
     del parser.stack[-6:]
     parser.shift_list(replay, lexer)
     return
@@ -221,7 +221,7 @@ def state_57_actions(parser, lexer):
 
     value = None
     value = parser.methods.expr_call(parser.stack[-3].value, None)
-    replay = [StateTermValue(0, Nt('expr'), value)]
+    replay = [StateTermValue(0, Nt('expr'), value, False)]
     del parser.stack[-3:]
     parser.shift_list(replay, lexer)
     return
@@ -230,7 +230,7 @@ def state_58_actions(parser, lexer):
 
     value = None
     value = parser.methods.args_single(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('expr_args'), value)]
+    replay = [StateTermValue(0, Nt('expr_args'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
     return
@@ -239,7 +239,7 @@ def state_59_actions(parser, lexer):
 
     value = None
     value = parser.methods.expr_call(parser.stack[-4].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('expr'), value)]
+    replay = [StateTermValue(0, Nt('expr'), value, False)]
     del parser.stack[-4:]
     parser.shift_list(replay, lexer)
     return
@@ -248,7 +248,7 @@ def state_60_actions(parser, lexer):
 
     value = None
     value = parser.methods.expr_some(parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('expr'), value)]
+    replay = [StateTermValue(0, Nt('expr'), value, False)]
     del parser.stack[-4:]
     parser.shift_list(replay, lexer)
     return
@@ -257,7 +257,7 @@ def state_61_actions(parser, lexer):
 
     value = None
     value = parser.methods.args_append(parser.stack[-3].value, parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('expr_args'), value)]
+    replay = [StateTermValue(0, Nt('expr_args'), value, False)]
     del parser.stack[-3:]
     parser.shift_list(replay, lexer)
     return
@@ -266,7 +266,7 @@ def state_62_actions(parser, lexer):
 
     value = None
     value = parser.methods.grammar(None, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('grammar'), value)]
+    replay = [StateTermValue(0, Nt('grammar'), value, False)]
     replay = replay + parser.stack[-1:]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
@@ -276,7 +276,7 @@ def state_63_actions(parser, lexer):
 
     value = None
     value = parser.methods.grammar(parser.stack[-3].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('grammar'), value)]
+    replay = [StateTermValue(0, Nt('grammar'), value, False)]
     replay = replay + parser.stack[-1:]
     del parser.stack[-3:]
     parser.shift_list(replay, lexer)
@@ -286,7 +286,7 @@ def state_64_actions(parser, lexer):
 
     value = None
     value = parser.stack[-2].value
-    replay = [StateTermValue(0, Nt('term'), value)]
+    replay = [StateTermValue(0, Nt('term'), value, False)]
     replay = replay + parser.stack[-1:]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -65,6 +65,14 @@ class ESTestCase(unittest.TestCase):
         self.assert_syntax_error(
             "switch (value) { case 1: break case 2: console.log('2'); }")
 
+    def test_asi_after_no_line_terminator_here(self):
+        self.assert_parses('''\
+           function f() {
+             return
+               x;
+           }
+        ''')
+
     def test_asi_suppressed(self):
         # The specification says ASI does not happen in the production
         # EmptyStatement : `;`.


### PR DESCRIPTION
This issue fix #366.

It convert `CheckNotOnNewLine` to a boolean expression tested in the action which is calling it. If it returns false, then we do not take the epsilon edge and backtrack by popping the stack and adding shifted tokens to the replay stack.

This PR adds a JS test case for the python parser, extracted from SpiderMonkey test262 test suite.
I have not yet tested against test262 test cases, as my SM tree is out-of-sync.