### PR TITLE
Fix parser tests and bench

### DIFF
--- a/crates/parser/benches/parser.rs
+++ b/crates/parser/benches/parser.rs
@@ -1,9 +1,12 @@
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use bumpalo::Bump;
+use jsparagus_ast::source_atom_set::SourceAtomSet;
 use jsparagus_parser::{parse_script, ParseOptions};
 
 fn parser_bench(c: &mut Criterion) {
@@ -23,7 +26,8 @@ fn parser_bench(c: &mut Criterion) {
             b.iter(|| {
                 let allocator = &Bump::new();
                 let options = ParseOptions::new();
-                let _ = parse_script(allocator, program, &options);
+                let atoms = Rc::new(RefCell::new(SourceAtomSet::new()));
+                let _ = parse_script(allocator, program, &options, atoms.clone());
             });
         },
         tests,

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -3,9 +3,12 @@ use std::iter;
 use crate::lexer::Lexer;
 use crate::parser::Parser;
 use crate::{parse_script, ParseOptions};
+use ast::source_atom_set::SourceAtomSet;
 use ast::{arena, source_location::SourceLocation, types::*};
 use bumpalo::{self, Bump};
 use generated_parser::{self, AstBuilder, ParseError, Result, TerminalId};
+use std::cell::RefCell;
+use std::rc::Rc;
 
 #[cfg(all(feature = "unstable", test))]
 mod benchmarks {
@@ -66,7 +69,8 @@ where
 {
     let buf = arena::alloc_str(allocator, &chunks_to_string(code));
     let options = ParseOptions::new();
-    parse_script(allocator, &buf, &options)
+    let atoms = Rc::new(RefCell::new(SourceAtomSet::new()));
+    parse_script(allocator, &buf, &options, atoms.clone())
 }
 
 fn assert_parses<'alloc, T: IntoChunks<'alloc>>(code: T) {
@@ -128,11 +132,12 @@ fn assert_incomplete<'alloc, T: IntoChunks<'alloc>>(code: T) {
 // same sequence of tokens (although possibly at different offsets).
 fn assert_same_tokens<'alloc>(left: &str, right: &str) {
     let allocator = &Bump::new();
-    let mut left_lexer = Lexer::new(allocator, left.chars());
-    let mut right_lexer = Lexer::new(allocator, right.chars());
+    let atoms = Rc::new(RefCell::new(SourceAtomSet::new()));
+    let mut left_lexer = Lexer::new(allocator, left.chars(), atoms.clone());
+    let mut right_lexer = Lexer::new(allocator, right.chars(), atoms.clone());
 
     let mut parser = Parser::new(
-        AstBuilder::new(allocator),
+        AstBuilder::new(allocator, atoms.clone()),
         generated_parser::START_STATE_MODULE,
     );
 
@@ -163,9 +168,10 @@ fn assert_same_tokens<'alloc>(left: &str, right: &str) {
 fn assert_can_close_after<'alloc, T: IntoChunks<'alloc>>(code: T) {
     let allocator = &Bump::new();
     let buf = chunks_to_string(code);
-    let mut lexer = Lexer::new(allocator, buf.chars());
+    let atoms = Rc::new(RefCell::new(SourceAtomSet::new()));
+    let mut lexer = Lexer::new(allocator, buf.chars(), atoms.clone());
     let mut parser = Parser::new(
-        AstBuilder::new(allocator),
+        AstBuilder::new(allocator, atoms.clone()),
         generated_parser::START_STATE_SCRIPT,
     );
     loop {
@@ -438,6 +444,7 @@ fn test_awkward_chunks() {
 
     let allocator = &Bump::new();
     let actual = try_parse(allocator, &vec!["x/", "=2;"]).unwrap();
+    let atoms = Rc::new(RefCell::new(SourceAtomSet::new()));
     let expected = Script {
         directives: arena::Vec::new_in(allocator),
         statements: bumpalo::vec![
@@ -451,7 +458,7 @@ fn test_awkward_chunks() {
                     binding: SimpleAssignmentTarget::AssignmentTargetIdentifier(
                         AssignmentTargetIdentifier {
                             name: Identifier {
-                                value: "x",
+                                value: atoms.borrow_mut().insert("x"),
                                 loc: SourceLocation::new(0, 1),
                             },
                             loc: SourceLocation::new(0, 1),
@@ -459,10 +466,10 @@ fn test_awkward_chunks() {
                     ),
                     expression: arena::alloc(
                         allocator,
-                        Expression::LiteralNumericExpression {
+                        Expression::LiteralNumericExpression(NumericLiteral {
                             value: 2.0,
                             loc: SourceLocation::new(3, 4),
-                        },
+                        }),
                     ),
                     loc: SourceLocation::new(0, 4),
                 },


### PR DESCRIPTION
This fixes the `cargo test` and `cargo bench` in the parser crate.