### PR TITLE
Implement scope handling for global and block (fixes #215, fixes #221, fixes #245)

### DIFF
--- a/crates/ast/src/source_atom_set.rs
+++ b/crates/ast/src/source_atom_set.rs
@@ -9,9 +9,11 @@ impl SourceAtomSetIndex {
     fn new(index: usize) -> Self {
         Self { index }
     }
+}
 
-    pub fn into_raw(self) -> usize {
-        self.index
+impl From<SourceAtomSetIndex> for usize {
+    fn from(index: SourceAtomSetIndex) -> usize {
+        index.index
     }
 }
 
@@ -216,10 +218,12 @@ impl<'alloc> SourceAtomSet<'alloc> {
     }
 
     pub fn get(&self, index: SourceAtomSetIndex) -> String {
-        self.atoms[index.into_raw()].clone()
+        self.atoms[usize::from(index)].clone()
     }
+}
 
-    pub fn into_vec(self) -> Vec<String> {
-        self.atoms
+impl<'alloc> From<SourceAtomSet<'alloc>> for Vec<String> {
+    fn from(set: SourceAtomSet<'alloc>) -> Vec<String> {
+        set.atoms
     }
 }

--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -4,12 +4,14 @@
 
 use crate::compilation_info::CompilationInfo;
 use crate::emitter::{EmitError, EmitOptions, EmitResult, InstructionWriter};
+use crate::emitter_scope::{EmitterScopeStack, NameLocation};
 use crate::opcode::Opcode;
 use crate::reference_op_emitter::{
-    AssignmentEmitter, CallEmitter, ElemReferenceEmitter, GetElemEmitter, GetNameEmitter,
-    GetPropEmitter, GetSuperElemEmitter, GetSuperPropEmitter, NameReferenceEmitter, NewEmitter,
-    PropReferenceEmitter,
+    AssignmentEmitter, CallEmitter, DeclarationEmitter, ElemReferenceEmitter, GetElemEmitter,
+    GetNameEmitter, GetPropEmitter, GetSuperElemEmitter, GetSuperPropEmitter, NameReferenceEmitter,
+    NewEmitter, PropReferenceEmitter,
 };
+use crate::scope::ScopeDataMap;
 use ast::source_atom_set::{CommonSourceAtomSetIndices, SourceAtomSet, SourceAtomSetIndex};
 use ast::types::*;
 
@@ -20,8 +22,9 @@ pub fn emit_program<'alloc>(
     ast: &Program,
     options: &EmitOptions,
     atoms: SourceAtomSet<'alloc>,
+    scope_data_map: ScopeDataMap,
 ) -> Result<EmitResult, EmitError> {
-    let mut emitter = AstEmitter::new(options, atoms);
+    let mut emitter = AstEmitter::new(options, atoms, scope_data_map);
 
     match ast {
         Program::Script(script) => emitter.emit_script(script)?,
@@ -37,22 +40,37 @@ pub struct AstEmitter<'alloc, 'opt> {
     pub emit: InstructionWriter,
     options: &'opt EmitOptions,
     compilation_info: CompilationInfo<'alloc>,
+    scope_stack: EmitterScopeStack,
 }
 
 impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
-    fn new(options: &'opt EmitOptions, atoms: SourceAtomSet<'alloc>) -> Self {
+    fn new(
+        options: &'opt EmitOptions,
+        atoms: SourceAtomSet<'alloc>,
+        scope_data_map: ScopeDataMap,
+    ) -> Self {
         Self {
             emit: InstructionWriter::new(),
             options,
-            compilation_info: CompilationInfo::new(atoms),
+            compilation_info: CompilationInfo::new(atoms, scope_data_map),
+            scope_stack: EmitterScopeStack::new(),
         }
     }
 
+    pub fn lookup_name(&mut self, name: SourceAtomSetIndex) -> NameLocation {
+        self.scope_stack.lookup_name(name)
+    }
+
     fn emit_script(&mut self, ast: &Script) -> Result<(), EmitError> {
+        self.scope_stack
+            .enter_global(&mut self.emit, &self.compilation_info.scope_data_map);
+
         for statement in &ast.statements {
             self.emit_statement(statement)?;
         }
         self.emit.ret_rval();
+
+        self.scope_stack.leave_global(&mut self.emit);
 
         Ok(())
     }
@@ -62,8 +80,20 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             Statement::ClassDeclaration(_) => {
                 return Err(EmitError::NotImplemented("TODO: ClassDeclaration"));
             }
-            Statement::BlockStatement { .. } => {
-                return Err(EmitError::NotImplemented("TODO: BlockStatement"));
+            Statement::BlockStatement { block, .. } => {
+                let scope_data_index = self.compilation_info.scope_data_map.get_index(block);
+
+                self.scope_stack.enter_lexical(
+                    &mut self.emit,
+                    &mut self.compilation_info.scope_data_map,
+                    scope_data_index,
+                );
+
+                for statement in &block.statements {
+                    self.emit_statement(statement)?;
+                }
+
+                self.scope_stack.leave_lexical(&mut self.emit);
             }
             Statement::BreakStatement { .. } => {
                 return Err(EmitError::NotImplemented("TODO: BreakStatement"));
@@ -122,10 +152,8 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             Statement::TryFinallyStatement { .. } => {
                 return Err(EmitError::NotImplemented("TODO: TryFinallyStatement"));
             }
-            Statement::VariableDeclarationStatement(_ast) => {
-                return Err(EmitError::NotImplemented(
-                    "TODO: VariableDeclarationStatement",
-                ));
+            Statement::VariableDeclarationStatement(ast) => {
+                self.emit_variable_declaration_statement(ast)?;
             }
             Statement::WhileStatement { .. } => {
                 return Err(EmitError::NotImplemented("TODO: WhileStatement"));
@@ -137,6 +165,47 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
                 return Err(EmitError::NotImplemented("TODO: FunctionDeclaration"));
             }
         };
+
+        Ok(())
+    }
+
+    fn emit_variable_declaration_statement(
+        &mut self,
+        ast: &VariableDeclaration,
+    ) -> Result<(), EmitError> {
+        match ast.kind {
+            VariableDeclarationKind::Var { .. } => {}
+            VariableDeclarationKind::Let { .. } | VariableDeclarationKind::Const { .. } => {}
+        }
+
+        for decl in &ast.declarators {
+            if let Some(init) = &decl.init {
+                self.emit_declaration_assignment(&decl.binding, &init)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn emit_declaration_assignment(
+        &mut self,
+        binding: &Binding,
+        init: &Expression,
+    ) -> Result<(), EmitError> {
+        match binding {
+            Binding::BindingIdentifier(binding) => {
+                let name = binding.name.value;
+                DeclarationEmitter {
+                    lhs: |emitter| Ok(NameReferenceEmitter { name }.emit_for_declaration(emitter)),
+                    rhs: |emitter| emitter.emit_expression(init),
+                }
+                .emit(self)?;
+                self.emit.pop();
+            }
+            _ => {
+                return Err(EmitError::NotImplemented("BindingPattern"));
+            }
+        }
 
         Ok(())
     }

--- a/crates/emitter/src/compilation_info.rs
+++ b/crates/emitter/src/compilation_info.rs
@@ -1,12 +1,16 @@
+use crate::scope::ScopeDataMap;
 use ast::source_atom_set::SourceAtomSet;
 
 pub struct CompilationInfo<'alloc> {
     pub atoms: SourceAtomSet<'alloc>,
-    // NOTE: scope information will be added to this struct.
+    pub scope_data_map: ScopeDataMap,
 }
 
 impl<'alloc> CompilationInfo<'alloc> {
-    pub fn new(atoms: SourceAtomSet<'alloc>) -> Self {
-        Self { atoms }
+    pub fn new(atoms: SourceAtomSet<'alloc>, scope_data_map: ScopeDataMap) -> Self {
+        Self {
+            atoms,
+            scope_data_map,
+        }
     }
 }

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -44,9 +44,11 @@ impl BytecodeOffset {
     fn new(offset: usize) -> Self {
         Self { offset }
     }
+}
 
-    pub fn into_raw(self) -> usize {
-        self.offset
+impl From<BytecodeOffset> for usize {
+    fn from(offset: BytecodeOffset) -> usize {
+        offset.offset
     }
 }
 
@@ -156,25 +158,22 @@ impl InstructionWriter {
     pub fn into_emit_result(self, compilation_info: CompilationInfo) -> EmitResult {
         EmitResult {
             bytecode: self.bytecode,
-            atoms: self.atoms.into_vec(),
-            all_atoms: compilation_info.atoms.into_vec(),
-            gcthings: self.gcthings.into_vec(),
-            scopes: compilation_info.scope_data_map.into_vec(),
-            scope_notes: self.scope_notes.into_vec(),
+            atoms: self.atoms.into(),
+            all_atoms: compilation_info.atoms.into(),
+            gcthings: self.gcthings.into(),
+            scopes: compilation_info.scope_data_map.into(),
+            scope_notes: self.scope_notes.into(),
 
             lineno: 1,
             column: 0,
 
-            main_offset: self.main_offset.into_raw(),
+            main_offset: self.main_offset.into(),
             max_fixed_slots: self.max_fixed_slots,
 
             // These values probably can't be out of range for u32, as we would
             // have hit other limits first. Release-assert anyway.
             maximum_stack_depth: self.maximum_stack_depth.try_into().unwrap(),
-            body_scope_index: self
-                .body_scope_index
-                .expect("body scope should be set")
-                .into_raw()
+            body_scope_index: usize::from(self.body_scope_index.expect("body scope should be set"))
                 .try_into()
                 .unwrap(),
             num_ic_entries: self.num_ic_entries.try_into().unwrap(),
@@ -219,7 +218,7 @@ impl InstructionWriter {
     }
 
     fn write_script_atom_set_index(&mut self, atom_index: ScriptAtomSetIndex) {
-        self.write_u32(atom_index.into_raw());
+        self.write_u32(atom_index.into());
     }
 
     fn write_offset(&mut self, offset: i32) {

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -6,10 +6,15 @@
 #![allow(dead_code)]
 
 use crate::compilation_info::CompilationInfo;
+use crate::frame_slot::FrameSlot;
+use crate::gcthings::{GCThing, GCThingIndex, GCThingList};
 use crate::opcode::Opcode;
+use crate::scope::{ScopeData, ScopeIndex};
+use crate::scope_notes::{ScopeNote, ScopeNoteIndex, ScopeNoteList};
 use crate::script_atom_set::{ScriptAtomSet, ScriptAtomSetIndex};
 use ast::source_atom_set::SourceAtomSetIndex;
 use byteorder::{ByteOrder, LittleEndian};
+use std::cmp;
 use std::convert::TryInto;
 use std::fmt;
 
@@ -35,16 +40,36 @@ pub struct BytecodeOffset {
     pub offset: usize,
 }
 
+impl BytecodeOffset {
+    fn new(offset: usize) -> Self {
+        Self { offset }
+    }
+
+    pub fn into_raw(self) -> usize {
+        self.offset
+    }
+}
+
 /// Low-level bytecode emitter.
 pub struct InstructionWriter {
     bytecode: Vec<u8>,
     atoms: ScriptAtomSet,
+
+    gcthings: GCThingList,
+    scope_notes: ScopeNoteList,
+
+    main_offset: BytecodeOffset,
+
+    /// The maximum number of fixed frame slots.
+    max_fixed_slots: FrameSlot,
 
     /// Stack depth after the instructions emitted so far.
     stack_depth: usize,
 
     /// Maximum stack_depth at any point in the instructions emitted so far.
     maximum_stack_depth: usize,
+
+    body_scope_index: Option<GCThingIndex>,
 
     /// Number of JOF_IC instructions emitted so far.
     num_ic_entries: usize,
@@ -71,13 +96,16 @@ pub struct EmitResult {
     pub bytecode: Vec<u8>,
     pub atoms: Vec<SourceAtomSetIndex>,
     pub all_atoms: Vec<String>,
+    pub gcthings: Vec<GCThing>,
+    pub scopes: Vec<ScopeData>,
+    pub scope_notes: Vec<ScopeNote>,
 
     // Line and column numbers for the first character of source.
     pub lineno: usize,
     pub column: usize,
 
     pub main_offset: usize,
-    pub max_fixed_slots: u32,
+    pub max_fixed_slots: FrameSlot,
     pub maximum_stack_depth: u32,
     pub body_scope_index: u32,
     pub num_ic_entries: u32,
@@ -113,8 +141,13 @@ impl InstructionWriter {
         Self {
             bytecode: Vec::new(),
             atoms: ScriptAtomSet::new(),
+            gcthings: GCThingList::new(),
+            scope_notes: ScopeNoteList::new(),
+            main_offset: BytecodeOffset::new(0),
+            max_fixed_slots: FrameSlot::new(0),
             stack_depth: 0,
             maximum_stack_depth: 0,
+            body_scope_index: None,
             num_ic_entries: 0,
             num_type_sets: 0,
         }
@@ -125,17 +158,25 @@ impl InstructionWriter {
             bytecode: self.bytecode,
             atoms: self.atoms.into_vec(),
             all_atoms: compilation_info.atoms.into_vec(),
+            gcthings: self.gcthings.into_vec(),
+            scopes: compilation_info.scope_data_map.into_vec(),
+            scope_notes: self.scope_notes.into_vec(),
 
             lineno: 1,
             column: 0,
 
-            main_offset: 0,
-            max_fixed_slots: 0,
+            main_offset: self.main_offset.into_raw(),
+            max_fixed_slots: self.max_fixed_slots,
 
             // These values probably can't be out of range for u32, as we would
             // have hit other limits first. Release-assert anyway.
             maximum_stack_depth: self.maximum_stack_depth.try_into().unwrap(),
-            body_scope_index: 0,
+            body_scope_index: self
+                .body_scope_index
+                .expect("body scope should be set")
+                .into_raw()
+                .try_into()
+                .unwrap(),
             num_ic_entries: self.num_ic_entries.try_into().unwrap(),
             num_type_sets: self.num_type_sets.try_into().unwrap(),
 
@@ -275,9 +316,7 @@ impl InstructionWriter {
     }
 
     pub fn bytecode_offset(&mut self) -> BytecodeOffset {
-        BytecodeOffset {
-            offset: self.bytecode.len(),
-        }
+        BytecodeOffset::new(self.bytecode.len())
     }
 
     pub fn stack_depth(&self) -> usize {
@@ -1264,4 +1303,41 @@ impl InstructionWriter {
     }
 
     // @@@@ END METHODS @@@@
+
+    fn update_max_frame_slots(&mut self, max_frame_slots: FrameSlot) {
+        self.max_fixed_slots = cmp::max(self.max_fixed_slots, max_frame_slots);
+    }
+
+    pub fn enter_global_scope(&mut self, scope_index: ScopeIndex) {
+        let index = self.gcthings.append_scope(scope_index);
+        self.body_scope_index = Some(index);
+    }
+
+    pub fn leave_global_scope(&self) {}
+
+    pub fn enter_lexical_scope(
+        &mut self,
+        scope_index: ScopeIndex,
+        parent_scope_note_index: Option<ScopeNoteIndex>,
+        next_frame_slot: FrameSlot,
+    ) -> ScopeNoteIndex {
+        self.update_max_frame_slots(next_frame_slot);
+
+        self.gcthings.append_scope(scope_index);
+        let offset = self.bytecode_offset();
+        let index = self
+            .scope_notes
+            .enter_scope(scope_index, offset, parent_scope_note_index);
+        index
+    }
+
+    pub fn leave_lexical_scope(&mut self, index: ScopeNoteIndex) {
+        self.debug_leave_lexical_env();
+        let offset = self.bytecode_offset();
+        self.scope_notes.leave_scope(index, offset);
+    }
+
+    pub fn switch_to_main(&mut self) {
+        self.main_offset = self.bytecode_offset();
+    }
 }

--- a/crates/emitter/src/emitter_scope.rs
+++ b/crates/emitter/src/emitter_scope.rs
@@ -186,7 +186,7 @@ impl EmitterScopeStack {
         emit.uninitialized();
         let mut slot = slot_start;
         while slot < slot_end {
-            emit.init_lexical(slot.into_raw());
+            emit.init_lexical(slot.into());
             slot.next();
         }
         emit.pop();

--- a/crates/emitter/src/emitter_scope.rs
+++ b/crates/emitter/src/emitter_scope.rs
@@ -1,0 +1,241 @@
+use crate::emitter::InstructionWriter;
+use crate::frame_slot::FrameSlot;
+use crate::scope::{BindingKind, GlobalScopeData, LexicalScopeData, ScopeDataMap, ScopeIndex};
+use crate::scope_notes::ScopeNoteIndex;
+use ast::source_atom_set::SourceAtomSetIndex;
+use std::collections::HashMap;
+
+/// Corresponds to js::frontend::NameLocation in
+/// m-c/js/src/frontend/NameAnalysisTypes.h
+#[derive(Debug, Clone)]
+pub enum NameLocation {
+    Dynamic,
+    Global(BindingKind),
+    FrameSlot(FrameSlot, BindingKind),
+}
+
+#[derive(Debug)]
+pub struct GlobalEmitterScope {
+    cache: HashMap<SourceAtomSetIndex, NameLocation>,
+}
+
+impl GlobalEmitterScope {
+    pub fn new(data: &GlobalScopeData) -> Self {
+        let mut cache = HashMap::new();
+        for item in data.iter() {
+            cache.insert(item.name(), NameLocation::Global(item.kind()));
+        }
+        Self { cache }
+    }
+
+    fn lookup_name(&self, name: SourceAtomSetIndex) -> Option<NameLocation> {
+        match self.cache.get(&name) {
+            Some(loc) => Some(loc.clone()),
+            None => Some(NameLocation::Global(BindingKind::Var)),
+        }
+    }
+
+    fn next_frame_slot(&self) -> FrameSlot {
+        FrameSlot::new(0)
+    }
+
+    fn scope_note_index(&self) -> Option<ScopeNoteIndex> {
+        None
+    }
+}
+
+#[derive(Debug)]
+pub struct LexicalEmitterScope {
+    cache: HashMap<SourceAtomSetIndex, NameLocation>,
+    next_frame_slot: FrameSlot,
+    scope_note_index: Option<ScopeNoteIndex>,
+}
+
+impl LexicalEmitterScope {
+    pub fn new(data: &LexicalScopeData, first_frame_slot: FrameSlot) -> Self {
+        let mut cache = HashMap::new();
+        let mut slot = first_frame_slot;
+        for item in data.iter() {
+            // FIXME: support environment (item.is_closed_over()).
+            cache.insert(item.name(), NameLocation::FrameSlot(slot, item.kind()));
+            slot.next();
+        }
+
+        Self {
+            cache,
+            next_frame_slot: slot,
+            scope_note_index: None,
+        }
+    }
+
+    fn lookup_name(&self, name: SourceAtomSetIndex) -> Option<NameLocation> {
+        match self.cache.get(&name) {
+            Some(loc) => Some(loc.clone()),
+            None => None,
+        }
+    }
+
+    fn next_frame_slot(&self) -> FrameSlot {
+        self.next_frame_slot
+    }
+
+    fn scope_note_index(&self) -> Option<ScopeNoteIndex> {
+        self.scope_note_index
+    }
+}
+
+#[derive(Debug)]
+pub enum EmitterScope {
+    Global(GlobalEmitterScope),
+    Lexical(LexicalEmitterScope),
+}
+
+impl EmitterScope {
+    fn lookup_name(&self, name: SourceAtomSetIndex) -> Option<NameLocation> {
+        match self {
+            EmitterScope::Global(scope) => scope.lookup_name(name),
+            EmitterScope::Lexical(scope) => scope.lookup_name(name),
+        }
+    }
+
+    fn next_frame_slot(&self) -> FrameSlot {
+        match self {
+            EmitterScope::Global(scope) => scope.next_frame_slot(),
+            EmitterScope::Lexical(scope) => scope.next_frame_slot(),
+        }
+    }
+
+    fn scope_note_index(&self) -> Option<ScopeNoteIndex> {
+        match self {
+            EmitterScope::Global(scope) => scope.scope_note_index(),
+            EmitterScope::Lexical(scope) => scope.scope_note_index(),
+        }
+    }
+}
+
+/// Compared to C++ impl, this uses explicit stack struct,
+/// given Rust cannot store a reference of stack-allocated object into
+/// another object that has longer-lifetime.
+///
+/// Some methods are implemented here, instead of each EmitterScope.
+pub struct EmitterScopeStack {
+    scope_stack: Vec<EmitterScope>,
+}
+
+impl EmitterScopeStack {
+    pub fn new() -> Self {
+        Self {
+            scope_stack: Vec::new(),
+        }
+    }
+
+    pub fn innermost(&self) -> &EmitterScope {
+        self.scope_stack
+            .last()
+            .expect("There should be at least one scope")
+    }
+
+    pub fn enter_global(&mut self, emit: &mut InstructionWriter, scope_data_map: &ScopeDataMap) {
+        let scope_index = scope_data_map.get_global_index();
+        let scope_data = scope_data_map.get_global_at(scope_index);
+
+        for item in scope_data.iter() {
+            let name_index = emit.get_atom_index(item.name());
+
+            match item.kind() {
+                BindingKind::Var => {
+                    if !item.is_top_level_function() {
+                        emit.def_var(name_index);
+                    }
+                }
+                BindingKind::Let => {
+                    emit.def_let(name_index);
+                }
+                BindingKind::Const => {
+                    emit.def_const(name_index);
+                }
+            }
+        }
+
+        emit.switch_to_main();
+
+        let scope = EmitterScope::Global(GlobalEmitterScope::new(scope_data));
+        self.scope_stack.push(scope);
+
+        emit.enter_global_scope(scope_index);
+    }
+
+    pub fn leave_global(&mut self, emit: &InstructionWriter) {
+        match self.scope_stack.pop() {
+            Some(EmitterScope::Global(_)) => {}
+            _ => panic!("unmatching scope"),
+        }
+        emit.leave_global_scope();
+    }
+
+    pub fn dead_zone_frame_slot_range(
+        &self,
+        emit: &mut InstructionWriter,
+        slot_start: FrameSlot,
+        slot_end: FrameSlot,
+    ) {
+        if slot_start == slot_end {
+            return;
+        }
+
+        emit.uninitialized();
+        let mut slot = slot_start;
+        while slot < slot_end {
+            emit.init_lexical(slot.into_raw());
+            slot.next();
+        }
+        emit.pop();
+    }
+
+    pub fn enter_lexical(
+        &mut self,
+        emit: &mut InstructionWriter,
+        scope_data_map: &mut ScopeDataMap,
+        scope_index: ScopeIndex,
+    ) {
+        let mut scope_data = scope_data_map.get_lexical_at_mut(scope_index);
+
+        let first_frame_slot = self.innermost().next_frame_slot();
+        let parent_scope_note_index = self.innermost().scope_note_index();
+
+        scope_data.first_frame_slot = first_frame_slot;
+
+        let mut lexical_scope = LexicalEmitterScope::new(scope_data, first_frame_slot);
+        let next_frame_slot = lexical_scope.next_frame_slot;
+        let index = emit.enter_lexical_scope(scope_index, parent_scope_note_index, next_frame_slot);
+        lexical_scope.scope_note_index = Some(index);
+
+        let scope = EmitterScope::Lexical(lexical_scope);
+        self.scope_stack.push(scope);
+
+        self.dead_zone_frame_slot_range(emit, first_frame_slot, next_frame_slot);
+    }
+
+    pub fn leave_lexical(&mut self, emit: &mut InstructionWriter) {
+        let lexical_scope = match self.scope_stack.pop() {
+            Some(EmitterScope::Lexical(scope)) => scope,
+            _ => panic!("unmatching scope"),
+        };
+        emit.leave_lexical_scope(
+            lexical_scope
+                .scope_note_index
+                .expect("scope note index should be populated"),
+        );
+    }
+
+    pub fn lookup_name(&mut self, name: SourceAtomSetIndex) -> NameLocation {
+        for scope in self.scope_stack.iter().rev() {
+            if let Some(loc) = scope.lookup_name(name) {
+                // FIXME: handle hops in aliased var.
+                return loc;
+            }
+        }
+
+        NameLocation::Dynamic
+    }
+}

--- a/crates/emitter/src/frame_slot.rs
+++ b/crates/emitter/src/frame_slot.rs
@@ -12,8 +12,10 @@ impl FrameSlot {
     pub fn next(&mut self) {
         self.slot += 1;
     }
+}
 
-    pub fn into_raw(self) -> u32 {
-        self.slot
+impl From<FrameSlot> for u32 {
+    fn from(slot: FrameSlot) -> u32 {
+        slot.slot
     }
 }

--- a/crates/emitter/src/frame_slot.rs
+++ b/crates/emitter/src/frame_slot.rs
@@ -1,0 +1,19 @@
+/// Slot in the stack frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd)]
+pub struct FrameSlot {
+    slot: u32,
+}
+
+impl FrameSlot {
+    pub fn new(slot: u32) -> Self {
+        Self { slot }
+    }
+
+    pub fn next(&mut self) {
+        self.slot += 1;
+    }
+
+    pub fn into_raw(self) -> u32 {
+        self.slot
+    }
+}

--- a/crates/emitter/src/gcthings.rs
+++ b/crates/emitter/src/gcthings.rs
@@ -17,9 +17,11 @@ impl GCThingIndex {
     fn new(index: usize) -> Self {
         Self { index }
     }
+}
 
-    pub fn into_raw(self) -> usize {
-        self.index
+impl From<GCThingIndex> for usize {
+    fn from(index: GCThingIndex) -> usize {
+        index.index
     }
 }
 
@@ -41,8 +43,10 @@ impl GCThingList {
         self.things.push(GCThing::Scope(scope_index));
         GCThingIndex::new(index)
     }
+}
 
-    pub fn into_vec(self) -> Vec<GCThing> {
-        self.things
+impl From<GCThingList> for Vec<GCThing> {
+    fn from(list: GCThingList) -> Vec<GCThing> {
+        list.things
     }
 }

--- a/crates/emitter/src/gcthings.rs
+++ b/crates/emitter/src/gcthings.rs
@@ -1,0 +1,48 @@
+use crate::scope::ScopeIndex;
+
+/// Corresponds to js::frontend::GCThingList::ListType
+/// in m-c/js/src/frontend/BytecodeSection.h.
+#[derive(Debug)]
+pub enum GCThing {
+    Scope(ScopeIndex),
+}
+
+/// Index into GCThingList.atoms.
+#[derive(Debug, Clone, Copy)]
+pub struct GCThingIndex {
+    index: usize,
+}
+
+impl GCThingIndex {
+    fn new(index: usize) -> Self {
+        Self { index }
+    }
+
+    pub fn into_raw(self) -> usize {
+        self.index
+    }
+}
+
+/// List of GC things.
+///
+/// Maps to JSScript::gcthings() in js/src/vm/JSScript.h.
+#[derive(Debug)]
+pub struct GCThingList {
+    things: Vec<GCThing>,
+}
+
+impl GCThingList {
+    pub fn new() -> Self {
+        Self { things: Vec::new() }
+    }
+
+    pub fn append_scope(&mut self, scope_index: ScopeIndex) -> GCThingIndex {
+        let index = self.things.len();
+        self.things.push(GCThing::Scope(scope_index));
+        GCThingIndex::new(index)
+    }
+
+    pub fn into_vec(self) -> Vec<GCThing> {
+        self.things
+    }
+}

--- a/crates/emitter/src/lib.rs
+++ b/crates/emitter/src/lib.rs
@@ -2,15 +2,24 @@ mod ast_emitter;
 mod compilation_info;
 mod dis;
 mod emitter;
+mod emitter_scope;
 mod forward_jump_emitter;
+mod frame_slot;
+mod gcthings;
 pub mod opcode;
 pub mod opcode_info;
 mod reference_op_emitter;
+mod scope;
+mod scope_notes;
+mod scope_pass;
 mod script_atom_set;
 
 extern crate jsparagus_ast as ast;
 
 pub use crate::emitter::{EmitError, EmitOptions, EmitResult};
+pub use crate::gcthings::GCThing;
+pub use crate::scope::{BindingName, ScopeData};
+pub use crate::scope_notes::ScopeNote;
 pub use dis::dis;
 
 use ast::source_atom_set::SourceAtomSet;
@@ -20,7 +29,8 @@ pub fn emit<'alloc>(
     options: &EmitOptions,
     atoms: SourceAtomSet<'alloc>,
 ) -> Result<EmitResult, EmitError> {
-    ast_emitter::emit_program(ast, options, atoms)
+    let scope_data_map = scope_pass::generate_scope_data(ast);
+    ast_emitter::emit_program(ast, options, atoms, scope_data_map)
 }
 
 #[cfg(test)]

--- a/crates/emitter/src/reference_op_emitter.rs
+++ b/crates/emitter/src/reference_op_emitter.rs
@@ -1,11 +1,17 @@
 use crate::ast_emitter::AstEmitter;
 use crate::emitter::EmitError;
+use crate::emitter_scope::NameLocation;
+use crate::frame_slot::FrameSlot;
+use crate::scope::BindingKind;
 use crate::script_atom_set::ScriptAtomSetIndex;
 use ast::source_atom_set::SourceAtomSetIndex;
 
 #[derive(Debug, PartialEq)]
 enum AssignmentReferenceKind {
-    GlobalName(ScriptAtomSetIndex),
+    GlobalVar(ScriptAtomSetIndex),
+    GlobalLexical(ScriptAtomSetIndex),
+    FrameSlot(FrameSlot),
+    Dynamic(ScriptAtomSetIndex),
     #[allow(dead_code)]
     Prop(ScriptAtomSetIndex),
     #[allow(dead_code)]
@@ -26,10 +32,33 @@ impl AssignmentReference {
 
     fn stack_slots(&self) -> usize {
         match self.kind {
-            AssignmentReferenceKind::GlobalName(_) => 1,
+            AssignmentReferenceKind::GlobalVar(_) => 1,
+            AssignmentReferenceKind::GlobalLexical(_) => 1,
+            AssignmentReferenceKind::FrameSlot(_) => 0,
+            AssignmentReferenceKind::Dynamic(_) => 1,
             AssignmentReferenceKind::Prop(_) => 1,
             AssignmentReferenceKind::Elem => 2,
         }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum DeclarationReferenceKind {
+    GlobalVar(ScriptAtomSetIndex),
+    GlobalLexical(ScriptAtomSetIndex),
+    FrameSlot(FrameSlot),
+}
+
+// See DeclarationReferenceEmitter.
+// This uses struct to hide the details from the consumer.
+#[derive(Debug)]
+#[must_use]
+pub struct DeclarationReference {
+    kind: DeclarationReferenceKind,
+}
+impl DeclarationReference {
+    fn new(kind: DeclarationReferenceKind) -> Self {
+        Self { kind }
     }
 }
 
@@ -59,12 +88,24 @@ pub struct GetNameEmitter {
 impl GetNameEmitter {
     pub fn emit(self, emitter: &mut AstEmitter) {
         let name_index = emitter.emit.get_atom_index(self.name);
+        let loc = emitter.lookup_name(self.name);
 
         //              [stack]
 
-        // FIXME: Support non-global case.
-        emitter.emit.get_g_name(name_index);
-        //              [stack] VAL
+        match loc {
+            NameLocation::Global(_kind) => {
+                emitter.emit.get_g_name(name_index);
+                //      [stack] VAL
+            }
+            NameLocation::Dynamic => {
+                emitter.emit.get_name(name_index);
+                //      [stack] VAL
+            }
+            NameLocation::FrameSlot(slot, _kind) => {
+                emitter.emit.get_local(slot.into_raw());
+                //      [stack] VAL
+            }
+        }
     }
 }
 
@@ -213,30 +254,92 @@ pub struct NameReferenceEmitter {
 impl NameReferenceEmitter {
     pub fn emit_for_call(self, emitter: &mut AstEmitter) -> CallReference {
         let name_index = emitter.emit.get_atom_index(self.name);
+        let loc = emitter.lookup_name(self.name);
 
         //              [stack]
 
-        // FIXME: Support non-global case.
-        emitter.emit.get_g_name(name_index);
-        //              [stack] CALLEE
+        match loc {
+            NameLocation::Global(_kind) => {
+                emitter.emit.get_g_name(name_index);
+                //      [stack] CALLEE
 
-        // FIXME: Support non-global cases.
-        emitter.emit.g_implicit_this(name_index);
-        //              [stack] CALLEE THIS
+                emitter.emit.g_implicit_this(name_index);
+                //      [stack] CALLEE THIS
+            }
+            NameLocation::Dynamic => {
+                emitter.emit.get_name(name_index);
+                //      [stack] CALLEE
+
+                emitter.emit.g_implicit_this(name_index);
+                //      [stack] CALLEE THIS
+            }
+            NameLocation::FrameSlot(slot, _kind) => {
+                emitter.emit.get_local(slot.into_raw());
+                //      [stack] CALLEE
+
+                emitter.emit.undefined();
+                //      [stack] CALLEE THIS
+            }
+        }
 
         CallReference::new(CallKind::Normal)
     }
 
     pub fn emit_for_assignment(self, emitter: &mut AstEmitter) -> AssignmentReference {
         let name_index = emitter.emit.get_atom_index(self.name);
+        let loc = emitter.lookup_name(self.name);
 
         //              [stack]
 
-        // FIXME: Support non-global case.
-        emitter.emit.bind_g_name(name_index);
-        //              [stack] GLOBAL
+        match loc {
+            NameLocation::Global(kind) => match kind {
+                BindingKind::Var => {
+                    emitter.emit.bind_g_name(name_index);
+                    //  [stack] GLOBAL
+                    AssignmentReference::new(AssignmentReferenceKind::GlobalVar(name_index))
+                }
+                BindingKind::Let | BindingKind::Const => {
+                    emitter.emit.bind_g_name(name_index);
+                    //  [stack] GLOBAL
+                    AssignmentReference::new(AssignmentReferenceKind::GlobalLexical(name_index))
+                }
+            },
+            NameLocation::Dynamic => {
+                emitter.emit.bind_name(name_index);
+                //      [stack] ENV
 
-        AssignmentReference::new(AssignmentReferenceKind::GlobalName(name_index))
+                AssignmentReference::new(AssignmentReferenceKind::Dynamic(name_index))
+            }
+            NameLocation::FrameSlot(slot, _kind) => {
+                AssignmentReference::new(AssignmentReferenceKind::FrameSlot(slot))
+            }
+        }
+    }
+
+    pub fn emit_for_declaration(self, emitter: &mut AstEmitter) -> DeclarationReference {
+        let name_index = emitter.emit.get_atom_index(self.name);
+        let loc = emitter.lookup_name(self.name);
+
+        //              [stack]
+
+        match loc {
+            NameLocation::Global(kind) => match kind {
+                BindingKind::Var => {
+                    emitter.emit.bind_g_name(name_index);
+                    //  [stack] GLOBAL
+                    DeclarationReference::new(DeclarationReferenceKind::GlobalVar(name_index))
+                }
+                BindingKind::Let | BindingKind::Const => {
+                    DeclarationReference::new(DeclarationReferenceKind::GlobalLexical(name_index))
+                }
+            },
+            NameLocation::Dynamic => {
+                panic!("declaration should have non-dynamic location");
+            }
+            NameLocation::FrameSlot(slot, _kind) => {
+                DeclarationReference::new(DeclarationReferenceKind::FrameSlot(slot))
+            }
+        }
     }
 }
 
@@ -464,11 +567,28 @@ where
         //              [stack] REF... VAL
 
         match reference.kind {
-            AssignmentReferenceKind::GlobalName(name_index) => {
+            AssignmentReferenceKind::GlobalVar(name_index) => {
                 //      [stack] GLOBAL VAL
 
-                // FIXME: Support non-global cases.
                 emitter.emit.set_g_name(name_index);
+                //      [stack] VAL
+            }
+            AssignmentReferenceKind::GlobalLexical(name_index) => {
+                //      [stack] VAL
+
+                emitter.emit.set_g_name(name_index);
+                //      [stack] VAL
+            }
+            AssignmentReferenceKind::Dynamic(name_index) => {
+                //      [stack] ENV VAL
+
+                emitter.emit.set_name(name_index);
+                //      [stack] VAL
+            }
+            AssignmentReferenceKind::FrameSlot(slot) => {
+                //      [stack] VAL
+
+                emitter.emit.set_local(slot.into_raw());
                 //      [stack] VAL
             }
             AssignmentReferenceKind::Prop(key_index) => {
@@ -491,6 +611,50 @@ where
     }
 
     // FIXME: Support compound assignment
+}
+
+// Struct for emitting bytecode for declaration `lhs = rhs` operation.
+pub struct DeclarationEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<DeclarationReference, EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub lhs: F1,
+    pub rhs: F2,
+}
+impl<F1, F2> DeclarationEmitter<F1, F2>
+where
+    F1: Fn(&mut AstEmitter) -> Result<DeclarationReference, EmitError>,
+    F2: Fn(&mut AstEmitter) -> Result<(), EmitError>,
+{
+    pub fn emit(self, emitter: &mut AstEmitter) -> Result<(), EmitError> {
+        let reference = (self.lhs)(emitter)?;
+
+        (self.rhs)(emitter)?;
+
+        match reference.kind {
+            DeclarationReferenceKind::GlobalVar(name_index) => {
+                //      [stack] GLOBAL VAL
+
+                emitter.emit.set_g_name(name_index);
+                //      [stack] VAL
+            }
+            DeclarationReferenceKind::GlobalLexical(name_index) => {
+                //      [stack] VAL
+
+                emitter.emit.init_g_lexical(name_index);
+                //      [stack] VAL
+            }
+            DeclarationReferenceKind::FrameSlot(slot) => {
+                //      [stack] VAL
+
+                emitter.emit.init_lexical(slot.into_raw());
+                //      [stack] VAL
+            }
+        }
+
+        Ok(())
+    }
 }
 
 // FIXME: Add increment

--- a/crates/emitter/src/reference_op_emitter.rs
+++ b/crates/emitter/src/reference_op_emitter.rs
@@ -102,7 +102,7 @@ impl GetNameEmitter {
                 //      [stack] VAL
             }
             NameLocation::FrameSlot(slot, _kind) => {
-                emitter.emit.get_local(slot.into_raw());
+                emitter.emit.get_local(slot.into());
                 //      [stack] VAL
             }
         }
@@ -274,7 +274,7 @@ impl NameReferenceEmitter {
                 //      [stack] CALLEE THIS
             }
             NameLocation::FrameSlot(slot, _kind) => {
-                emitter.emit.get_local(slot.into_raw());
+                emitter.emit.get_local(slot.into());
                 //      [stack] CALLEE
 
                 emitter.emit.undefined();
@@ -588,7 +588,7 @@ where
             AssignmentReferenceKind::FrameSlot(slot) => {
                 //      [stack] VAL
 
-                emitter.emit.set_local(slot.into_raw());
+                emitter.emit.set_local(slot.into());
                 //      [stack] VAL
             }
             AssignmentReferenceKind::Prop(key_index) => {
@@ -648,7 +648,7 @@ where
             DeclarationReferenceKind::FrameSlot(slot) => {
                 //      [stack] VAL
 
-                emitter.emit.init_lexical(slot.into_raw());
+                emitter.emit.init_lexical(slot.into());
                 //      [stack] VAL
             }
         }

--- a/crates/emitter/src/scope.rs
+++ b/crates/emitter/src/scope.rs
@@ -223,9 +223,11 @@ impl ScopeIndex {
     fn new(index: usize) -> Self {
         Self { index }
     }
+}
 
-    pub fn into_raw(self) -> usize {
-        self.index
+impl From<ScopeIndex> for usize {
+    fn from(index: ScopeIndex) -> usize {
+        index.index
     }
 }
 
@@ -255,24 +257,26 @@ impl ScopeDataList {
     }
 
     pub fn populate(&mut self, index: ScopeIndex, scope: ScopeData) {
-        self.scopes[index.into_raw()].replace(scope);
+        self.scopes[usize::from(index)].replace(scope);
     }
 
     fn get(&self, index: ScopeIndex) -> &ScopeData {
-        self.scopes[index.into_raw()]
+        self.scopes[usize::from(index)]
             .as_ref()
             .expect("Should be populated")
     }
 
     fn get_mut(&mut self, index: ScopeIndex) -> &mut ScopeData {
-        self.scopes[index.into_raw()]
+        self.scopes[usize::from(index)]
             .as_mut()
             .expect("Should be populated")
     }
+}
 
-    pub fn into_vec(mut self) -> Vec<ScopeData> {
-        self.scopes
-            .drain(..)
+impl From<ScopeDataList> for Vec<ScopeData> {
+    fn from(list: ScopeDataList) -> Vec<ScopeData> {
+        list.scopes
+            .into_iter()
             .map(|g| g.expect("Should be populated"))
             .collect()
     }
@@ -326,8 +330,10 @@ impl ScopeDataMap {
             _ => panic!("Unexpected scope data for lexical"),
         }
     }
+}
 
-    pub fn into_vec(self) -> Vec<ScopeData> {
-        self.scopes.into_vec()
+impl From<ScopeDataMap> for Vec<ScopeData> {
+    fn from(map: ScopeDataMap) -> Vec<ScopeData> {
+        map.scopes.into()
     }
 }

--- a/crates/emitter/src/scope.rs
+++ b/crates/emitter/src/scope.rs
@@ -1,0 +1,333 @@
+use crate::frame_slot::FrameSlot;
+use ast::associated_data::AssociatedData;
+use ast::source_atom_set::SourceAtomSetIndex;
+use ast::source_location_accessor::SourceLocationAccessor;
+use ast::type_id::NodeTypeIdAccessor;
+
+/// Corrsponds to js::BindingKind in m-c/js/src/vm/Scope.h,
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BindingKind {
+    Var,
+    Let,
+    Const,
+}
+
+/// Maps to js::BindingName in m-c/js/src/vm/Scope.h.
+#[derive(Debug)]
+pub struct BindingName {
+    pub name: SourceAtomSetIndex,
+    pub is_closed_over: bool,
+    pub is_top_level_function: bool,
+}
+
+impl BindingName {
+    pub fn new(name: SourceAtomSetIndex) -> Self {
+        Self {
+            name,
+            is_closed_over: false,
+            is_top_level_function: false,
+        }
+    }
+
+    pub fn new_top_level_function(name: SourceAtomSetIndex) -> Self {
+        Self {
+            name,
+            is_closed_over: false,
+            is_top_level_function: true,
+        }
+    }
+}
+
+/// Corresponds to the accessor part of js::BindingIter
+/// in m-c/js/src/vm/Scope.h.
+pub struct BindingIterItem<'a> {
+    name: &'a BindingName,
+    kind: BindingKind,
+}
+
+impl<'a> BindingIterItem<'a> {
+    fn new(name: &'a BindingName, kind: BindingKind) -> Self {
+        Self { name, kind }
+    }
+
+    pub fn name(&self) -> SourceAtomSetIndex {
+        self.name.name
+    }
+
+    pub fn is_top_level_function(&self) -> bool {
+        self.name.is_top_level_function
+    }
+
+    pub fn kind(&self) -> BindingKind {
+        self.kind
+    }
+}
+
+/// Bindings created in global environment.
+///
+/// Maps to js::GlobalScope::Data in m-c/js/src/vm/Scope.h.
+#[derive(Debug)]
+pub struct GlobalScopeData {
+    pub let_start: usize,
+    pub const_start: usize,
+
+    /// Corrsponds to GlobalScope::Data.{length, trailingNames}.
+    pub bindings: Vec<BindingName>,
+}
+
+impl GlobalScopeData {
+    pub fn new(var_count: usize, let_count: usize, const_count: usize) -> Self {
+        let capacity = var_count + let_count + const_count;
+
+        Self {
+            let_start: var_count,
+            const_start: var_count + let_count,
+            bindings: Vec::with_capacity(capacity),
+        }
+    }
+
+    pub fn iter<'a>(&'a self) -> GlobalBindingIter<'a> {
+        GlobalBindingIter::new(self)
+    }
+}
+
+/// Corrsponds to the iteration part of js::BindingIter
+/// in m-c/js/src/vm/Scope.h.
+pub struct GlobalBindingIter<'a> {
+    data: &'a GlobalScopeData,
+    i: usize,
+}
+
+impl<'a> GlobalBindingIter<'a> {
+    fn new(data: &'a GlobalScopeData) -> Self {
+        Self { data, i: 0 }
+    }
+}
+
+impl<'a> Iterator for GlobalBindingIter<'a> {
+    type Item = BindingIterItem<'a>;
+
+    fn next(&mut self) -> Option<BindingIterItem<'a>> {
+        if self.i == self.data.bindings.len() {
+            return None;
+        }
+
+        let kind = if self.i < self.data.let_start {
+            BindingKind::Var
+        } else if self.i < self.data.const_start {
+            BindingKind::Let
+        } else {
+            BindingKind::Const
+        };
+
+        let name = &self.data.bindings[self.i];
+
+        self.i += 1;
+
+        Some(BindingIterItem::new(name, kind))
+    }
+}
+
+/// Bindings created in lexical environment.
+///
+/// Maps to js::LexicalScope::Data in m-c/js/src/vm/Scope.h,
+/// and the parameter for js::frontend::ScopeCreationData::create
+/// in m-c/js/src/frontend/Stencil.h
+#[derive(Debug)]
+pub struct LexicalScopeData {
+    pub const_start: usize,
+
+    /// Corrsponds to LexicalScope::Data.{length, trailingNames}.
+    pub bindings: Vec<BindingName>,
+
+    /// The first frame slot of this scope.
+    ///
+    /// Unlike LexicalScope::Data, this struct holds the first frame slot,
+    /// instead of the next frame slot.
+    ///
+    /// This is because ScopeCreationData::create receives the first frame slot
+    /// and LexicalScope::Data.nextFrameSlot is calculated there.
+    pub first_frame_slot: FrameSlot,
+
+    /// ScopeIndex of the enclosing scope.
+    ///
+    /// A parameter for ScopeCreationData::create.
+    pub enclosing: ScopeIndex,
+}
+
+impl LexicalScopeData {
+    pub fn new(let_count: usize, const_count: usize, enclosing: ScopeIndex) -> Self {
+        let capacity = let_count + const_count;
+
+        Self {
+            const_start: let_count,
+            bindings: Vec::with_capacity(capacity),
+            // Set to the correct value in EmitterScopeStack::enter_lexical.
+            first_frame_slot: FrameSlot::new(0),
+            enclosing,
+        }
+    }
+
+    pub fn iter<'a>(&'a self) -> LexicalBindingIter<'a> {
+        LexicalBindingIter::new(self)
+    }
+}
+
+/// Corresponds to the iteration part of js::BindingIter
+/// in m-c/js/src/vm/Scope.h.
+pub struct LexicalBindingIter<'a> {
+    data: &'a LexicalScopeData,
+    i: usize,
+}
+
+impl<'a> LexicalBindingIter<'a> {
+    fn new(data: &'a LexicalScopeData) -> Self {
+        Self { data, i: 0 }
+    }
+}
+
+impl<'a> Iterator for LexicalBindingIter<'a> {
+    type Item = BindingIterItem<'a>;
+
+    fn next(&mut self) -> Option<BindingIterItem<'a>> {
+        if self.i == self.data.bindings.len() {
+            return None;
+        }
+
+        let kind = if self.i < self.data.const_start {
+            BindingKind::Let
+        } else {
+            BindingKind::Const
+        };
+
+        let name = &self.data.bindings[self.i];
+
+        self.i += 1;
+
+        Some(BindingIterItem::new(name, kind))
+    }
+}
+
+#[derive(Debug)]
+pub enum ScopeData {
+    Global(GlobalScopeData),
+    Lexical(LexicalScopeData),
+}
+
+/// Index into ScopeDataList.scopes.
+#[derive(Debug, Clone, Copy)]
+pub struct ScopeIndex {
+    index: usize,
+}
+impl ScopeIndex {
+    fn new(index: usize) -> Self {
+        Self { index }
+    }
+
+    pub fn into_raw(self) -> usize {
+        self.index
+    }
+}
+
+/// The list of all scope data.
+#[derive(Debug)]
+pub struct ScopeDataList {
+    /// Uses Option to make this populated later.
+    scopes: Vec<Option<ScopeData>>,
+}
+
+impl ScopeDataList {
+    pub fn new() -> Self {
+        Self { scopes: Vec::new() }
+    }
+
+    #[allow(dead_code)]
+    pub fn append(&mut self, scope: ScopeData) -> ScopeIndex {
+        let index = self.scopes.len();
+        self.scopes.push(Some(scope));
+        ScopeIndex::new(index)
+    }
+
+    pub fn allocate(&mut self) -> ScopeIndex {
+        let index = self.scopes.len();
+        self.scopes.push(None);
+        ScopeIndex::new(index)
+    }
+
+    pub fn populate(&mut self, index: ScopeIndex, scope: ScopeData) {
+        self.scopes[index.into_raw()].replace(scope);
+    }
+
+    fn get(&self, index: ScopeIndex) -> &ScopeData {
+        self.scopes[index.into_raw()]
+            .as_ref()
+            .expect("Should be populated")
+    }
+
+    fn get_mut(&mut self, index: ScopeIndex) -> &mut ScopeData {
+        self.scopes[index.into_raw()]
+            .as_mut()
+            .expect("Should be populated")
+    }
+
+    pub fn into_vec(mut self) -> Vec<ScopeData> {
+        self.scopes
+            .drain(..)
+            .map(|g| g.expect("Should be populated"))
+            .collect()
+    }
+}
+
+/// Scope data associated with AST node.
+#[derive(Debug)]
+pub struct ScopeDataMap {
+    scopes: ScopeDataList,
+    global: ScopeIndex,
+    non_global: AssociatedData<ScopeIndex>,
+}
+
+impl ScopeDataMap {
+    pub fn new(
+        scopes: ScopeDataList,
+        global: ScopeIndex,
+        non_global: AssociatedData<ScopeIndex>,
+    ) -> Self {
+        Self {
+            scopes,
+            global,
+            non_global,
+        }
+    }
+
+    pub fn get_global_index(&self) -> ScopeIndex {
+        self.global
+    }
+
+    pub fn get_global_at(&self, index: ScopeIndex) -> &GlobalScopeData {
+        match self.scopes.get(index) {
+            ScopeData::Global(scope) => scope,
+            _ => panic!("Unexpected scope data for global"),
+        }
+    }
+
+    pub fn get_index<NodeT>(&self, node: &NodeT) -> ScopeIndex
+    where
+        NodeT: SourceLocationAccessor + NodeTypeIdAccessor,
+    {
+        self.non_global
+            .get(node)
+            .expect("There should be a scope data associated")
+            .clone()
+    }
+
+    pub fn get_lexical_at_mut(&mut self, index: ScopeIndex) -> &mut LexicalScopeData {
+        match self.scopes.get_mut(index) {
+            ScopeData::Lexical(scope) => scope,
+            _ => panic!("Unexpected scope data for lexical"),
+        }
+    }
+
+    pub fn into_vec(self) -> Vec<ScopeData> {
+        self.scopes.into_vec()
+    }
+}

--- a/crates/emitter/src/scope_notes.rs
+++ b/crates/emitter/src/scope_notes.rs
@@ -1,0 +1,70 @@
+use crate::emitter::BytecodeOffset;
+use crate::scope::ScopeIndex;
+
+/// Maps to js::ScopeNote in m-c/js/src/vm//JSScript.h.
+#[derive(Debug)]
+pub struct ScopeNote {
+    pub scope_index: ScopeIndex,
+    pub start: BytecodeOffset,
+    pub end: BytecodeOffset,
+    pub parent: Option<ScopeNoteIndex>,
+}
+
+impl ScopeNote {
+    fn new(scope_index: ScopeIndex, start: BytecodeOffset, parent: Option<ScopeNoteIndex>) -> Self {
+        Self {
+            scope_index,
+            start: start.clone(),
+            end: start,
+            parent,
+        }
+    }
+}
+
+/// Index into ScopeNoteList.notes.
+#[derive(Debug, Clone, Copy)]
+pub struct ScopeNoteIndex {
+    index: usize,
+}
+
+impl ScopeNoteIndex {
+    fn new(index: usize) -> Self {
+        Self { index }
+    }
+
+    pub fn into_raw(self) -> usize {
+        self.index
+    }
+}
+
+/// List of scope notes.
+///
+/// Maps to JSScript::scopeNotes() in js/src/vm/JSScript.h.
+pub struct ScopeNoteList {
+    notes: Vec<ScopeNote>,
+}
+
+impl ScopeNoteList {
+    pub fn new() -> Self {
+        Self { notes: Vec::new() }
+    }
+
+    pub fn enter_scope(
+        &mut self,
+        scope_index: ScopeIndex,
+        offset: BytecodeOffset,
+        parent: Option<ScopeNoteIndex>,
+    ) -> ScopeNoteIndex {
+        let index = self.notes.len();
+        self.notes.push(ScopeNote::new(scope_index, offset, parent));
+        ScopeNoteIndex::new(index)
+    }
+
+    pub fn leave_scope(&mut self, index: ScopeNoteIndex, offset: BytecodeOffset) {
+        self.notes[index.into_raw()].end = offset;
+    }
+
+    pub fn into_vec(self) -> Vec<ScopeNote> {
+        self.notes
+    }
+}

--- a/crates/emitter/src/scope_notes.rs
+++ b/crates/emitter/src/scope_notes.rs
@@ -31,9 +31,11 @@ impl ScopeNoteIndex {
     fn new(index: usize) -> Self {
         Self { index }
     }
+}
 
-    pub fn into_raw(self) -> usize {
-        self.index
+impl From<ScopeNoteIndex> for usize {
+    fn from(index: ScopeNoteIndex) -> usize {
+        index.index
     }
 }
 
@@ -61,10 +63,12 @@ impl ScopeNoteList {
     }
 
     pub fn leave_scope(&mut self, index: ScopeNoteIndex, offset: BytecodeOffset) {
-        self.notes[index.into_raw()].end = offset;
+        self.notes[usize::from(index)].end = offset;
     }
+}
 
-    pub fn into_vec(self) -> Vec<ScopeNote> {
-        self.notes
+impl From<ScopeNoteList> for Vec<ScopeNote> {
+    fn from(list: ScopeNoteList) -> Vec<ScopeNote> {
+        list.notes
     }
 }

--- a/crates/emitter/src/scope_pass.rs
+++ b/crates/emitter/src/scope_pass.rs
@@ -1,0 +1,874 @@
+//! Collect bindings and generate scope data from AST.
+//! The information is used while emitting bytecode.
+
+use crate::scope::{
+    BindingName, GlobalScopeData, LexicalScopeData, ScopeData, ScopeDataList, ScopeDataMap,
+    ScopeIndex,
+};
+use ast::source_atom_set::SourceAtomSetIndex;
+use ast::{associated_data::AssociatedData, types::*, visit::Pass};
+use indexmap::set::IndexSet;
+use std::marker::PhantomData;
+
+/// The kind of items inside the result of VarScopedDeclarations.
+///
+/// This enum isn't actually used, but just for simplifying comment in
+/// ScopeKind.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq)]
+enum VarScopedDeclarationsItemKind {
+    /// Static Semantics: VarScopedDeclarations
+    /// https://tc39.es/ecma262/#sec-variable-statement-static-semantics-varscopeddeclarations
+    ///
+    /// VariableDeclarationList : VariableDeclaration
+    ///
+    /// 1. Return a new List containing VariableDeclaration.
+    ///
+    /// VariableDeclarationList : VariableDeclarationList, VariableDeclaration
+    ///
+    /// 1. Let declarations be VarScopedDeclarations of VariableDeclarationList.
+    /// 2. Append VariableDeclaration to declarations.
+    /// 3. Return declarations.
+    VariableDeclaration,
+
+    /// Static Semantics: VarScopedDeclarations
+    /// https://tc39.es/ecma262/#sec-for-in-and-for-of-statements-static-semantics-varscopeddeclarations
+    ///
+    /// IterationStatement :
+    ///   for ( var ForBinding in Expression ) Statement
+    ///   for ( var ForBinding of AssignmentExpression ) Statement
+    ///   for await ( var ForBinding of AssignmentExpression ) Statement
+    ///
+    /// 1. Let declarations be a List containing ForBinding.
+    /// 2. Append to declarations the elements of the VarScopedDeclarations of
+    ///    Statement.
+    /// 3. Return declarations.
+    ForBinding,
+
+    /// Static Semantics: VarScopedDeclarations
+    /// https://tc39.es/ecma262/#sec-function-definitions-static-semantics-varscopeddeclarations
+    ///
+    /// FunctionStatementList : StatementList
+    ///
+    /// 1. Return the TopLevelVarScopedDeclarations of StatementList.
+
+    /// Static Semantics: VarScopedDeclarations
+    /// https://tc39.es/ecma262/#sec-scripts-static-semantics-varscopeddeclarations
+    ///
+    /// ScriptBody : StatementList
+    ///
+    /// 1. Return TopLevelVarScopedDeclarations of StatementList.
+
+    /// Static Semantics: TopLevelVarScopedDeclarations
+    /// https://tc39.es/ecma262/#sec-block-static-semantics-toplevelvarscopeddeclarations
+    ///
+    /// StatementListItem : Declaration
+    ///
+    /// 1. If Declaration is Declaration : HoistableDeclaration, then
+    ///   a. Let declaration be DeclarationPart of HoistableDeclaration.
+    ///   b. Return « declaration ».
+    /// 2. Return a new empty List.
+
+    /// Static Semantics: DeclarationPart
+    /// https://tc39.es/ecma262/#sec-static-semantics-declarationpart
+    ///
+    /// HoistableDeclaration : FunctionDeclaration
+    ///
+    /// 1. Return FunctionDeclaration.
+    FunctionDeclaration,
+
+    /// HoistableDeclaration : GeneratorDeclaration
+    ///
+    /// 1. Return GeneratorDeclaration.
+    GeneratorDeclaration,
+
+    /// HoistableDeclaration : AsyncFunctionDeclaration
+    ///
+    /// 1. Return AsyncFunctionDeclaration.
+    AsyncFunctionDeclaration,
+
+    /// HoistableDeclaration : AsyncGeneratorDeclaration
+    ///
+    /// 1. Return AsyncGeneratorDeclaration.
+    AsyncGeneratorDeclaration,
+
+    /// Static Semantics: TopLevelVarScopedDeclarations
+    /// https://tc39.es/ecma262/#sec-labelled-statements-static-semantics-toplevelvarscopeddeclarations
+    ///
+    /// LabelledItem : FunctionDeclaration
+    ///
+    /// 1. Return a new List containing FunctionDeclaration.
+    /* FunctionDeclaration */
+
+    /// Annex B Initializers in ForIn Statement Heads
+    /// https://tc39.es/ecma262/#sec-initializers-in-forin-statement-heads
+    ///
+    /// IterationStatement :
+    ///   for ( var BindingIdentifier Initializer in Expression ) Statement
+    ///
+    /// 1. Let declarations be a List containing BindingIdentifier.
+    /// 2. Append to declarations the elements of the VarScopedDeclarations of
+    ///    Statement.
+    /// 3. Return declarations.
+    BindingIdentifier,
+}
+
+/// The kind of items inside the result of LexicallyScopedDeclarations.
+///
+/// This enum isn't actually used, but just for simplifying comment in
+/// ScopeKind.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq)]
+enum LexicallyScopedDeclarations {
+    /// Static Semantics: LexicallyScopedDeclarations
+    /// https://tc39.es/ecma262/#sec-block-static-semantics-lexicallyscopeddeclarations
+    ///
+    /// StatementListItem : Declaration
+    ///
+    /// 1. Return a new List containing DeclarationPart of Declaration.
+
+    /// Static Semantics: DeclarationPart
+    /// https://tc39.es/ecma262/#sec-static-semantics-declarationpart
+    ///
+    /// HoistableDeclaration : FunctionDeclaration
+    ///
+    /// 1. Return FunctionDeclaration.
+    FunctionDeclaration,
+
+    /// HoistableDeclaration : GeneratorDeclaration
+    ///
+    /// 1. Return GeneratorDeclaration.
+    GeneratorDeclaration,
+
+    /// HoistableDeclaration : AsyncFunctionDeclaration
+    ///
+    /// 1. Return AsyncFunctionDeclaration.
+    AsyncFunctionDeclaration,
+
+    /// HoistableDeclaration : AsyncGeneratorDeclaration
+    ///
+    /// 1. Return AsyncGeneratorDeclaration.
+    AsyncGeneratorDeclaration,
+
+    /// Declaration : ClassDeclaration
+    ///
+    /// 1. Return ClassDeclaration.
+    ClassDeclaration,
+
+    /// Declaration : LexicalDeclaration
+    ///
+    /// 1. Return LexicalDeclaration.
+    LexicalDeclarationWithLet,
+    LexicalDeclarationWithConst,
+
+    /// Static Semantics: LexicallyScopedDeclarations
+    /// https://tc39.es/ecma262/#sec-labelled-statements-static-semantics-lexicallyscopeddeclarations
+    ///
+    /// LabelledItem : FunctionDeclaration
+    ///
+    /// 1. Return a new List containing FunctionDeclaration.
+    /* FunctionDeclaration */
+
+    /// Static Semantics: LexicallyScopedDeclarations
+    /// https://tc39.es/ecma262/#sec-function-definitions-static-semantics-lexicallyscopeddeclarations
+    ///
+    /// FunctionStatementList : StatementList
+    ///
+    /// 1. Return the TopLevelLexicallyScopedDeclarations of StatementList.
+
+    /// Static Semantics: LexicallyScopedDeclarations
+    /// https://tc39.es/ecma262/#sec-scripts-static-semantics-lexicallyscopeddeclarations
+    ///
+    /// ScriptBody : StatementList
+    ///
+    /// 1. Return TopLevelLexicallyScopedDeclarations of StatementList.
+
+    /// Static Semantics: TopLevelLexicallyScopedDeclarations
+    /// https://tc39.es/ecma262/#sec-block-static-semantics-toplevellexicallyscopeddeclarations
+    ///
+    /// StatementListItem : Declaration
+    ///
+    /// 1. If Declaration is Declaration : HoistableDeclaration, then
+    ///   a. Return « ».
+    /// 2. Return a new List containing Declaration.
+
+    /// Static Semantics: LexicallyScopedDeclarations
+    /// https://tc39.es/ecma262/#sec-exports-static-semantics-lexicallyscopeddeclarations
+    ///
+    /// ExportDeclaration : export Declaration
+    ///
+    /// 1. Return a new List containing DeclarationPart of Declaration.
+
+    /// ExportDeclaration : export default HoistableDeclaration
+    ///
+    /// 1. Return a new List containing DeclarationPart of HoistableDeclaration.
+
+    /// ExportDeclaration : export default ClassDeclaration
+    ///
+    /// 1. Return a new List containing ClassDeclaration.
+    /* ClassDeclaration */
+
+    /// ExportDeclaration : export default AssignmentExpression ;
+    ///
+    /// 1. Return a new List containing this ExportDeclaration.
+    ExportDeclarationWithAssignmentExpression,
+}
+
+/// Items on the Context.scope_stack.
+/// Specifies the kind of BindingIdentifier.
+///
+/// This includes only BindingIdentifier that appears inside list or recursive
+/// structure.
+///
+/// BindingIdentifier that appears only once for a structure
+/// (e.g. Function.name) should be handled immediately, without using
+/// Context.scope_stack.
+#[derive(Debug, Clone, PartialEq)]
+enum ScopeKind {
+    /// VarScopedDeclarationsItemKind::VariableDeclaration
+    /// VarScopedDeclarationsItemKind::ForBinding
+    /// VarScopedDeclarationsItemKind::BindingIdentifier
+    Var,
+
+    /// LexicallyScopedDeclarations::LexicalDeclarationWithLet
+    Let,
+
+    /// LexicallyScopedDeclarations::LexicalDeclarationWithConst
+    Const,
+
+    #[allow(dead_code)]
+    FormalParameter,
+
+    #[allow(dead_code)]
+    CatchParameter,
+
+    /// LexicallyScopedDeclarations::ExportDeclarationWithAssignmentExpression
+    #[allow(dead_code)]
+    Export,
+
+    /// VarScopedDeclarationsItemKind::FunctionDeclaration
+    /// VarScopedDeclarationsItemKind::GeneratorDeclaration
+    /// VarScopedDeclarationsItemKind::AsyncFunctionDeclaration
+    /// VarScopedDeclarationsItemKind::AsyncGeneratorDeclaration
+    #[allow(dead_code)]
+    ScriptBodyStatementList,
+    #[allow(dead_code)]
+    FunctionStatementList,
+
+    /// LexicallyScopedDeclarations::FunctionDeclaration
+    /// LexicallyScopedDeclarations::GeneratorDeclaration
+    /// LexicallyScopedDeclarations::AsyncFunctionDeclaration
+    /// LexicallyScopedDeclarations::AsyncGeneratorDeclaration
+    /// LexicallyScopedDeclarations::ClassDeclaration
+    #[allow(dead_code)]
+    BlockStatementList,
+}
+
+/// Variables declared/used in GlobalDeclarationInstantiation.
+///
+/// Collected while visiting Script's fields, and used when leaving Script.
+#[derive(Debug)]
+struct GlobalContext {
+    /// Runtime Semantics: GlobalDeclarationInstantiation ( script, env )
+    /// https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
+    ///
+    /// Step 9. Let declaredFunctionNames be a new empty List.
+    declared_function_names: IndexSet<SourceAtomSetIndex>,
+
+    /// Step 11. Let declaredVarNames be a new empty List.
+    /// NOTE: This is slightly different than the spec that this can contain
+    ///       names in declaredFunctionNames.
+    ///       The duplication should be filtered before the use.
+    declared_var_names: IndexSet<SourceAtomSetIndex>,
+
+    /// Step 15. Let lexDeclarations be the LexicallyScopedDeclarations of
+    ///          script.
+    let_names: Vec<SourceAtomSetIndex>,
+    const_names: Vec<SourceAtomSetIndex>,
+
+    scope_index: ScopeIndex,
+    // FIXME: Step 8. Let functionsToInitialize be a new empty List.
+}
+
+impl GlobalContext {
+    fn new(scope_index: ScopeIndex) -> Self {
+        Self {
+            declared_function_names: IndexSet::new(),
+            declared_var_names: IndexSet::new(),
+            let_names: Vec::new(),
+            const_names: Vec::new(),
+            scope_index,
+        }
+    }
+
+    fn declare_var<'alloc>(&mut self, binding: &BindingIdentifier) {
+        // Runtime Semantics: GlobalDeclarationInstantiation ( script, env )
+        // https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
+        //
+        // Step 7. Let varDeclarations be the VarScopedDeclarations of script.
+        //
+        // Step 12. For each d in varDeclarations, do
+        // Step 12.a. If d is a VariableDeclaration, a ForBinding, or a
+        //            BindingIdentifier, then
+        // Step 12.a.i. For each String vn in the BoundNames of d, do
+        // (implicit)
+
+        // Step 12.a.i.i If vn is not an element of declaredFunctionNames, then
+        // (done in remove_function_names_from_var_names)
+
+        // Step 12.a.i.1.a. Let vnDefinable be ? envRec.CanDeclareGlobalVar(vn).
+        // Step 12.a.i.1.b. If vnDefinable is false, throw a TypeError
+        //                  exception.
+        // (done in runtime)
+
+        // Step 12.a.i.1.c. If vn is not an element of declaredVarNames, then
+        // Step 12.a.i.1.a.i. Append vn to declaredVarNames.
+        self.declared_var_names.insert(binding.name.value);
+    }
+
+    fn declare_let<'alloc>(&mut self, binding: &BindingIdentifier) {
+        // Runtime Semantics: GlobalDeclarationInstantiation ( script, env )
+        // https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
+        //
+        // Step 15. Let lexDeclarations be the LexicallyScopedDeclarations of
+        //          script.
+        self.let_names.push(binding.name.value);
+    }
+
+    fn declare_const<'alloc>(&mut self, binding: &BindingIdentifier) {
+        // Runtime Semantics: GlobalDeclarationInstantiation ( script, env )
+        // https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
+        //
+        // Step 15. Let lexDeclarations be the LexicallyScopedDeclarations of
+        //          script.
+        self.const_names.push(binding.name.value);
+    }
+
+    fn declare_function<'alloc>(&mut self, fun: &Function) {
+        // Step 10. For each d in varDeclarations, in reverse list order, do
+        // Step 10.a. If d is neither a VariableDeclaration nor a ForBinding
+        //            nor a BindingIdentifier, then
+        // (implicit)
+
+        // Step 10.a.i. Assert: d is either a FunctionDeclaration,
+        //              a GeneratorDeclaration, an AsyncFunctionDeclaration,
+        //              or an AsyncGeneratorDeclaration.
+
+        // Step 10.a.ii. NOTE: If there are multiple function declarations for
+        //               the same name, the last declaration is used.
+
+        // Step 10.a.iii. Let fn be the sole element of the BoundNames of d.
+        let fn_ = if let Some(ref name) = fun.name {
+            name.name.value
+        } else {
+            panic!("FunctionDeclaration should have name");
+        };
+
+        // Step 10.a.iv. If fn is not an element of declaredFunctionNames, then
+        //
+        // NOTE: Instead of iterating in reverse list oder, we iterate in
+        // normal order and overwrite existing item.
+
+        // Steps 10.a.iv.1-2.
+        // (done in runtime)
+
+        // Step 10.a.iv.3. Append fn to declaredFunctionNames.
+        self.declared_function_names.insert(fn_);
+
+        // Step 10.a.iv.4. Insert d as the first element of
+        //                 functionsToInitialize.
+        //
+        // Cannot do this given lifetime is unknown.
+        // (we can modify visitor to pass lifetime)
+        //self.functions_to_initialize.insert(fn_, fun);
+    }
+
+    fn remove_function_names_from_var_names(&mut self) {
+        // Runtime Semantics: GlobalDeclarationInstantiation ( script, env )
+        // https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
+        //
+        // Step 12.a.i.i If vn is not an element of declaredFunctionNames, then
+        //
+        // To avoid doing 2-pass, we note all var names, and filter function
+        // names out after visiting all of them.
+        for n in &self.declared_function_names {
+            self.declared_var_names.remove(n);
+        }
+    }
+
+    fn into_scope_data(self) -> ScopeData {
+        let mut data = GlobalScopeData::new(
+            self.declared_var_names.len() + self.declared_function_names.len(),
+            self.let_names.len(),
+            self.const_names.len(),
+        );
+
+        // Runtime Semantics: GlobalDeclarationInstantiation ( script, env )
+        // https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
+        //
+        // NOTE: Steps are reordered to match the order of binding in runtime.
+        //
+        // Step 18. For each String vn in declaredVarNames, in list order, do
+        for n in &self.declared_var_names {
+            // 18.a. Perform ? envRec.CreateGlobalVarBinding(vn, false).
+            data.bindings.push(BindingName::new(*n))
+        }
+
+        // Step 17. For each Parse Node f in functionsToInitialize, do
+        for n in &self.declared_function_names {
+            // Step 17.a. Let fn be the sole element of the BoundNames of f.
+            // Step 17.b. Let fo be InstantiateFunctionObject of f with
+            //            argument env.
+            // Step 17.c. Perform
+            //            ? envRec.CreateGlobalFunctionBinding(fn, fo, false).
+            //
+            // FIXME: for Annex B functions, use `new`.
+            data.bindings.push(BindingName::new_top_level_function(*n));
+        }
+
+        // Step 15. Let lexDeclarations be the LexicallyScopedDeclarations of
+        //          script.
+        // Step 16. For each element d in lexDeclarations, do
+        // Step 16.b. For each element dn of the BoundNames of d, do
+        for n in &self.let_names {
+            // Step 16.b.ii. Else,
+            // Step 16.b.ii.1. Perform ? envRec.CreateMutableBinding(dn, false).
+            data.bindings.push(BindingName::new(*n))
+        }
+        for n in &self.const_names {
+            // Step 16.b.i. If IsConstantDeclaration of d is true, then
+            // Step 16.b.i.1. Perform ? envRec.CreateImmutableBinding(dn, true).
+            data.bindings.push(BindingName::new(*n))
+        }
+
+        ScopeData::Global(data)
+    }
+}
+
+/// Variables declared/used in BlockDeclarationInstantiation
+///
+/// Collected while visiting Block's fields, and used when leaving Block.
+#[derive(Debug)]
+struct BlockContext {
+    /// Step 3. Let declarations be the LexicallyScopedDeclarations of code.
+    let_names: Vec<SourceAtomSetIndex>,
+    fun_names: Vec<SourceAtomSetIndex>,
+    const_names: Vec<SourceAtomSetIndex>,
+
+    /// Scope associated to this context.
+    scope_index: ScopeIndex,
+}
+
+impl BlockContext {
+    fn new(scope_index: ScopeIndex) -> Self {
+        Self {
+            let_names: Vec::new(),
+            fun_names: Vec::new(),
+            const_names: Vec::new(),
+            scope_index,
+        }
+    }
+
+    fn declare_let<'alloc>(&mut self, binding: &BindingIdentifier) {
+        // https://tc39.es/ecma262/#sec-blockdeclarationinstantiation
+        // Runtime Semantics: BlockDeclarationInstantiation ( code, env )
+        //
+        // Step 3. Let declarations be the LexicallyScopedDeclarations of code.
+        self.let_names.push(binding.name.value);
+    }
+
+    fn declare_const<'alloc>(&mut self, binding: &BindingIdentifier) {
+        // https://tc39.es/ecma262/#sec-blockdeclarationinstantiation
+        // Runtime Semantics: BlockDeclarationInstantiation ( code, env )
+        //
+        // Step 3. Let declarations be the LexicallyScopedDeclarations of code.
+        self.const_names.push(binding.name.value);
+    }
+
+    fn declare_function<'alloc>(&mut self, fun: &Function) {
+        // https://tc39.es/ecma262/#sec-blockdeclarationinstantiation
+        // Runtime Semantics: BlockDeclarationInstantiation ( code, env )
+        //
+        // Step 3. Let declarations be the LexicallyScopedDeclarations of code.
+
+        let fn_ = if let Some(ref name) = fun.name {
+            name.name.value
+        } else {
+            panic!("FunctionDeclaration should have name");
+        };
+
+        self.fun_names.push(fn_);
+    }
+
+    fn into_scope_data(self, enclosing: ScopeIndex) -> ScopeData {
+        // FIXME: Before this, perform Annex B for functions.
+
+        let mut data = LexicalScopeData::new(
+            self.let_names.len() + self.fun_names.len(),
+            self.const_names.len(),
+            enclosing,
+        );
+
+        // https://tc39.es/ecma262/#sec-blockdeclarationinstantiation
+        // Runtime Semantics: BlockDeclarationInstantiation ( code, env )
+        //
+        // Step 1. Let envRec be env's EnvironmentRecord.
+        // Step 2. Assert: envRec is a declarative Environment Record.
+        // (implicit)
+
+        // Step 4. For each element d in declarations, do
+        // Step 4.a. For each element dn of the BoundNames of d, do
+        for n in &self.let_names {
+            // Step 4.a.ii. Else,
+            // Step 4.a.ii.1. Perform ! envRec.CreateMutableBinding(dn, false).
+            data.bindings.push(BindingName::new(*n))
+        }
+        for n in &self.fun_names {
+            // Step 4.b. If d is a FunctionDeclaration, a GeneratorDeclaration,
+            //           an AsyncFunctionDeclaration,
+            //           or an AsyncGeneratorDeclaration, then
+            // Step 4.b.i. Let fn be the sole element of the BoundNames of d.
+            // Step 4.b.ii. Let fo be InstantiateFunctionObject of d with
+            //              argument env.
+            // Step 4.b.iii. Perform envRec.InitializeBinding(fn, fo).
+            data.bindings.push(BindingName::new(*n))
+        }
+        for n in &self.const_names {
+            // Step 4.a.i. If IsConstantDeclaration of d is true, then
+            // Step 4.a.i.1. Perform ! envRec.CreateImmutableBinding(dn, true).
+            data.bindings.push(BindingName::new(*n))
+        }
+
+        ScopeData::Lexical(data)
+    }
+}
+
+#[derive(Debug)]
+enum Context {
+    Global(GlobalContext),
+    Block(BlockContext),
+}
+
+impl Context {
+    fn get_scope_index(&self) -> ScopeIndex {
+        match self {
+            Context::Global(context) => context.scope_index,
+            Context::Block(context) => context.scope_index,
+        }
+    }
+}
+
+/// Tracks what kind of binding the BindingIdentifier node corresponds to.
+#[derive(Debug)]
+struct ScopeKindStack {
+    stack: Vec<ScopeKind>,
+}
+
+impl ScopeKindStack {
+    fn new() -> Self {
+        Self { stack: Vec::new() }
+    }
+
+    fn innermost<'a>(&'a self) -> &'a ScopeKind {
+        self.stack
+            .last()
+            .expect("There should be at least one scope on the stack")
+    }
+
+    fn push(&mut self, kind: ScopeKind) {
+        self.stack.push(kind)
+    }
+
+    fn pop(&mut self, kind: ScopeKind) {
+        match self.stack.pop() {
+            Some(k) if k == kind => {}
+            _ => panic!("unmatching scope kind"),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.stack.len() == 0
+    }
+}
+
+/// The stack of context for creating binding into.
+#[derive(Debug)]
+struct ContextStack {
+    stack: Vec<Context>,
+}
+
+impl ContextStack {
+    fn new() -> Self {
+        Self { stack: Vec::new() }
+    }
+
+    fn innermost_var<'a>(&'a mut self) -> &'a mut Context {
+        for context in self.stack.iter_mut().rev() {
+            match context {
+                Context::Global(_) => return context,
+                _ => {}
+            }
+        }
+
+        panic!("There should be at least one scope on the stack");
+    }
+
+    fn innermost_lexical<'a>(&'a mut self) -> &'a mut Context {
+        self.stack
+            .last_mut()
+            .expect("There should be at least one scope on the stack")
+    }
+
+    fn current_scope_index(&self) -> ScopeIndex {
+        self.stack
+            .last()
+            .expect("There should be at least one scope on the stack")
+            .get_scope_index()
+    }
+
+    fn push_global(&mut self, context: GlobalContext) {
+        self.stack.push(Context::Global(context))
+    }
+
+    fn pop_global(&mut self) -> GlobalContext {
+        match self.stack.pop() {
+            Some(Context::Global(context)) => context,
+            _ => panic!("unmatching context"),
+        }
+    }
+
+    fn push_block(&mut self, context: BlockContext) {
+        self.stack.push(Context::Block(context))
+    }
+
+    fn pop_block(&mut self) -> BlockContext {
+        match self.stack.pop() {
+            Some(Context::Block(context)) => context,
+            _ => panic!("unmatching context"),
+        }
+    }
+}
+
+/// Visit all nodes in the AST, and create a scope data.
+#[derive(Debug)]
+struct ScopePass<'alloc> {
+    scope_kind_stack: ScopeKindStack,
+    context_stack: ContextStack,
+    scopes: ScopeDataList,
+
+    /// The global scope information.
+    /// Using `Option` to make this field populated later.
+    global: Option<ScopeIndex>,
+
+    /// The map from non-global AST node to scope information.
+    non_global: AssociatedData<ScopeIndex>,
+
+    phantom: PhantomData<&'alloc ()>,
+}
+
+impl<'alloc> ScopePass<'alloc> {
+    fn new() -> Self {
+        Self {
+            scope_kind_stack: ScopeKindStack::new(),
+            context_stack: ContextStack::new(),
+            scopes: ScopeDataList::new(),
+            global: None,
+            non_global: AssociatedData::new(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'alloc> From<ScopePass<'alloc>> for ScopeDataMap {
+    fn from(pass: ScopePass<'alloc>) -> ScopeDataMap {
+        ScopeDataMap::new(
+            pass.scopes,
+            pass.global.expect("There should be global scope data"),
+            pass.non_global,
+        )
+    }
+}
+
+impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
+    fn enter_script(&mut self, _ast: &mut Script<'alloc>) {
+        // SetRealmGlobalObject ( realmRec, globalObj, thisValue )
+        // https://tc39.es/ecma262/#sec-setrealmglobalobject
+        //
+        // Steps 1-4, 7.
+        // (done in runtime)
+
+        // Step 5. Let newGlobalEnv be
+        //         NewGlobalEnvironment(globalObj, thisValue).
+        let index = self.scopes.allocate();
+        let context = GlobalContext::new(index);
+        self.global = Some(index);
+
+        // Step 6. Set realmRec.[[GlobalEnv]] to newGlobalEnv.
+        // (implicit)
+
+        // ScriptEvaluation ( scriptRecord )
+        // https://tc39.es/ecma262/#sec-runtime-semantics-scriptevaluation
+        //
+        // Step 1. Let globalEnv be scriptRecord.[[Realm]].[[GlobalEnv]].
+        // (implicit)
+
+        // Step 2. Let scriptContext be a new ECMAScript code execution context.
+        // (implicit)
+
+        // Steps 3-5.
+        // (done in runtime)
+
+        // Step 6. Set the VariableEnvironment of scriptContext to globalEnv.
+        // Step 7. Set the LexicalEnvironment of scriptContext to globalEnv.
+        self.context_stack.push_global(context);
+
+        // Steps 8-17.
+        // (done in runtime)
+    }
+
+    fn leave_script(&mut self, _ast: &mut Script<'alloc>) {
+        let mut context = self.context_stack.pop_global();
+
+        // Runtime Semantics: GlobalDeclarationInstantiation ( script, env )
+        // https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
+        //
+        // Steps 3-6.
+        // (done in runtime)
+
+        // Step 12.a.i.i If vn is not an element of declaredFunctionNames, then
+        context.remove_function_names_from_var_names();
+
+        // Step 14. NOTE: Annex B.3.3.2 adds additional steps at this point.
+        //
+        // FIXME: Implement
+
+        // Steps 15-18.
+        self.scopes
+            .populate(context.scope_index, context.into_scope_data());
+    }
+
+    fn enter_enum_statement_variant_block_statement(&mut self, block: &mut Block<'alloc>) {
+        // https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
+        // Runtime Semantics: Evaluation
+        //
+        // Block : { StatementList }
+        //
+        // Step 1. Let oldEnv be the running execution context's
+        //         LexicalEnvironment.
+        // (implicit)
+
+        // Step 2. Let blockEnv be NewDeclarativeEnvironment(oldEnv).
+        let index = self.scopes.allocate();
+        let context = BlockContext::new(index);
+        self.non_global.insert(block, index);
+
+        // Step 3. Perform
+        //         BlockDeclarationInstantiation(StatementList, blockEnv).
+        // (done in leave_enum_statement_variant_block_statement)
+
+        // Step 4. Set the running execution context's LexicalEnvironment to
+        //         blockEnv.
+        self.context_stack.push_block(context);
+
+        // Step 5. Let blockValue be the result of evaluating StatementList.
+        // (done in runtime)
+    }
+
+    fn leave_enum_statement_variant_block_statement(&mut self, _block: &mut Block<'alloc>) {
+        let context = self.context_stack.pop_block();
+        let enclosing = self.context_stack.current_scope_index();
+
+        // https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
+        // Runtime Semantics: Evaluation
+        //
+        // Block : { StatementList }
+        //
+        // Step 3. Perform
+        //         BlockDeclarationInstantiation(StatementList, blockEnv).
+        self.scopes
+            .populate(context.scope_index, context.into_scope_data(enclosing));
+
+        // Step 6. Set the running execution context's LexicalEnvironment to
+        //         oldEnv.
+
+        // Step 7. Return blockValue.
+        // (implicit)
+    }
+
+    fn enter_variable_declaration(&mut self, ast: &mut VariableDeclaration<'alloc>) {
+        match ast.kind {
+            VariableDeclarationKind::Var { .. } => {
+                self.scope_kind_stack.push(ScopeKind::Var);
+            }
+            VariableDeclarationKind::Let { .. } => {
+                self.scope_kind_stack.push(ScopeKind::Let);
+            }
+            VariableDeclarationKind::Const { .. } => {
+                self.scope_kind_stack.push(ScopeKind::Const);
+            }
+        }
+    }
+
+    fn leave_variable_declaration(&mut self, ast: &mut VariableDeclaration<'alloc>) {
+        match ast.kind {
+            VariableDeclarationKind::Var { .. } => {
+                self.scope_kind_stack.pop(ScopeKind::Var);
+            }
+            VariableDeclarationKind::Let { .. } => {
+                self.scope_kind_stack.pop(ScopeKind::Let);
+            }
+            VariableDeclarationKind::Const { .. } => {
+                self.scope_kind_stack.pop(ScopeKind::Const);
+            }
+        }
+    }
+
+    fn visit_binding_identifier(&mut self, ast: &mut BindingIdentifier) {
+        // NOTE: The following should be handled at the parent node,
+        // without visiting BindingIdentifier field:
+        //   * Function.name
+        //   * ClassExpression.name
+        //   * ClassDeclaration.name
+        //   * Import.default_binding
+        //   * ImportNamespace.default_binding
+        //   * ImportNamespace.namespace_binding
+        //   * ImportSpecifier.binding
+
+        if self.scope_kind_stack.is_empty() {
+            // FIXME
+            // Do nothing for unsupported case.
+            // Emitter will return NotImplemented anyway.
+            return;
+        }
+
+        match self.scope_kind_stack.innermost() {
+            ScopeKind::Var => match self.context_stack.innermost_var() {
+                Context::Global(ref mut context) => context.declare_var(ast),
+                _ => panic!("unexpected var context"),
+            },
+            ScopeKind::Let => match self.context_stack.innermost_lexical() {
+                Context::Global(ref mut context) => context.declare_let(ast),
+                Context::Block(ref mut context) => context.declare_let(ast),
+            },
+            ScopeKind::Const => match self.context_stack.innermost_lexical() {
+                Context::Global(ref mut context) => context.declare_const(ast),
+                Context::Block(ref mut context) => context.declare_const(ast),
+            },
+            _ => panic!("Not implemeneted"),
+        }
+    }
+
+    fn enter_enum_statement_variant_function_declaration(&mut self, ast: &mut Function<'alloc>) {
+        match self.context_stack.innermost_lexical() {
+            Context::Global(ref mut context) => context.declare_function(ast),
+            Context::Block(ref mut context) => context.declare_function(ast),
+        }
+    }
+}
+
+/// Visit all nodes in the AST, and create a scope data.
+pub fn generate_scope_data<'alloc>(ast: &mut Program<'alloc>) -> ScopeDataMap {
+    let mut scope_pass = ScopePass::new();
+    scope_pass.visit_program(ast);
+    scope_pass.into()
+}

--- a/crates/emitter/src/script_atom_set.rs
+++ b/crates/emitter/src/script_atom_set.rs
@@ -10,9 +10,11 @@ impl ScriptAtomSetIndex {
     fn new(index: u32) -> Self {
         Self { index }
     }
+}
 
-    pub fn into_raw(self) -> u32 {
-        self.index
+impl From<ScriptAtomSetIndex> for u32 {
+    fn from(index: ScriptAtomSetIndex) -> u32 {
+        index.index
     }
 }
 
@@ -35,8 +37,10 @@ impl ScriptAtomSet {
         let (index, _) = self.atoms.insert_full(value);
         ScriptAtomSetIndex::new(index as u32)
     }
+}
 
-    pub fn into_vec(mut self) -> Vec<SourceAtomSetIndex> {
-        self.atoms.drain(..).collect()
+impl From<ScriptAtomSet> for Vec<SourceAtomSetIndex> {
+    fn from(set: ScriptAtomSet) -> Vec<SourceAtomSetIndex> {
+        set.atoms.into_iter().collect()
     }
 }

--- a/crates/interpreter/src/evaluate.rs
+++ b/crates/interpreter/src/evaluate.rs
@@ -54,7 +54,7 @@ impl Helpers for EmitResult {
 
     fn read_atom(&self, offset: usize) -> String {
         let index = self.atoms[self.read_i32(offset) as usize];
-        self.all_atoms[index.into_raw()].clone()
+        self.all_atoms[index.into()].clone()
     }
 }
 


### PR DESCRIPTION
Implements scope handling for global and block lexical, excluding `eval` (that needs environment object):
  * Scope pass:
    * Added `BindingName` that's same thing as C++ one
    * Added `GlobalScopeData` and `LexicalScopeData`, corresponds to C++ `*Scope::Data`
    * Added `ScopeDataMap`, to associate scope data to AST node
    * Add `ScopePass` that replaces previous scope pass:
      * visits AST nodes and calculate scope/bindings, that's mostly scope handling part of C++ Parser, but uses similar structure as the spec
  * Emitter pass:
    * When entering/leaving script and block, handle scope, and emit necessary ops
    * Support `VariableDeclarationStatement`, to test scopes
    * Support `GCThing` with scope variant
    * Added prologue/main distinction, for `DefVar` etc
    * Support `ScopeNote`, that's same as C++ one
    * Calculate `maxFixedSlots`
    * Add `EmitterScope` and `EmitterScopeStack`, that does almost same thing as C++ `EmitterScope`:
      * provide lookup and iteration
      * tracks scope nesting
    * reference_op_emitter now supports `GlobalVar`, `GlobalLexical`, `FrameSlot`, and `Dynamic`
