### PR TITLE
Return NotImplemented for static class field (fixes #381)

### DIFF
--- a/crates/generated_parser/src/ast_builder.rs
+++ b/crates/generated_parser/src/ast_builder.rs
@@ -4067,6 +4067,15 @@ impl<'alloc> AstBuilder<'alloc> {
         )
     }
 
+    // ClassElement : `static` MethodDefinition
+    pub fn class_element_static_field(
+        &self,
+        _static_token: arena::Box<'alloc, Token>,
+        _field: arena::Box<'alloc, ClassElement<'alloc>>,
+    ) -> Result<arena::Box<'alloc, Void>> {
+        Err(ParseError::NotImplemented("class static field"))
+    }
+
     // ClassElement : `;`
     pub fn class_element_empty(
         &self,

--- a/js_parser/es-simplified.esgrammar
+++ b/js_parser/es-simplified.esgrammar
@@ -1224,6 +1224,8 @@ ClassElement[Yield, Await] :
     => class_element_static($0, $1)
   FieldDefinition[?Yield, ?Await] `;`
     => class_element_to_vec($0)
+  `static` FieldDefinition[?Yield, ?Await] `;`
+    => class_element_static_field($0, $1)
   `;`
     => class_element_empty()
 


### PR DESCRIPTION
For now, just return `NotImplemented` from `AstBuilder`, without generating AST nodes