### PR TITLE
 Do not allocate String while atomization (fixes #397) 

### DIFF
--- a/crates/ast/src/source_atom_set.rs
+++ b/crates/ast/src/source_atom_set.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use indexmap::set::IndexSet;
 
 /// Index into SourceAtomSet.atoms.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -160,18 +160,14 @@ for_all_common_atoms!(define_struct);
 /// WARNING: This set itself does *NOT* map to JSScript::atoms().
 #[derive(Debug)]
 pub struct SourceAtomSet<'alloc> {
-    atoms: Vec<&'alloc str>,
-
-    /// Cache for the case the same string is inserted multiple times.
-    atom_indices: HashMap<&'alloc str, SourceAtomSetIndex>,
+    atoms: IndexSet<&'alloc str>,
 }
 
 impl<'alloc> SourceAtomSet<'alloc> {
     // Create a set, with all common atoms inserted.
     pub fn new() -> Self {
         let mut result = Self {
-            atoms: Vec::new(),
-            atom_indices: HashMap::new(),
+            atoms: IndexSet::new(),
         };
         result.insert_common_atoms();
         result
@@ -183,10 +179,7 @@ impl<'alloc> SourceAtomSet<'alloc> {
             ($self: ident,
              $(($s:tt, $method:ident, $variant:ident),)*) => {
                 $(
-                    $self.atoms.push($s);
-                    $self
-                        .atom_indices
-                        .insert($s, CommonSourceAtomSetIndices::$method());
+                    $self.atoms.insert($s);
                 )*
             };
         }
@@ -199,31 +192,22 @@ impl<'alloc> SourceAtomSet<'alloc> {
     // it with the result of this method.
     pub fn new_uninitialized() -> Self {
         Self {
-            atoms: Vec::new(),
-            atom_indices: HashMap::new(),
+            atoms: IndexSet::new(),
         }
     }
 
     pub fn insert(&mut self, s: &'alloc str) -> SourceAtomSetIndex {
-        match self.atom_indices.get(s) {
-            Some(index) => return *index,
-            _ => {}
-        }
-
-        let index = self.atoms.len();
-        self.atoms.push(s);
-        let result = SourceAtomSetIndex::new(index);
-        self.atom_indices.insert(s, result);
-        result
+        let (index, _) = self.atoms.insert_full(s);
+        SourceAtomSetIndex::new(index)
     }
 
     pub fn get(&self, index: SourceAtomSetIndex) -> &'alloc str {
-        self.atoms[usize::from(index)].clone()
+        self.atoms.get_index(usize::from(index)).unwrap()
     }
 }
 
 impl<'alloc> From<SourceAtomSet<'alloc>> for Vec<&'alloc str> {
     fn from(set: SourceAtomSet<'alloc>) -> Vec<&'alloc str> {
-        set.atoms
+        set.atoms.into_iter().collect()
     }
 }

--- a/crates/ast/src/source_atom_set.rs
+++ b/crates/ast/src/source_atom_set.rs
@@ -160,7 +160,7 @@ for_all_common_atoms!(define_struct);
 /// WARNING: This set itself does *NOT* map to JSScript::atoms().
 #[derive(Debug)]
 pub struct SourceAtomSet<'alloc> {
-    atoms: Vec<String>,
+    atoms: Vec<&'alloc str>,
 
     /// Cache for the case the same string is inserted multiple times.
     atom_indices: HashMap<&'alloc str, SourceAtomSetIndex>,
@@ -183,7 +183,7 @@ impl<'alloc> SourceAtomSet<'alloc> {
             ($self: ident,
              $(($s:tt, $method:ident, $variant:ident),)*) => {
                 $(
-                    $self.atoms.push($s.to_string());
+                    $self.atoms.push($s);
                     $self
                         .atom_indices
                         .insert($s, CommonSourceAtomSetIndices::$method());
@@ -211,19 +211,19 @@ impl<'alloc> SourceAtomSet<'alloc> {
         }
 
         let index = self.atoms.len();
-        self.atoms.push(s.to_string());
+        self.atoms.push(s);
         let result = SourceAtomSetIndex::new(index);
         self.atom_indices.insert(s, result);
         result
     }
 
-    pub fn get(&self, index: SourceAtomSetIndex) -> String {
+    pub fn get(&self, index: SourceAtomSetIndex) -> &'alloc str {
         self.atoms[usize::from(index)].clone()
     }
 }
 
-impl<'alloc> From<SourceAtomSet<'alloc>> for Vec<String> {
-    fn from(set: SourceAtomSet<'alloc>) -> Vec<String> {
+impl<'alloc> From<SourceAtomSet<'alloc>> for Vec<&'alloc str> {
+    fn from(set: SourceAtomSet<'alloc>) -> Vec<&'alloc str> {
         set.atoms
     }
 }

--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -23,7 +23,7 @@ pub fn emit_program<'alloc>(
     options: &EmitOptions,
     atoms: SourceAtomSet<'alloc>,
     scope_data_map: ScopeDataMap,
-) -> Result<EmitResult, EmitError> {
+) -> Result<EmitResult<'alloc>, EmitError> {
     let mut emitter = AstEmitter::new(options, atoms, scope_data_map);
 
     match ast {

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -17,7 +17,6 @@ use byteorder::{ByteOrder, LittleEndian};
 use std::cmp;
 use std::convert::TryInto;
 use std::fmt;
-use std::marker::PhantomData;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ResumeKind {
@@ -98,7 +97,7 @@ impl EmitOptions {
 pub struct EmitResult<'alloc> {
     pub bytecode: Vec<u8>,
     pub atoms: Vec<SourceAtomSetIndex>,
-    pub all_atoms: Vec<String>,
+    pub all_atoms: Vec<&'alloc str>,
     pub gcthings: Vec<GCThing>,
     pub scopes: Vec<ScopeData>,
     pub scope_notes: Vec<ScopeNote>,
@@ -123,9 +122,6 @@ pub struct EmitResult<'alloc> {
     pub has_non_syntactic_scope: bool,
     pub needs_function_environment_objects: bool,
     pub has_module_goal: bool,
-
-    // NOTE: Removed in the next patch.
-    phantom: PhantomData<&'alloc ()>,
 }
 
 /// The error of bytecode-compilation.
@@ -195,9 +191,6 @@ impl InstructionWriter {
             has_non_syntactic_scope: false,
             needs_function_environment_objects: false,
             has_module_goal: false,
-
-            // NOTE: Removed in the next patch.
-            phantom: PhantomData,
         }
     }
 

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -17,6 +17,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use std::cmp;
 use std::convert::TryInto;
 use std::fmt;
+use std::marker::PhantomData;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ResumeKind {
@@ -94,7 +95,7 @@ impl EmitOptions {
 
 /// The output of bytecode-compiling a script or module.
 #[derive(Debug)]
-pub struct EmitResult {
+pub struct EmitResult<'alloc> {
     pub bytecode: Vec<u8>,
     pub atoms: Vec<SourceAtomSetIndex>,
     pub all_atoms: Vec<String>,
@@ -122,6 +123,9 @@ pub struct EmitResult {
     pub has_non_syntactic_scope: bool,
     pub needs_function_environment_objects: bool,
     pub has_module_goal: bool,
+
+    // NOTE: Removed in the next patch.
+    phantom: PhantomData<&'alloc ()>,
 }
 
 /// The error of bytecode-compilation.
@@ -155,7 +159,10 @@ impl InstructionWriter {
         }
     }
 
-    pub fn into_emit_result(self, compilation_info: CompilationInfo) -> EmitResult {
+    pub fn into_emit_result<'alloc>(
+        self,
+        compilation_info: CompilationInfo<'alloc>,
+    ) -> EmitResult<'alloc> {
         EmitResult {
             bytecode: self.bytecode,
             atoms: self.atoms.into(),
@@ -188,6 +195,9 @@ impl InstructionWriter {
             has_non_syntactic_scope: false,
             needs_function_environment_objects: false,
             has_module_goal: false,
+
+            // NOTE: Removed in the next patch.
+            phantom: PhantomData,
         }
     }
 

--- a/crates/emitter/src/lib.rs
+++ b/crates/emitter/src/lib.rs
@@ -28,7 +28,7 @@ pub fn emit<'alloc>(
     ast: &mut ast::types::Program,
     options: &EmitOptions,
     atoms: SourceAtomSet<'alloc>,
-) -> Result<EmitResult, EmitError> {
+) -> Result<EmitResult<'alloc>, EmitError> {
     let scope_data_map = scope_pass::generate_scope_data(ast);
     ast_emitter::emit_program(ast, options, atoms, scope_data_map)
 }

--- a/crates/generated_parser/src/ast_builder.rs
+++ b/crates/generated_parser/src/ast_builder.rs
@@ -123,9 +123,9 @@ impl<'alloc> AstBuilder<'alloc> {
         vec![in self.allocator; value]
     }
 
-    fn collect_vec_from_results<T, C>(&self, results: C) -> Result<arena::Vec<'alloc, T>>
+    fn collect_vec_from_results<T, C>(&self, results: C) -> Result<'alloc, arena::Vec<'alloc, T>>
     where
-        C: IntoIterator<Item = Result<T>>,
+        C: IntoIterator<Item = Result<'alloc, T>>,
     {
         let mut out = self.new_vec();
         for result in results {
@@ -146,7 +146,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn identifier_reference(
         &self,
         token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Identifier>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Identifier>> {
         self.on_identifier_reference(&token)?;
         Ok(self.alloc(self.identifier(token)))
     }
@@ -155,7 +155,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn binding_identifier(
         &mut self,
         token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, BindingIdentifier>> {
+    ) -> Result<'alloc, arena::Box<'alloc, BindingIdentifier>> {
         self.on_binding_identifier(&token)?;
         let loc = token.loc;
         Ok(self.alloc(BindingIdentifier {
@@ -168,7 +168,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn binding_identifier_yield(
         &mut self,
         token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, BindingIdentifier>> {
+    ) -> Result<'alloc, arena::Box<'alloc, BindingIdentifier>> {
         self.on_binding_identifier(&token)?;
         let loc = token.loc;
         Ok(self.alloc(BindingIdentifier {
@@ -184,7 +184,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn binding_identifier_await(
         &mut self,
         token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, BindingIdentifier>> {
+    ) -> Result<'alloc, arena::Box<'alloc, BindingIdentifier>> {
         self.on_binding_identifier(&token)?;
         let loc = token.loc;
         Ok(self.alloc(BindingIdentifier {
@@ -200,7 +200,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn label_identifier(
         &self,
         token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Label>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Label>> {
         self.on_label_identifier(&token)?;
         let loc = token.loc;
         Ok(self.alloc(Label {
@@ -265,7 +265,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn uncover_parenthesized_expression(
         &self,
         parenthesized: arena::Box<'alloc, CoverParenthesized<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         match parenthesized.unbox() {
             CoverParenthesized::Expression { expression, .. } => {
                 // TODO - does this need to rewalk the expression to look for
@@ -301,7 +301,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn assignment_target_maybe_default_to_binding(
         &self,
         target: AssignmentTargetMaybeDefault<'alloc>,
-    ) -> Result<Parameter<'alloc>> {
+    ) -> Result<'alloc, Parameter<'alloc>> {
         match target {
             AssignmentTargetMaybeDefault::AssignmentTarget(target) => Ok(Parameter::Binding(
                 self.assignment_target_to_binding(target)?,
@@ -320,7 +320,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn assignment_target_property_to_binding_property(
         &self,
         target: AssignmentTargetProperty<'alloc>,
-    ) -> Result<BindingProperty<'alloc>> {
+    ) -> Result<'alloc, BindingProperty<'alloc>> {
         Ok(match target {
             AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(
                 AssignmentTargetPropertyIdentifier {
@@ -348,7 +348,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn assignment_rest_property_to_binding_identifier(
         &self,
         target: AssignmentTarget<'alloc>,
-    ) -> Result<arena::Box<'alloc, BindingIdentifier>> {
+    ) -> Result<'alloc, arena::Box<'alloc, BindingIdentifier>> {
         match target {
             // ({...x} = dv) => {}
             AssignmentTarget::SimpleAssignmentTarget(
@@ -381,7 +381,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn assignment_target_to_binding(
         &self,
         target: AssignmentTarget<'alloc>,
-    ) -> Result<Binding<'alloc>> {
+    ) -> Result<'alloc, Binding<'alloc>> {
         match target {
             // (a = dv) => {}
             AssignmentTarget::SimpleAssignmentTarget(
@@ -414,8 +414,8 @@ impl<'alloc> AstBuilder<'alloc> {
                             .map(|target| self.assignment_target_maybe_default_to_binding(target))
                             .transpose()
                     }))?;
-                let rest: Option<Result<arena::Box<'alloc, Binding<'alloc>>>> = rest.map(
-                    |rest_target| -> Result<arena::Box<'alloc, Binding<'alloc>>> {
+                let rest: Option<Result<'alloc, arena::Box<'alloc, Binding<'alloc>>>> = rest.map(
+                    |rest_target| -> Result<'alloc, arena::Box<'alloc, Binding<'alloc>>> {
                         Ok(self.alloc(self.assignment_target_to_binding(rest_target.unbox())?))
                     },
                 );
@@ -461,7 +461,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn object_property_to_binding_property(
         &self,
         op: ObjectProperty<'alloc>,
-    ) -> Result<BindingProperty<'alloc>> {
+    ) -> Result<'alloc, BindingProperty<'alloc>> {
         match op {
             ObjectProperty::NamedObjectProperty(NamedObjectProperty::DataProperty(
                 DataProperty {
@@ -507,7 +507,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn spread_expression_to_rest_binding(
         &self,
         expression: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<arena::Box<'alloc, BindingIdentifier>> {
+    ) -> Result<'alloc, arena::Box<'alloc, BindingIdentifier>> {
         Ok(match expression.unbox() {
             Expression::IdentifierExpression(IdentifierExpression { name, loc }) => {
                 self.alloc(BindingIdentifier { name, loc })
@@ -539,7 +539,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn object_expression_to_object_binding(
         &self,
         object: ObjectExpression<'alloc>,
-    ) -> Result<ObjectBinding<'alloc>> {
+    ) -> Result<'alloc, ObjectBinding<'alloc>> {
         let mut properties = object.properties;
         let loc = object.loc;
         let rest = self.pop_trailing_spread_property(&mut properties);
@@ -559,7 +559,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn array_elements_to_parameters(
         &self,
         elements: arena::Vec<'alloc, ArrayExpressionElement<'alloc>>,
-    ) -> Result<arena::Vec<'alloc, Option<Parameter<'alloc>>>> {
+    ) -> Result<'alloc, arena::Vec<'alloc, Option<Parameter<'alloc>>>> {
         self.collect_vec_from_results(elements.into_iter().map(|element| match element {
                 ArrayExpressionElement::Expression(expr) =>
                     Ok(Some(self.expression_to_parameter(expr.unbox())?)),
@@ -590,7 +590,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn expression_to_binding_no_default(
         &self,
         expression: Expression<'alloc>,
-    ) -> Result<Binding<'alloc>> {
+    ) -> Result<'alloc, Binding<'alloc>> {
         match expression {
             Expression::IdentifierExpression(IdentifierExpression { name, loc }) => {
                 Ok(Binding::BindingIdentifier(BindingIdentifier { name, loc }))
@@ -624,7 +624,10 @@ impl<'alloc> AstBuilder<'alloc> {
         }
     }
 
-    fn expression_to_parameter(&self, expression: Expression<'alloc>) -> Result<Parameter<'alloc>> {
+    fn expression_to_parameter(
+        &self,
+        expression: Expression<'alloc>,
+    ) -> Result<'alloc, Parameter<'alloc>> {
         match expression {
             Expression::AssignmentExpression {
                 binding,
@@ -648,7 +651,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn expression_to_parameter_list(
         &self,
         expression: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<arena::Vec<'alloc, Parameter<'alloc>>> {
+    ) -> Result<'alloc, arena::Vec<'alloc, Parameter<'alloc>>> {
         // When the production
         // *ArrowParameters* `:` *CoverParenthesizedExpressionAndArrowParameterList*
         // is recognized the following grammar is used to refine the
@@ -680,7 +683,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn arguments_to_parameter_list(
         &self,
         arguments: Arguments<'alloc>,
-    ) -> Result<arena::Box<'alloc, FormalParameters<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, FormalParameters<'alloc>>> {
         let loc = arguments.loc;
         let mut items = self.new_vec();
         let mut rest: Option<Binding<'alloc>> = None;
@@ -755,7 +758,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn numeric_literal(
         &self,
         token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         let loc = token.loc;
         Ok(
             self.alloc(Expression::LiteralNumericExpression(NumericLiteral {
@@ -773,7 +776,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn bigint_literal(
         &self,
         _token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         Err(ParseError::NotImplemented("BigInt"))
     }
 
@@ -781,7 +784,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn string_literal(
         &self,
         token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         let loc = token.loc;
         // Hack: Prevent emission for scripts with "use strict"
         // directive.
@@ -1046,7 +1049,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn property_name_identifier(
         &self,
         token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, PropertyName<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, PropertyName<'alloc>>> {
         let value = token.value.as_atom();
         if value == CommonSourceAtomSetIndices::__proto__() {
             return Err(ParseError::NotImplemented("__proto__ as property name"));
@@ -1065,7 +1068,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn property_name_string(
         &self,
         token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, PropertyName<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, PropertyName<'alloc>>> {
         let value = token.value.as_atom();
         if value == CommonSourceAtomSetIndices::__proto__() {
             return Err(ParseError::NotImplemented("__proto__ as property name"));
@@ -1084,7 +1087,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn property_name_numeric(
         &self,
         token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, PropertyName<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, PropertyName<'alloc>>> {
         let loc = token.loc;
         let value = Self::numeric_literal_value(token);
         Ok(
@@ -1103,7 +1106,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn property_name_bigint(
         &self,
         _token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, PropertyName<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, PropertyName<'alloc>>> {
         Err(ParseError::NotImplemented("BigInt"))
     }
 
@@ -1125,7 +1128,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         _name: arena::Box<'alloc, Identifier>,
         _initializer: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<arena::Box<'alloc, ObjectProperty<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, ObjectProperty<'alloc>>> {
         // Awkward. This needs to be stored somehow until we reach an enclosing
         // context where it can be reinterpreted as a default value in an
         // object destructuring assignment pattern.
@@ -1158,7 +1161,7 @@ impl<'alloc> AstBuilder<'alloc> {
         _head: arena::Box<'alloc, Token>,
         _expression: arena::Box<'alloc, Expression<'alloc>>,
         _spans: arena::Box<'alloc, Void>,
-    ) -> Result<arena::Box<'alloc, TemplateExpression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, TemplateExpression<'alloc>>> {
         Err(ParseError::NotImplemented("template strings"))
     }
 
@@ -1168,7 +1171,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         _middle_list: Option<arena::Box<'alloc, Void>>,
         _tail: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("template strings"))
     }
 
@@ -1177,7 +1180,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         _middle: arena::Box<'alloc, Token>,
         _expression: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("template strings"))
     }
 
@@ -1187,7 +1190,7 @@ impl<'alloc> AstBuilder<'alloc> {
         _middle_list: arena::Box<'alloc, Void>,
         _middle: arena::Box<'alloc, Token>,
         _expression: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("template strings"))
     }
 
@@ -1274,7 +1277,7 @@ impl<'alloc> AstBuilder<'alloc> {
     // OptionalChain : `?.` TemplateLiteral
     pub fn error_optional_chain_with_template(
         &self,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         Err(ParseError::IllegalCharacter('`'))
     }
 
@@ -1591,7 +1594,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         operand: arena::Box<'alloc, Expression<'alloc>>,
         operator_token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         let operand = self.expression_to_simple_assignment_target(operand)?;
         let operand_loc = operand.get_loc();
         Ok(self.alloc(Expression::UpdateExpression {
@@ -1609,7 +1612,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         operand: arena::Box<'alloc, Expression<'alloc>>,
         operator_token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         let operand = self.expression_to_simple_assignment_target(operand)?;
         let operand_loc = operand.get_loc();
         Ok(self.alloc(Expression::UpdateExpression {
@@ -1627,7 +1630,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         operator_token: arena::Box<'alloc, Token>,
         operand: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         let operand = self.expression_to_simple_assignment_target(operand)?;
         let operand_loc = operand.get_loc();
         Ok(self.alloc(Expression::UpdateExpression {
@@ -1645,7 +1648,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         operator_token: arena::Box<'alloc, Token>,
         operand: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         let operand = self.expression_to_simple_assignment_target(operand)?;
         let operand_loc = operand.get_loc();
         Ok(self.alloc(Expression::UpdateExpression {
@@ -1925,7 +1928,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         mut elements: arena::Vec<'alloc, ArrayExpressionElement<'alloc>>,
         loc: SourceLocation,
-    ) -> Result<ArrayAssignmentTarget<'alloc>> {
+    ) -> Result<'alloc, ArrayAssignmentTarget<'alloc>> {
         let spread = self.pop_trailing_spread_element(&mut elements);
         let elements =
             self.collect_vec_from_results(elements.into_iter().map(|element| match element {
@@ -1937,7 +1940,7 @@ impl<'alloc> AstBuilder<'alloc> {
                 )),
                 ArrayExpressionElement::Elision { .. } => Ok(None),
             }))?;
-        let rest: Option<Result<arena::Box<'alloc, AssignmentTarget<'alloc>>>> =
+        let rest: Option<Result<'alloc, arena::Box<'alloc, AssignmentTarget<'alloc>>>> =
             spread.map(|expr| Ok(self.alloc(self.expression_to_assignment_target(expr)?)));
         let rest = rest.transpose()?;
         Ok(ArrayAssignmentTarget {
@@ -1950,7 +1953,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn object_property_to_assignment_target_property(
         &self,
         property: arena::Box<'alloc, ObjectProperty<'alloc>>,
-    ) -> Result<AssignmentTargetProperty<'alloc>> {
+    ) -> Result<'alloc, AssignmentTargetProperty<'alloc>> {
         Ok(match property.unbox() {
             ObjectProperty::NamedObjectProperty(NamedObjectProperty::MethodDefinition(_)) => {
                 return Err(ParseError::ObjectPatternWithMethod)
@@ -1995,14 +1998,14 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         mut properties: arena::Vec<'alloc, arena::Box<'alloc, ObjectProperty<'alloc>>>,
         loc: SourceLocation,
-    ) -> Result<ObjectAssignmentTarget<'alloc>> {
+    ) -> Result<'alloc, ObjectAssignmentTarget<'alloc>> {
         let spread = self.pop_trailing_spread_property(&mut properties);
         let properties = self.collect_vec_from_results(
             properties
                 .into_iter()
                 .map(|p| self.object_property_to_assignment_target_property(p)),
         )?;
-        let rest: Option<Result<arena::Box<'alloc, AssignmentTarget<'alloc>>>> =
+        let rest: Option<Result<'alloc, arena::Box<'alloc, AssignmentTarget<'alloc>>>> =
             spread.map(|expr| Ok(self.alloc(self.expression_to_assignment_target(expr)?)));
         let rest = rest.transpose()?;
         Ok(ObjectAssignmentTarget {
@@ -2015,7 +2018,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn expression_to_assignment_target_maybe_default(
         &self,
         expression: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<AssignmentTargetMaybeDefault<'alloc>> {
+    ) -> Result<'alloc, AssignmentTargetMaybeDefault<'alloc>> {
         Ok(match expression.unbox() {
             Expression::AssignmentExpression {
                 binding,
@@ -2038,7 +2041,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn expression_to_assignment_target(
         &self,
         expression: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<AssignmentTarget<'alloc>> {
+    ) -> Result<'alloc, AssignmentTarget<'alloc>> {
         Ok(match expression.unbox() {
             Expression::ArrayExpression(ArrayExpression { elements, loc }) => {
                 AssignmentTarget::AssignmentTargetPattern(
@@ -2065,7 +2068,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn expression_to_simple_assignment_target(
         &self,
         expression: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<SimpleAssignmentTarget<'alloc>> {
+    ) -> Result<'alloc, SimpleAssignmentTarget<'alloc>> {
         Ok(match expression.unbox() {
             // Static Semantics: AssignmentTargetType
             // https://tc39.es/ecma262/#sec-identifiers-static-semantics-assignmenttargettype
@@ -2163,7 +2166,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         left_hand_side: arena::Box<'alloc, Expression<'alloc>>,
         value: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         let target = self.expression_to_assignment_target(left_hand_side)?;
         let target_loc = target.get_loc();
         let value_loc = value.get_loc();
@@ -2242,7 +2245,7 @@ impl<'alloc> AstBuilder<'alloc> {
         left_hand_side: arena::Box<'alloc, Expression<'alloc>>,
         operator: arena::Box<'alloc, CompoundAssignmentOperator>,
         value: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         let target = self.expression_to_simple_assignment_target(left_hand_side)?;
         let target_loc = target.get_loc();
         let value_loc = value.get_loc();
@@ -2272,7 +2275,7 @@ impl<'alloc> AstBuilder<'alloc> {
         open_token: arena::Box<'alloc, Token>,
         statements: Option<arena::Box<'alloc, arena::Vec<'alloc, Statement<'alloc>>>>,
         close_token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Block<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Block<'alloc>>> {
         self.check_block_bindings(open_token.loc.start)?;
 
         Ok(self.alloc(Block {
@@ -2328,7 +2331,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &mut self,
         kind: arena::Box<'alloc, VariableDeclarationKind>,
         declarators: arena::Box<'alloc, arena::Vec<'alloc, VariableDeclarator<'alloc>>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         let binding_kind = match &*kind {
             VariableDeclarationKind::Let { .. } => BindingKind::Let,
             VariableDeclarationKind::Const { .. } => BindingKind::Const,
@@ -2367,7 +2370,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &mut self,
         kind: arena::Box<'alloc, VariableDeclarationKind>,
         declarators: arena::Box<'alloc, arena::Vec<'alloc, VariableDeclarator<'alloc>>>,
-    ) -> Result<arena::Box<'alloc, VariableDeclarationOrExpression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, VariableDeclarationOrExpression<'alloc>>> {
         let binding_kind = match &*kind {
             VariableDeclarationKind::Let { .. } => BindingKind::Let,
             VariableDeclarationKind::Const { .. } => BindingKind::Const,
@@ -2705,7 +2708,7 @@ impl<'alloc> AstBuilder<'alloc> {
         test: arena::Box<'alloc, Expression<'alloc>>,
         consequent: arena::Box<'alloc, Statement<'alloc>>,
         alternate: Option<arena::Box<'alloc, Statement<'alloc>>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_single_statement(&consequent)?;
         if let Some(ref stmt) = alternate {
             self.check_single_statement(&stmt)?;
@@ -2733,7 +2736,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn make_block_stmt_from_function_decl(
         &mut self,
         fun: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         let fun_loc = fun.get_loc();
 
         // Annex B. FunctionDeclarations in IfStatement Statement Clauses
@@ -2761,7 +2764,7 @@ impl<'alloc> AstBuilder<'alloc> {
         }))
     }
 
-    fn is_strict(&self) -> Result<bool> {
+    fn is_strict(&self) -> Result<'alloc, bool> {
         Err(ParseError::NotImplemented(
             "strict-mode-only early error is not yet supported",
         ))
@@ -2774,7 +2777,7 @@ impl<'alloc> AstBuilder<'alloc> {
         stmt: arena::Box<'alloc, Statement<'alloc>>,
         test: arena::Box<'alloc, Expression<'alloc>>,
         close_token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_single_statement(&stmt)?;
 
         Ok(self.alloc(Statement::DoWhileStatement {
@@ -2790,7 +2793,7 @@ impl<'alloc> AstBuilder<'alloc> {
         while_token: arena::Box<'alloc, Token>,
         test: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_single_statement(&stmt)?;
 
         let stmt_loc = stmt.get_loc();
@@ -2810,7 +2813,7 @@ impl<'alloc> AstBuilder<'alloc> {
         test: Option<arena::Box<'alloc, Expression<'alloc>>>,
         update: Option<arena::Box<'alloc, Expression<'alloc>>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_single_statement(&stmt)?;
         self.for_statement_common(for_token, init, test, update, stmt)
     }
@@ -2823,7 +2826,7 @@ impl<'alloc> AstBuilder<'alloc> {
         test: Option<arena::Box<'alloc, Expression<'alloc>>>,
         update: Option<arena::Box<'alloc, Expression<'alloc>>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_single_statement(&stmt)?;
         self.check_lexical_for_bindings(&init.get_loc())?;
         self.for_statement_common(for_token, Some(init), test, update, stmt)
@@ -2836,7 +2839,7 @@ impl<'alloc> AstBuilder<'alloc> {
         test: Option<arena::Box<'alloc, Expression<'alloc>>>,
         update: Option<arena::Box<'alloc, Expression<'alloc>>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         let stmt_loc = stmt.get_loc();
         Ok(self.alloc(Statement::ForStatement {
             init,
@@ -2894,7 +2897,7 @@ impl<'alloc> AstBuilder<'alloc> {
         left: VariableDeclarationOrAssignmentTarget<'alloc>,
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_single_statement(&stmt)?;
         self.for_in_statement_common(for_token, left, right, stmt)
     }
@@ -2906,7 +2909,7 @@ impl<'alloc> AstBuilder<'alloc> {
         left: VariableDeclarationOrAssignmentTarget<'alloc>,
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_single_statement(&stmt)?;
         self.check_lexical_for_bindings(&left.get_loc())?;
         self.for_in_statement_common(for_token, left, right, stmt)
@@ -2918,7 +2921,7 @@ impl<'alloc> AstBuilder<'alloc> {
         left: VariableDeclarationOrAssignmentTarget<'alloc>,
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         let stmt_loc = stmt.get_loc();
         Ok(self.alloc(Statement::ForInStatement {
             left,
@@ -2957,7 +2960,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn for_assignment_target(
         &self,
         expression: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<VariableDeclarationOrAssignmentTarget<'alloc>> {
+    ) -> Result<'alloc, VariableDeclarationOrAssignmentTarget<'alloc>> {
         Ok(VariableDeclarationOrAssignmentTarget::AssignmentTarget(
             self.expression_to_assignment_target(expression)?,
         ))
@@ -2978,7 +2981,7 @@ impl<'alloc> AstBuilder<'alloc> {
         left: VariableDeclarationOrAssignmentTarget<'alloc>,
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_single_statement(&stmt)?;
         self.for_of_statement_common(for_token, left, right, stmt)
     }
@@ -2990,7 +2993,7 @@ impl<'alloc> AstBuilder<'alloc> {
         left: VariableDeclarationOrAssignmentTarget<'alloc>,
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_single_statement(&stmt)?;
         self.check_lexical_for_bindings(&left.get_loc())?;
         self.for_of_statement_common(for_token, left, right, stmt)
@@ -3002,7 +3005,7 @@ impl<'alloc> AstBuilder<'alloc> {
         left: VariableDeclarationOrAssignmentTarget<'alloc>,
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         let stmt_loc = stmt.get_loc();
         Ok(self.alloc(Statement::ForOfStatement {
             left,
@@ -3020,7 +3023,7 @@ impl<'alloc> AstBuilder<'alloc> {
         left: VariableDeclarationOrAssignmentTarget,
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_single_statement(&stmt)?;
         self.for_await_of_statement_common(for_token, left, right, stmt)
     }
@@ -3032,7 +3035,7 @@ impl<'alloc> AstBuilder<'alloc> {
         left: VariableDeclarationOrAssignmentTarget,
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_single_statement(&stmt)?;
         self.check_lexical_for_bindings(&left.get_loc())?;
         self.for_await_of_statement_common(for_token, left, right, stmt)
@@ -3044,7 +3047,7 @@ impl<'alloc> AstBuilder<'alloc> {
         _left: VariableDeclarationOrAssignmentTarget,
         _right: arena::Box<'alloc, Expression<'alloc>>,
         _stmt: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         Err(ParseError::NotImplemented(
             "for await statement (missing from AST)",
         ))
@@ -3191,7 +3194,7 @@ impl<'alloc> AstBuilder<'alloc> {
         open_token: arena::Box<'alloc, Token>,
         cases: Option<arena::Box<'alloc, arena::Vec<'alloc, SwitchCase<'alloc>>>>,
         close_token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_case_block_binding(open_token.loc.start)?;
 
         Ok(self.alloc(Statement::SwitchStatement {
@@ -3218,7 +3221,7 @@ impl<'alloc> AstBuilder<'alloc> {
         default_case: arena::Box<'alloc, SwitchDefault<'alloc>>,
         post_default_cases: Option<arena::Box<'alloc, arena::Vec<'alloc, SwitchCase<'alloc>>>>,
         close_token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Statement<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
         self.check_case_block_binding(open_token.loc.start)?;
 
         Ok(self.alloc(Statement::SwitchStatementWithDefault {
@@ -3386,7 +3389,7 @@ impl<'alloc> AstBuilder<'alloc> {
         catch_token: arena::Box<'alloc, Token>,
         binding: arena::Box<'alloc, Binding<'alloc>>,
         body: arena::Box<'alloc, Block<'alloc>>,
-    ) -> Result<arena::Box<'alloc, CatchClause<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, CatchClause<'alloc>>> {
         let catch_loc = catch_token.loc;
         let body_loc = body.loc;
 
@@ -3409,7 +3412,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &mut self,
         catch_token: arena::Box<'alloc, Token>,
         body: arena::Box<'alloc, Block<'alloc>>,
-    ) -> Result<arena::Box<'alloc, CatchClause<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, CatchClause<'alloc>>> {
         let catch_loc = catch_token.loc;
         let body_loc = body.loc;
 
@@ -3465,7 +3468,7 @@ impl<'alloc> AstBuilder<'alloc> {
         body_open_token: arena::Box<'alloc, Token>,
         mut body: arena::Box<'alloc, FunctionBody<'alloc>>,
         body_close_token: arena::Box<'alloc, Token>,
-    ) -> Result<Function<'alloc>> {
+    ) -> Result<'alloc, Function<'alloc>> {
         let param_open_loc = param_open_token.loc;
         let param_close_loc = param_close_token.loc;
         let body_close_loc = body_close_token.loc;
@@ -3499,7 +3502,7 @@ impl<'alloc> AstBuilder<'alloc> {
         body_open_token: arena::Box<'alloc, Token>,
         mut body: arena::Box<'alloc, FunctionBody<'alloc>>,
         body_close_token: arena::Box<'alloc, Token>,
-    ) -> Result<Function<'alloc>> {
+    ) -> Result<'alloc, Function<'alloc>> {
         let param_open_loc = param_open_token.loc;
         let param_close_loc = param_close_token.loc;
         let body_close_loc = body_close_token.loc;
@@ -3533,7 +3536,7 @@ impl<'alloc> AstBuilder<'alloc> {
         body_open_token: arena::Box<'alloc, Token>,
         mut body: arena::Box<'alloc, FunctionBody<'alloc>>,
         body_close_token: arena::Box<'alloc, Token>,
-    ) -> Result<Function<'alloc>> {
+    ) -> Result<'alloc, Function<'alloc>> {
         let param_open_loc = param_open_token.loc;
         let param_close_loc = param_close_token.loc;
         let body_close_loc = body_close_token.loc;
@@ -3567,7 +3570,7 @@ impl<'alloc> AstBuilder<'alloc> {
         body_open_token: arena::Box<'alloc, Token>,
         mut body: arena::Box<'alloc, FunctionBody<'alloc>>,
         body_close_token: arena::Box<'alloc, Token>,
-    ) -> Result<Function<'alloc>> {
+    ) -> Result<'alloc, Function<'alloc>> {
         let param_open_loc = param_open_token.loc;
         let param_close_loc = param_close_token.loc;
         let body_close_loc = body_close_token.loc;
@@ -3670,7 +3673,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &mut self,
         params: arena::Box<'alloc, FormalParameters<'alloc>>,
         body: arena::Box<'alloc, ArrowExpressionBody<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         self.check_unique_function_bindings(params.loc.start, params.loc.end)?;
 
         let params_loc = params.loc;
@@ -3703,7 +3706,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn uncover_arrow_parameters(
         &self,
         covered: arena::Box<'alloc, CoverParenthesized<'alloc>>,
-    ) -> Result<arena::Box<'alloc, FormalParameters<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, FormalParameters<'alloc>>> {
         Ok(match covered.unbox() {
             CoverParenthesized::Expression { expression, loc } => self.alloc(FormalParameters {
                 items: self.expression_to_parameter_list(expression)?,
@@ -3744,7 +3747,7 @@ impl<'alloc> AstBuilder<'alloc> {
         body_open_token: arena::Box<'alloc, Token>,
         mut body: arena::Box<'alloc, FunctionBody<'alloc>>,
         body_close_token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, MethodDefinition<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, MethodDefinition<'alloc>>> {
         let name_loc = name.get_loc();
         let param_open_loc = param_open_token.loc;
         let param_close_loc = param_close_token.loc;
@@ -3794,7 +3797,7 @@ impl<'alloc> AstBuilder<'alloc> {
         body_open_token: arena::Box<'alloc, Token>,
         mut body: arena::Box<'alloc, FunctionBody<'alloc>>,
         body_close_token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, MethodDefinition<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, MethodDefinition<'alloc>>> {
         let param_open_loc = param_open_token.loc;
         let param_close_loc = param_close_token.loc;
         let body_close_loc = body_close_token.loc;
@@ -3824,7 +3827,7 @@ impl<'alloc> AstBuilder<'alloc> {
         body_open_token: arena::Box<'alloc, Token>,
         mut body: arena::Box<'alloc, FunctionBody<'alloc>>,
         body_close_token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, MethodDefinition<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, MethodDefinition<'alloc>>> {
         let param_open_loc = param_open_token.loc;
         let param_close_loc = param_close_token.loc;
         let body_close_loc = body_close_token.loc;
@@ -3888,7 +3891,7 @@ impl<'alloc> AstBuilder<'alloc> {
         body_open_token: arena::Box<'alloc, Token>,
         mut body: arena::Box<'alloc, FunctionBody<'alloc>>,
         body_close_token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, MethodDefinition<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, MethodDefinition<'alloc>>> {
         let param_open_loc = param_open_token.loc;
         let param_close_loc = param_close_token.loc;
         let body_close_loc = body_close_token.loc;
@@ -4076,7 +4079,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         _static_token: arena::Box<'alloc, Token>,
         _field: arena::Box<'alloc, ClassElement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("class static field"))
     }
 
@@ -4098,7 +4101,7 @@ impl<'alloc> AstBuilder<'alloc> {
         body_open_token: arena::Box<'alloc, Token>,
         mut body: arena::Box<'alloc, FunctionBody<'alloc>>,
         body_close_token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, MethodDefinition<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, MethodDefinition<'alloc>>> {
         let param_open_loc = param_open_token.loc;
         let param_close_loc = param_close_token.loc;
         let body_close_loc = body_close_token.loc;
@@ -4138,7 +4141,7 @@ impl<'alloc> AstBuilder<'alloc> {
         async_token: arena::Box<'alloc, Token>,
         identifier: arena::Box<'alloc, BindingIdentifier>,
         body: arena::Box<'alloc, ArrowExpressionBody<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         let params = self.arrow_parameters_bare(identifier);
 
         self.check_unique_function_bindings(params.loc.start, params.loc.end)?;
@@ -4156,7 +4159,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &mut self,
         params: arena::Box<'alloc, Expression<'alloc>>,
         body: arena::Box<'alloc, ArrowExpressionBody<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Expression<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Expression<'alloc>>> {
         let (params, call_loc) = self.async_arrow_parameters(params)?;
 
         self.check_unique_function_bindings(params.loc.start, params.loc.end)?;
@@ -4176,7 +4179,7 @@ impl<'alloc> AstBuilder<'alloc> {
     fn async_arrow_parameters(
         &self,
         call_expression: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<(arena::Box<'alloc, FormalParameters<'alloc>>, SourceLocation)> {
+    ) -> Result<'alloc, (arena::Box<'alloc, FormalParameters<'alloc>>, SourceLocation)> {
         match call_expression.unbox() {
             Expression::CallExpression(CallExpression {
                 callee: ce,
@@ -4219,7 +4222,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn script(
         &mut self,
         script: Option<arena::Box<'alloc, Script<'alloc>>>,
-    ) -> Result<arena::Box<'alloc, Script<'alloc>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Script<'alloc>>> {
         self.check_script_bindings()?;
 
         Ok(match script {
@@ -4258,7 +4261,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn module(
         &mut self,
         body: Option<arena::Box<'alloc, arena::Vec<'alloc, Statement<'alloc>>>>,
-    ) -> Result<arena::Box<'alloc, arena::Vec<'alloc, Statement<'alloc>>>> {
+    ) -> Result<'alloc, arena::Box<'alloc, arena::Vec<'alloc, Statement<'alloc>>>> {
         self.check_module_bindings()?;
 
         Ok(body.unwrap_or_else(|| self.alloc(self.new_vec())))
@@ -4288,7 +4291,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         _import_clause: Option<arena::Box<'alloc, Void>>,
         _module_specifier: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("import"))
     }
 
@@ -4302,7 +4305,7 @@ impl<'alloc> AstBuilder<'alloc> {
         _default_binding: Option<arena::Box<'alloc, BindingIdentifier>>,
         _name_space_import: Option<arena::Box<'alloc, Void>>,
         _named_imports: Option<arena::Box<'alloc, Void>>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("import"))
     }
 
@@ -4310,12 +4313,12 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn name_space_import(
         &self,
         _name: arena::Box<'alloc, BindingIdentifier>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("import"))
     }
 
     // NamedImports : `{` `}`
-    pub fn imports_list_empty(&self) -> Result<arena::Box<'alloc, Void>> {
+    pub fn imports_list_empty(&self) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("import"))
     }
 
@@ -4325,7 +4328,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         _list: arena::Box<'alloc, Void>,
         _item: arena::Box<'alloc, Void>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("import"))
     }
 
@@ -4333,7 +4336,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn import_specifier(
         &self,
         _name: arena::Box<'alloc, BindingIdentifier>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("import"))
     }
 
@@ -4342,7 +4345,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         _original_name: arena::Box<'alloc, Token>,
         _local_name: arena::Box<'alloc, BindingIdentifier>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("import"))
     }
 
@@ -4350,7 +4353,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn module_specifier(
         &self,
         _token: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Token>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Token>> {
         Err(ParseError::NotImplemented("import"))
     }
 
@@ -4358,7 +4361,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn export_all_from(
         &self,
         _module_specifier: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("export"))
     }
 
@@ -4367,7 +4370,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         _export_clause: arena::Box<'alloc, Void>,
         _module_specifier: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("export"))
     }
 
@@ -4375,7 +4378,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn export_set(
         &self,
         _export_clause: arena::Box<'alloc, Void>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("export"))
     }
 
@@ -4383,7 +4386,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn export_vars(
         &self,
         _statement: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("export"))
     }
 
@@ -4391,7 +4394,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn export_declaration(
         &self,
         _declaration: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("export"))
     }
 
@@ -4399,7 +4402,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn export_default_hoistable(
         &self,
         _declaration: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("export"))
     }
 
@@ -4407,7 +4410,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn export_default_class(
         &self,
         _class_declaration: arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("export"))
     }
 
@@ -4415,12 +4418,12 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn export_default_value(
         &self,
         _expression: arena::Box<'alloc, Expression<'alloc>>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("export"))
     }
 
     // ExportClause : `{` `}`
-    pub fn exports_list_empty(&self) -> Result<arena::Box<'alloc, Void>> {
+    pub fn exports_list_empty(&self) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("export"))
     }
 
@@ -4430,7 +4433,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         _list: arena::Box<'alloc, Void>,
         _export_specifier: arena::Box<'alloc, Void>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("export"))
     }
 
@@ -4438,7 +4441,7 @@ impl<'alloc> AstBuilder<'alloc> {
     pub fn export_specifier(
         &self,
         _identifier: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("export"))
     }
 
@@ -4447,13 +4450,13 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         _local_name: arena::Box<'alloc, Token>,
         _exported_name: arena::Box<'alloc, Token>,
-    ) -> Result<arena::Box<'alloc, Void>> {
+    ) -> Result<'alloc, arena::Box<'alloc, Void>> {
         Err(ParseError::NotImplemented("export"))
     }
 
     // Check Early Error for BindingIdentifier and note binding info to the
     // stack.
-    fn on_binding_identifier(&mut self, token: &arena::Box<'alloc, Token>) -> Result<()> {
+    fn on_binding_identifier(&mut self, token: &arena::Box<'alloc, Token>) -> Result<'alloc, ()> {
         let context = IdentifierEarlyErrorsContext::new();
         context.check_binding_identifier(token, &self.atoms.borrow())?;
 
@@ -4474,13 +4477,13 @@ impl<'alloc> AstBuilder<'alloc> {
     }
 
     // Check Early Error for IdentifierReference.
-    fn on_identifier_reference(&self, token: &arena::Box<'alloc, Token>) -> Result<()> {
+    fn on_identifier_reference(&self, token: &arena::Box<'alloc, Token>) -> Result<'alloc, ()> {
         let context = IdentifierEarlyErrorsContext::new();
         context.check_identifier_reference(token, &self.atoms.borrow())
     }
 
     // Check Early Error for LabelIdentifier.
-    fn on_label_identifier(&self, token: &arena::Box<'alloc, Token>) -> Result<()> {
+    fn on_label_identifier(&self, token: &arena::Box<'alloc, Token>) -> Result<'alloc, ()> {
         let context = IdentifierEarlyErrorsContext::new();
         context.check_label_identifier(token, &self.atoms.borrow())
     }
@@ -4552,7 +4555,7 @@ impl<'alloc> AstBuilder<'alloc> {
 
     // Declare bindings to Block-like context, where function declarations
     // are lexical.
-    fn declare_block<T>(&self, context: &mut T, index: usize) -> Result<()>
+    fn declare_block<T>(&self, context: &mut T, index: usize) -> Result<'alloc, ()>
     where
         T: LexicalEarlyErrorsContext + VarEarlyErrorsContext,
     {
@@ -4616,7 +4619,7 @@ impl<'alloc> AstBuilder<'alloc> {
     }
 
     // Check bindings in Block.
-    fn check_block_bindings(&mut self, start_of_block_offset: usize) -> Result<()> {
+    fn check_block_bindings(&mut self, start_of_block_offset: usize) -> Result<'alloc, ()> {
         let mut context = BlockEarlyErrorsContext::new();
         let index = self.find_first_binding(start_of_block_offset);
         self.declare_block(&mut context, index)?;
@@ -4631,7 +4634,7 @@ impl<'alloc> AstBuilder<'alloc> {
         context: &mut LexicalForHeadEarlyErrorsContext,
         from: usize,
         to: usize,
-    ) -> Result<()> {
+    ) -> Result<'alloc, ()> {
         for info in self.bindings.iter().skip(from).take(to - from) {
             match info.kind {
                 BindingKind::Let => {
@@ -4664,7 +4667,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &self,
         context: &mut LexicalForBodyEarlyErrorsContext,
         index: usize,
-    ) -> Result<()> {
+    ) -> Result<'alloc, ()> {
         for info in self.bindings.iter().skip(index) {
             match info.kind {
                 BindingKind::Var => {
@@ -4685,7 +4688,7 @@ impl<'alloc> AstBuilder<'alloc> {
     }
 
     // Check bindings in lexical for-statement.
-    fn check_lexical_for_bindings(&mut self, bindings_loc: &SourceLocation) -> Result<()> {
+    fn check_lexical_for_bindings(&mut self, bindings_loc: &SourceLocation) -> Result<'alloc, ()> {
         let mut head_context = LexicalForHeadEarlyErrorsContext::new();
 
         let head_index = self.find_first_binding(bindings_loc.start);
@@ -4700,7 +4703,7 @@ impl<'alloc> AstBuilder<'alloc> {
     }
 
     // Check bindings in CaseBlock of switch-statement.
-    fn check_case_block_binding(&mut self, start_of_block_offset: usize) -> Result<()> {
+    fn check_case_block_binding(&mut self, start_of_block_offset: usize) -> Result<'alloc, ()> {
         let mut context = CaseBlockEarlyErrorsContext::new();
 
         let index = self.find_first_binding(start_of_block_offset);
@@ -4711,7 +4714,7 @@ impl<'alloc> AstBuilder<'alloc> {
     }
 
     // Declare bindings to the parameter of function or catch.
-    fn declare_param<T>(&self, context: &mut T, from: usize, to: usize) -> Result<()>
+    fn declare_param<T>(&self, context: &mut T, from: usize, to: usize) -> Result<'alloc, ()>
     where
         T: ParameterEarlyErrorsContext,
     {
@@ -4727,7 +4730,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &mut self,
         is_simple: bool,
         bindings_loc: &SourceLocation,
-    ) -> Result<()> {
+    ) -> Result<'alloc, ()> {
         let mut param_context = if is_simple {
             CatchParameterEarlyErrorsContext::new_with_binding_identifier()
         } else {
@@ -4746,7 +4749,7 @@ impl<'alloc> AstBuilder<'alloc> {
     }
 
     // Check bindings in Catch with no parameter and Block.
-    fn check_catch_no_param_bindings(&mut self, catch_offset: usize) -> Result<()> {
+    fn check_catch_no_param_bindings(&mut self, catch_offset: usize) -> Result<'alloc, ()> {
         let body_index = self.find_first_binding(catch_offset);
 
         let param_context = CatchParameterEarlyErrorsContext::new_with_binding_identifier();
@@ -4759,7 +4762,7 @@ impl<'alloc> AstBuilder<'alloc> {
 
     // Declare bindings to script-or-function-like context, where function
     // declarations are body-level.
-    fn declare_script_or_function<T>(&self, context: &mut T, index: usize) -> Result<()>
+    fn declare_script_or_function<T>(&self, context: &mut T, index: usize) -> Result<'alloc, ()>
     where
         T: LexicalEarlyErrorsContext + VarEarlyErrorsContext,
     {
@@ -4820,7 +4823,7 @@ impl<'alloc> AstBuilder<'alloc> {
         is_simple: bool,
         start_of_param_offset: usize,
         end_of_param_offset: usize,
-    ) -> Result<()> {
+    ) -> Result<'alloc, ()> {
         let mut param_context = if is_simple {
             FormalParametersEarlyErrorsContext::new_simple()
         } else {
@@ -4843,7 +4846,7 @@ impl<'alloc> AstBuilder<'alloc> {
         &mut self,
         start_of_param_offset: usize,
         end_of_param_offset: usize,
-    ) -> Result<()> {
+    ) -> Result<'alloc, ()> {
         let mut param_context = UniqueFormalParametersEarlyErrorsContext::new();
 
         let param_index = self.find_first_binding(start_of_param_offset);
@@ -4858,7 +4861,7 @@ impl<'alloc> AstBuilder<'alloc> {
     }
 
     // Check bindings in Script.
-    fn check_script_bindings(&mut self) -> Result<()> {
+    fn check_script_bindings(&mut self) -> Result<'alloc, ()> {
         let mut context = ScriptEarlyErrorsContext::new();
         self.declare_script_or_function(&mut context, 0)?;
         self.pop_bindings_from(0);
@@ -4867,7 +4870,7 @@ impl<'alloc> AstBuilder<'alloc> {
     }
 
     // Check bindings in Module.
-    fn check_module_bindings(&mut self) -> Result<()> {
+    fn check_module_bindings(&mut self) -> Result<'alloc, ()> {
         let mut context = ModuleEarlyErrorsContext::new();
         self.declare_script_or_function(&mut context, 0)?;
         self.pop_bindings_from(0);
@@ -4900,7 +4903,10 @@ impl<'alloc> AstBuilder<'alloc> {
     // https://tc39.es/ecma262/#sec-if-statement-static-semantics-early-errors
     // https://tc39.es/ecma262/#sec-semantics-static-semantics-early-errors
     // https://tc39.es/ecma262/#sec-with-statement-static-semantics-early-errors
-    fn check_single_statement(&self, stmt: &arena::Box<'alloc, Statement<'alloc>>) -> Result<()> {
+    fn check_single_statement(
+        &self,
+        stmt: &arena::Box<'alloc, Statement<'alloc>>,
+    ) -> Result<'alloc, ()> {
         // * It is a Syntax Error if IsLabelledFunction(Statement) is true.
         if self.is_labelled_function(stmt) {
             return Err(ParseError::LabelledFunctionDeclInSingleStatement);

--- a/crates/generated_parser/src/early_errors.rs
+++ b/crates/generated_parser/src/early_errors.rs
@@ -18,35 +18,35 @@ impl DeclarationInfo {
     }
 }
 
-pub type EarlyErrorsResult = Result<(), ParseError>;
+pub type EarlyErrorsResult<'alloc> = Result<(), ParseError<'alloc>>;
 
 pub trait LexicalEarlyErrorsContext {
-    fn declare_lex(
+    fn declare_lex<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult;
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc>;
 }
 
 pub trait VarEarlyErrorsContext {
-    fn declare_var(
+    fn declare_var<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult;
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc>;
 }
 
 pub trait ParameterEarlyErrorsContext {
-    fn declare(
+    fn declare<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult;
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc>;
 }
 
 // ===========================================================================
@@ -62,7 +62,7 @@ impl IdentifierEarlyErrorsContext {
         Self {}
     }
 
-    fn is_strict(&self) -> Result<bool, ParseError> {
+    fn is_strict<'alloc>(&self) -> Result<bool, ParseError<'alloc>> {
         Err(ParseError::NotImplemented(
             "strict-mode-only early error is not yet supported",
         ))
@@ -70,7 +70,7 @@ impl IdentifierEarlyErrorsContext {
 
     // Not used due to NotImplemented before the callsite.
     /*
-    fn is_module(&self) -> Result<bool, ParseError> {
+    fn is_module(&self) -> Result<bool, ParseError<'alloc>> {
         Err(ParseError::NotImplemented(
             "module-only early error is not yet supported",
         ))
@@ -104,8 +104,8 @@ impl IdentifierEarlyErrorsContext {
     pub fn check_binding_identifier<'alloc>(
         &self,
         token: &arena::Box<'alloc, Token>,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         if Self::is_arguments_identifier(token) || Self::is_eval_identifier(token) {
             // Static Semantics: Early Errors
             // https://tc39.es/ecma262/#sec-identifiers-static-semantics-early-errors
@@ -150,8 +150,8 @@ impl IdentifierEarlyErrorsContext {
     pub fn check_label_identifier<'alloc>(
         &self,
         token: &arena::Box<'alloc, Token>,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         if Self::is_yield_identifier(token) {
             return self.check_yield_common(token, atoms);
         }
@@ -166,8 +166,8 @@ impl IdentifierEarlyErrorsContext {
     pub fn check_identifier_reference<'alloc>(
         &self,
         token: &arena::Box<'alloc, Token>,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         if Self::is_yield_identifier(token) {
             return self.check_yield_common(token, atoms);
         }
@@ -182,8 +182,8 @@ impl IdentifierEarlyErrorsContext {
     fn check_yield_common<'alloc>(
         &self,
         _token: &arena::Box<'alloc, Token>,
-        _atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        _atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         // Static Semantics: Early Errors
         // https://tc39.es/ecma262/#sec-identifiers-static-semantics-early-errors
         //
@@ -228,8 +228,8 @@ impl IdentifierEarlyErrorsContext {
     fn check_await_common<'alloc>(
         &self,
         _token: &arena::Box<'alloc, Token>,
-        _atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        _atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         // Static Semantics: Early Errors
         // https://tc39.es/ecma262/#sec-identifiers-static-semantics-early-errors
         //
@@ -322,8 +322,8 @@ impl IdentifierEarlyErrorsContext {
     fn check_identifier<'alloc>(
         &self,
         token: &arena::Box<'alloc, Token>,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         match token.terminal_id {
             TerminalId::NameWithEscape => {
                 let name = token.value.as_atom();
@@ -592,7 +592,7 @@ impl BlockEarlyErrorsContext {
         }
     }
 
-    fn is_strict(&self) -> Result<bool, ParseError> {
+    fn is_strict<'alloc>(&self) -> Result<bool, ParseError<'alloc>> {
         Err(ParseError::NotImplemented(
             "strict-mode-only early error is not yet supported",
         ))
@@ -600,13 +600,13 @@ impl BlockEarlyErrorsContext {
 }
 
 impl LexicalEarlyErrorsContext for BlockEarlyErrorsContext {
-    fn declare_lex(
+    fn declare_lex<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         debug_assert!(Self::is_supported_lexical(kind));
 
         // Static Semantics: Early Errors
@@ -670,13 +670,13 @@ impl LexicalEarlyErrorsContext for BlockEarlyErrorsContext {
 }
 
 impl VarEarlyErrorsContext for BlockEarlyErrorsContext {
-    fn declare_var(
+    fn declare_var<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         debug_assert!(Self::is_supported_var(kind));
 
         // Static Semantics: Early Errors
@@ -753,13 +753,13 @@ impl LexicalForHeadEarlyErrorsContext {
 }
 
 impl LexicalEarlyErrorsContext for LexicalForHeadEarlyErrorsContext {
-    fn declare_lex(
+    fn declare_lex<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         debug_assert!(Self::is_supported_lexical(kind));
 
         // Static Semantics: Early Errors
@@ -832,13 +832,13 @@ impl InternalForBodyEarlyErrorsContext {
 }
 
 impl VarEarlyErrorsContext for InternalForBodyEarlyErrorsContext {
-    fn declare_var(
+    fn declare_var<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        _atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        _atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         debug_assert!(Self::is_supported_var(kind));
 
         self.var_names_of_stmt
@@ -864,13 +864,13 @@ impl LexicalForBodyEarlyErrorsContext {
 }
 
 impl VarEarlyErrorsContext for LexicalForBodyEarlyErrorsContext {
-    fn declare_var(
+    fn declare_var<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         // Static Semantics: Early Errors
         // https://tc39.es/ecma262/#sec-for-statement-static-semantics-early-errors
         //
@@ -938,7 +938,7 @@ impl CaseBlockEarlyErrorsContext {
         BlockEarlyErrorsContext::is_supported_var(kind)
     }
 
-    fn is_strict(&self) -> Result<bool, ParseError> {
+    fn is_strict<'alloc>(&self) -> Result<bool, ParseError<'alloc>> {
         Err(ParseError::NotImplemented(
             "strict-mode-only early error is not yet supported",
         ))
@@ -946,13 +946,13 @@ impl CaseBlockEarlyErrorsContext {
 }
 
 impl LexicalEarlyErrorsContext for CaseBlockEarlyErrorsContext {
-    fn declare_lex(
+    fn declare_lex<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         debug_assert!(Self::is_supported_lexical(kind));
 
         // Static Semantics: Early Errors
@@ -1013,13 +1013,13 @@ impl LexicalEarlyErrorsContext for CaseBlockEarlyErrorsContext {
 }
 
 impl VarEarlyErrorsContext for CaseBlockEarlyErrorsContext {
-    fn declare_var(
+    fn declare_var<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         debug_assert!(Self::is_supported_var(kind));
 
         // Static Semantics: Early Errors
@@ -1075,12 +1075,12 @@ impl CatchParameterEarlyErrorsContext {
 }
 
 impl ParameterEarlyErrorsContext for CatchParameterEarlyErrorsContext {
-    fn declare(
+    fn declare<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         // BoundNames of CatchParameter
         //
         // CatchParameter => BindingIdentifier
@@ -1124,13 +1124,13 @@ impl CatchBlockEarlyErrorsContext {
 }
 
 impl LexicalEarlyErrorsContext for CatchBlockEarlyErrorsContext {
-    fn declare_lex(
+    fn declare_lex<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         // Static Semantics: Early Errors
         // https://tc39.es/ecma262/#sec-try-statement-static-semantics-early-errors
         //
@@ -1150,13 +1150,13 @@ impl LexicalEarlyErrorsContext for CatchBlockEarlyErrorsContext {
 }
 
 impl VarEarlyErrorsContext for CatchBlockEarlyErrorsContext {
-    fn declare_var(
+    fn declare_var<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         // Static Semantics: Early Errors
         // https://tc39.es/ecma262/#sec-try-statement-static-semantics-early-errors
         //
@@ -1236,12 +1236,12 @@ impl FormalParametersEarlyErrorsContext {
 }
 
 impl ParameterEarlyErrorsContext for FormalParametersEarlyErrorsContext {
-    fn declare(
+    fn declare<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         // BoundNames of FormalParameterList
         //
         // Static Semantics: BoundNames
@@ -1308,12 +1308,12 @@ impl UniqueFormalParametersEarlyErrorsContext {
 }
 
 impl ParameterEarlyErrorsContext for UniqueFormalParametersEarlyErrorsContext {
-    fn declare(
+    fn declare<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         let kind = DeclarationKind::FormalParameter;
 
         // Static Semantics: Early Errors
@@ -1466,13 +1466,13 @@ impl InternalFunctionBodyEarlyErrorsContext {
 }
 
 impl LexicalEarlyErrorsContext for InternalFunctionBodyEarlyErrorsContext {
-    fn declare_lex(
+    fn declare_lex<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         debug_assert!(Self::is_supported_lexical(kind));
 
         // Static Semantics: Early Errors
@@ -1520,13 +1520,13 @@ impl LexicalEarlyErrorsContext for InternalFunctionBodyEarlyErrorsContext {
 }
 
 impl VarEarlyErrorsContext for InternalFunctionBodyEarlyErrorsContext {
-    fn declare_var(
+    fn declare_var<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         debug_assert!(Self::is_supported_var(kind));
 
         // Static Semantics: Early Errors
@@ -1583,13 +1583,13 @@ impl FunctionBodyEarlyErrorsContext {
 }
 
 impl LexicalEarlyErrorsContext for FunctionBodyEarlyErrorsContext {
-    fn declare_lex(
+    fn declare_lex<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         // Static Semantics: Early Errors
         // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
         //
@@ -1675,13 +1675,13 @@ impl LexicalEarlyErrorsContext for FunctionBodyEarlyErrorsContext {
 }
 
 impl VarEarlyErrorsContext for FunctionBodyEarlyErrorsContext {
-    fn declare_var(
+    fn declare_var<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         self.body.declare_var(name, kind, offset, atoms)
     }
 }
@@ -1713,13 +1713,13 @@ impl UniqueFunctionBodyEarlyErrorsContext {
 }
 
 impl LexicalEarlyErrorsContext for UniqueFunctionBodyEarlyErrorsContext {
-    fn declare_lex(
+    fn declare_lex<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         // Static Semantics: Early Errors
         // https://tc39.es/ecma262/#sec-arrow-function-definitions-static-semantics-early-errors
         //
@@ -1819,13 +1819,13 @@ impl LexicalEarlyErrorsContext for UniqueFunctionBodyEarlyErrorsContext {
 }
 
 impl VarEarlyErrorsContext for UniqueFunctionBodyEarlyErrorsContext {
-    fn declare_var(
+    fn declare_var<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         self.body.declare_var(name, kind, offset, atoms)
     }
 }
@@ -1889,13 +1889,13 @@ impl ScriptEarlyErrorsContext {
 }
 
 impl LexicalEarlyErrorsContext for ScriptEarlyErrorsContext {
-    fn declare_lex(
+    fn declare_lex<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         debug_assert!(Self::is_supported_lexical(kind));
 
         // Static Semantics: Early Errors
@@ -1942,13 +1942,13 @@ impl LexicalEarlyErrorsContext for ScriptEarlyErrorsContext {
 }
 
 impl VarEarlyErrorsContext for ScriptEarlyErrorsContext {
-    fn declare_var(
+    fn declare_var<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         debug_assert!(Self::is_supported_var(kind));
 
         // Static Semantics: Early Errors
@@ -2075,12 +2075,12 @@ impl ModuleEarlyErrorsContext {
     }
 
     #[allow(dead_code)]
-    pub fn add_exported_name(
+    pub fn add_exported_name<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         // Static Semantics: Early Errors
         // https://tc39.es/ecma262/#sec-module-semantics-static-semantics-early-errors
         //
@@ -2108,7 +2108,10 @@ impl ModuleEarlyErrorsContext {
     }
 
     #[allow(dead_code)]
-    pub fn check_exported_name(&self, atoms: &SourceAtomSet) -> EarlyErrorsResult {
+    pub fn check_exported_name<'alloc>(
+        &self,
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         // Static Semantics: Early Errors
         // https://tc39.es/ecma262/#sec-module-semantics-static-semantics-early-errors
         //
@@ -2131,13 +2134,13 @@ impl ModuleEarlyErrorsContext {
 }
 
 impl LexicalEarlyErrorsContext for ModuleEarlyErrorsContext {
-    fn declare_lex(
+    fn declare_lex<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         debug_assert!(Self::is_supported_lexical(kind));
 
         // Static Semantics: Early Errors
@@ -2196,13 +2199,13 @@ impl LexicalEarlyErrorsContext for ModuleEarlyErrorsContext {
 }
 
 impl VarEarlyErrorsContext for ModuleEarlyErrorsContext {
-    fn declare_var(
+    fn declare_var<'alloc>(
         &mut self,
         name: SourceAtomSetIndex,
         kind: DeclarationKind,
         offset: usize,
-        atoms: &SourceAtomSet,
-    ) -> EarlyErrorsResult {
+        atoms: &SourceAtomSet<'alloc>,
+    ) -> EarlyErrorsResult<'alloc> {
         debug_assert!(Self::is_supported_var(kind));
 
         // Static Semantics: Early Errors

--- a/crates/generated_parser/src/error.rs
+++ b/crates/generated_parser/src/error.rs
@@ -1,7 +1,6 @@
 use crate::stack_value_generated::AstError;
 use crate::DeclarationKind;
 use crate::Token;
-use std::marker::PhantomData;
 use std::{convert::Infallible, error::Error, fmt};
 
 #[derive(Debug)]
@@ -22,7 +21,7 @@ pub enum ParseError<'alloc> {
     UnexpectedEnd,
     InvalidAssignmentTarget,
     InvalidParameter,
-    InvalidIdentifier(String, usize),
+    InvalidIdentifier(&'alloc str, usize),
     AstError(String),
 
     // Destructuring errors
@@ -36,17 +35,14 @@ pub enum ParseError<'alloc> {
     ArrowHeadInvalid,
     ArrowParametersWithNonFinalRest,
 
-    DuplicateBinding(String, DeclarationKind, usize, DeclarationKind, usize),
-    DuplicateExport(String, usize, usize),
-    MissingExport(String, usize),
+    DuplicateBinding(&'alloc str, DeclarationKind, usize, DeclarationKind, usize),
+    DuplicateExport(&'alloc str, usize, usize),
+    MissingExport(&'alloc str, usize),
 
     // Annex B. FunctionDeclarations in IfStatement Statement Clauses
     // https://tc39.es/ecma262/#sec-functiondeclarations-in-ifstatement-statement-clauses
     FunctionDeclInSingleStatement,
     LabelledFunctionDeclInSingleStatement,
-
-    // NOTE: Removed in the next patch.
-    Phantom(PhantomData<&'alloc ()>),
 }
 
 impl<'alloc> ParseError<'alloc> {
@@ -110,8 +106,6 @@ impl<'alloc> ParseError<'alloc> {
             ParseError::LabelledFunctionDeclInSingleStatement => format!(
                 "functions can only be labelled inside blocks"
             ),
-            // NOTE: Removed in the next patch.
-            ParseError::Phantom(_) => panic!("should not happen"),
         }
     }
 }

--- a/crates/interpreter/src/evaluate.rs
+++ b/crates/interpreter/src/evaluate.rs
@@ -35,7 +35,7 @@ trait Helpers {
     fn read_atom(&self, offset: usize) -> String;
 }
 
-impl Helpers for EmitResult {
+impl<'alloc> Helpers for EmitResult<'alloc> {
     fn read_u16(&self, offset: usize) -> u16 {
         u16::from_le_bytes(self.bytecode[offset..offset + 2].try_into().unwrap())
     }

--- a/crates/interpreter/src/evaluate.rs
+++ b/crates/interpreter/src/evaluate.rs
@@ -54,7 +54,7 @@ impl<'alloc> Helpers for EmitResult<'alloc> {
 
     fn read_atom(&self, offset: usize) -> String {
         let index = self.atoms[self.read_i32(offset) as usize];
-        self.all_atoms[usize::from(index)].clone()
+        self.all_atoms[usize::from(index)].to_string()
     }
 }
 

--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -73,7 +73,7 @@ impl<'alloc> Lexer<'alloc> {
         chars.next()
     }
 
-    pub fn next<'parser>(&mut self, parser: &Parser<'parser>) -> Result<Token> {
+    pub fn next<'parser>(&mut self, parser: &Parser<'parser>) -> Result<'alloc, Token> {
         let (loc, value, terminal_id) = self.advance_impl(parser)?;
         let value = match terminal_id {
             TerminalId::NumericLiteral => {
@@ -103,7 +103,7 @@ impl<'alloc> Lexer<'alloc> {
         })
     }
 
-    fn unexpected_err(&mut self) -> ParseError {
+    fn unexpected_err(&mut self) -> ParseError<'alloc> {
         if let Some(ch) = self.peek() {
             ParseError::IllegalCharacter(ch)
         } else {
@@ -194,7 +194,7 @@ impl<'alloc> Lexer<'alloc> {
     /// that a SingleLineHTMLCloseComment must occur at the start of a line. We
     /// use `is_on_new_line` for that.)
     ///
-    fn skip_multi_line_comment(&mut self, builder: &mut AutoCow<'alloc>) -> Result<()> {
+    fn skip_multi_line_comment(&mut self, builder: &mut AutoCow<'alloc>) -> Result<'alloc, ()> {
         while let Some(ch) = self.chars.next() {
             match ch {
                 '*' if self.peek() == Some('/') => {
@@ -299,7 +299,7 @@ impl<'alloc> Lexer<'alloc> {
     fn identifier_name_tail(
         &mut self,
         mut builder: AutoCow<'alloc>,
-    ) -> Result<(bool, &'alloc str)> {
+    ) -> Result<'alloc, (bool, &'alloc str)> {
         while let Some(ch) = self.peek() {
             if !is_identifier_part(ch) {
                 if ch == '\\' {
@@ -324,7 +324,7 @@ impl<'alloc> Lexer<'alloc> {
         Ok((has_different, builder.finish(&self)))
     }
 
-    fn identifier_name(&mut self, mut builder: AutoCow<'alloc>) -> Result<&'alloc str> {
+    fn identifier_name(&mut self, mut builder: AutoCow<'alloc>) -> Result<'alloc, &'alloc str> {
         match self.chars.next() {
             None => {
                 return Err(ParseError::UnexpectedEnd);
@@ -386,7 +386,7 @@ impl<'alloc> Lexer<'alloc> {
         &mut self,
         start: usize,
         builder: AutoCow<'alloc>,
-    ) -> Result<(SourceLocation, Option<&'alloc str>, TerminalId)> {
+    ) -> Result<'alloc, (SourceLocation, Option<&'alloc str>, TerminalId)> {
         let (has_different, text) = self.identifier_name_tail(builder)?;
 
         // https://tc39.es/ecma262/#sec-keywords-and-reserved-words
@@ -489,7 +489,7 @@ impl<'alloc> Lexer<'alloc> {
         &mut self,
         start: usize,
         builder: AutoCow<'alloc>,
-    ) -> Result<(SourceLocation, Option<&'alloc str>, TerminalId)> {
+    ) -> Result<'alloc, (SourceLocation, Option<&'alloc str>, TerminalId)> {
         let name = self.identifier_name(builder)?;
         Ok((
             SourceLocation::new(start, self.offset()),
@@ -503,7 +503,7 @@ impl<'alloc> Lexer<'alloc> {
     ///     `u` Hex4Digits
     ///     `u{` CodePoint `}`
     /// ```
-    fn unicode_escape_sequence_after_backslash(&mut self) -> Result<char> {
+    fn unicode_escape_sequence_after_backslash(&mut self) -> Result<'alloc, char> {
         match self.chars.next() {
             Some('u') => {}
             _ => {
@@ -513,7 +513,7 @@ impl<'alloc> Lexer<'alloc> {
         self.unicode_escape_sequence_after_backslash_and_u()
     }
 
-    fn unicode_escape_sequence_after_backslash_and_u(&mut self) -> Result<char> {
+    fn unicode_escape_sequence_after_backslash_and_u(&mut self) -> Result<'alloc, char> {
         let value = match self.peek() {
             Some('{') => {
                 self.chars.next();
@@ -557,7 +557,7 @@ impl<'alloc> Lexer<'alloc> {
     /// DecimalDigit :: one of
     ///     `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
     /// ```
-    fn decimal_digits(&mut self) -> Result<bool> {
+    fn decimal_digits(&mut self) -> Result<'alloc, bool> {
         if let Some('0'..='9') = self.peek() {
             self.chars.next();
         } else {
@@ -568,7 +568,7 @@ impl<'alloc> Lexer<'alloc> {
         Ok(true)
     }
 
-    fn decimal_digits_after_first_digit(&mut self) -> Result<()> {
+    fn decimal_digits_after_first_digit(&mut self) -> Result<'alloc, ()> {
         while let Some(next) = self.peek() {
             match next {
                 '_' => {
@@ -603,7 +603,7 @@ impl<'alloc> Lexer<'alloc> {
     ///     `+` DecimalDigits
     ///     `-` DecimalDigits
     /// ```
-    fn optional_exponent(&mut self) -> Result<()> {
+    fn optional_exponent(&mut self) -> Result<'alloc, ()> {
         if let Some('e') | Some('E') = self.peek() {
             self.chars.next();
 
@@ -622,7 +622,7 @@ impl<'alloc> Lexer<'alloc> {
     /// HexDigit :: one of
     ///     `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `a` `b` `c` `d` `e` `f` `A` `B` `C` `D` `E` `F`
     /// ```
-    fn hex_digit(&mut self) -> Result<u32> {
+    fn hex_digit(&mut self) -> Result<'alloc, u32> {
         match self.chars.next() {
             None => Err(ParseError::InvalidEscapeSequence),
             Some(c @ '0'..='9') => Ok(c as u32 - '0' as u32),
@@ -632,7 +632,7 @@ impl<'alloc> Lexer<'alloc> {
         }
     }
 
-    fn code_point_to_char(value: u32) -> Result<char> {
+    fn code_point_to_char(value: u32) -> Result<'alloc, char> {
         if 0xd800 <= value && value <= 0xdfff {
             Err(ParseError::NotImplemented(
                 "unicode escape sequences (surrogates)",
@@ -646,7 +646,7 @@ impl<'alloc> Lexer<'alloc> {
     /// Hex4Digits ::
     ///     HexDigit HexDigit HexDigit HexDigit
     /// ```
-    fn hex_4_digits(&mut self) -> Result<char> {
+    fn hex_4_digits(&mut self) -> Result<'alloc, char> {
         let mut value = 0;
         for _ in 0..4 {
             value = (value << 4) | self.hex_digit()?;
@@ -662,7 +662,7 @@ impl<'alloc> Lexer<'alloc> {
     ///    HexDigit
     ///    HexDigits HexDigit
     /// ```
-    fn code_point(&mut self) -> Result<char> {
+    fn code_point(&mut self) -> Result<'alloc, char> {
         let mut value = self.hex_digit()?;
 
         loop {
@@ -707,7 +707,7 @@ impl<'alloc> Lexer<'alloc> {
     /// BigIntLiteralSuffix ::
     ///     `n`
     /// ```
-    fn numeric_literal_starting_with_zero(&mut self) -> Result<NumericType> {
+    fn numeric_literal_starting_with_zero(&mut self) -> Result<'alloc, NumericType> {
         match self.peek() {
             // BinaryIntegerLiteral ::
             //     `0b` BinaryDigits
@@ -900,7 +900,7 @@ impl<'alloc> Lexer<'alloc> {
     }
 
     /// Scan a NumericLiteral (defined in 11.8.3, extended by B.1.1).
-    fn decimal_literal(&mut self) -> Result<NumericType> {
+    fn decimal_literal(&mut self) -> Result<'alloc, NumericType> {
         // DecimalLiteral ::
         //     DecimalIntegerLiteral `.` DecimalDigits? ExponentPart?
         //     `.` DecimalDigits ExponentPart?
@@ -922,12 +922,12 @@ impl<'alloc> Lexer<'alloc> {
 
     /// Scan a NumericLiteral (defined in 11.8.3, extended by B.1.1) after
     /// having already consumed the first character, which is a decimal digit.
-    fn decimal_literal_after_first_digit(&mut self) -> Result<NumericType> {
+    fn decimal_literal_after_first_digit(&mut self) -> Result<'alloc, NumericType> {
         self.decimal_digits_after_first_digit()?;
         self.decimal_literal_after_digits()
     }
 
-    fn decimal_literal_after_digits(&mut self) -> Result<NumericType> {
+    fn decimal_literal_after_digits(&mut self) -> Result<'alloc, NumericType> {
         match self.peek() {
             Some('.') => {
                 self.chars.next();
@@ -945,7 +945,7 @@ impl<'alloc> Lexer<'alloc> {
         Ok(NumericType::Normal)
     }
 
-    fn check_after_numeric_literal(&self) -> Result<()> {
+    fn check_after_numeric_literal(&self) -> Result<'alloc, ()> {
         // The SourceCharacter immediately following a
         // NumericLiteral must not be an IdentifierStart or
         // DecimalDigit. (11.8.3)
@@ -994,7 +994,7 @@ impl<'alloc> Lexer<'alloc> {
     /// FourToSeven :: one of
     ///     `4` `5` `6` `7`
     /// ```
-    fn escape_sequence(&mut self, text: &mut String<'alloc>) -> Result<()> {
+    fn escape_sequence(&mut self, text: &mut String<'alloc>) -> Result<'alloc, ()> {
         match self.chars.next() {
             None => {
                 return Err(ParseError::UnterminatedString);
@@ -1137,7 +1137,7 @@ impl<'alloc> Lexer<'alloc> {
     fn string_literal(
         &mut self,
         delimiter: char,
-    ) -> Result<(SourceLocation, Option<&'alloc str>, TerminalId)> {
+    ) -> Result<'alloc, (SourceLocation, Option<&'alloc str>, TerminalId)> {
         let offset = self.offset() - 1;
         let mut builder = AutoCow::new(&self);
         loop {
@@ -1181,7 +1181,10 @@ impl<'alloc> Lexer<'alloc> {
     // ------------------------------------------------------------------------
     // 11.8.5 Regular Expression Literals
 
-    fn regular_expression_backslash_sequence(&mut self, text: &mut String<'alloc>) -> Result<()> {
+    fn regular_expression_backslash_sequence(
+        &mut self,
+        text: &mut String<'alloc>,
+    ) -> Result<'alloc, ()> {
         text.push('\\');
         match self.chars.next() {
             None | Some(CR) | Some(LF) | Some(LS) | Some(PS) => Err(ParseError::UnterminatedRegExp),
@@ -1196,7 +1199,7 @@ impl<'alloc> Lexer<'alloc> {
     fn regular_expression_literal(
         &mut self,
         builder: &mut AutoCow<'alloc>,
-    ) -> Result<(SourceLocation, Option<&'alloc str>, TerminalId)> {
+    ) -> Result<'alloc, (SourceLocation, Option<&'alloc str>, TerminalId)> {
         let offset = self.offset();
 
         loop {
@@ -1319,7 +1322,7 @@ impl<'alloc> Lexer<'alloc> {
         start: usize,
         subst: TerminalId,
         tail: TerminalId,
-    ) -> Result<(SourceLocation, Option<&'alloc str>, TerminalId)> {
+    ) -> Result<'alloc, (SourceLocation, Option<&'alloc str>, TerminalId)> {
         let mut builder = AutoCow::new(&self);
         while let Some(ch) = self.chars.next() {
             // TemplateCharacter ::
@@ -1377,7 +1380,7 @@ impl<'alloc> Lexer<'alloc> {
     fn advance_impl<'parser>(
         &mut self,
         parser: &Parser<'parser>,
-    ) -> Result<(SourceLocation, Option<&'alloc str>, TerminalId)> {
+    ) -> Result<'alloc, (SourceLocation, Option<&'alloc str>, TerminalId)> {
         let mut builder = AutoCow::new(&self);
         let mut start = self.offset();
         while let Some(c) = self.chars.next() {

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -37,7 +37,7 @@ pub fn parse_script<'alloc>(
     source: &'alloc str,
     _options: &ParseOptions,
     atoms: Rc<RefCell<SourceAtomSet<'alloc>>>,
-) -> Result<arena::Box<'alloc, Script<'alloc>>> {
+) -> Result<'alloc, arena::Box<'alloc, Script<'alloc>>> {
     Ok(parse(allocator, source, START_STATE_SCRIPT, atoms)?.to_ast()?)
 }
 
@@ -46,7 +46,7 @@ pub fn parse_module<'alloc>(
     source: &'alloc str,
     _options: &ParseOptions,
     atoms: Rc<RefCell<SourceAtomSet<'alloc>>>,
-) -> Result<arena::Box<'alloc, Module<'alloc>>> {
+) -> Result<'alloc, arena::Box<'alloc, Module<'alloc>>> {
     Ok(parse(allocator, source, START_STATE_MODULE, atoms)?.to_ast()?)
 }
 
@@ -55,7 +55,7 @@ fn parse<'alloc>(
     source: &'alloc str,
     start_state: usize,
     atoms: Rc<RefCell<SourceAtomSet<'alloc>>>,
-) -> Result<StackValue<'alloc>> {
+) -> Result<'alloc, StackValue<'alloc>> {
     let mut tokens = Lexer::new(allocator, source.chars(), atoms.clone());
 
     TABLES.check();
@@ -76,7 +76,7 @@ pub fn is_partial_script<'alloc>(
     allocator: &'alloc bumpalo::Bump,
     source: &'alloc str,
     atoms: Rc<RefCell<SourceAtomSet<'alloc>>>,
-) -> Result<bool> {
+) -> Result<'alloc, bool> {
     let mut parser = Parser::new(
         AstBuilder::new(allocator, atoms.clone()),
         START_STATE_SCRIPT,

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -24,7 +24,7 @@ impl<'alloc> AstBuilderDelegate<'alloc> for Parser<'alloc> {
 }
 
 impl<'alloc> ParserTrait<'alloc, StackValue<'alloc>> for Parser<'alloc> {
-    fn shift(&mut self, tv: TermValue<StackValue<'alloc>>) -> Result<bool> {
+    fn shift(&mut self, tv: TermValue<StackValue<'alloc>>) -> Result<'alloc, bool> {
         // Shift the new terminal/nonterminal and its associated value.
         let mut state = self.state();
         assert!(state < TABLES.shift_count);
@@ -71,7 +71,7 @@ impl<'alloc> ParserTrait<'alloc, StackValue<'alloc>> for Parser<'alloc> {
         self.state_stack.pop().unwrap();
         self.node_stack.pop().unwrap()
     }
-    fn check_not_on_new_line(&mut self, peek: usize) -> Result<bool> {
+    fn check_not_on_new_line(&mut self, peek: usize) -> Result<'alloc, bool> {
         let sv = &self.node_stack[self.node_stack.len() - peek].value;
         if let StackValue::Token(ref token) = sv {
             if !token.is_on_new_line {
@@ -103,7 +103,7 @@ impl<'alloc> Parser<'alloc> {
         *self.state_stack.last().unwrap()
     }
 
-    pub fn write_token(&mut self, token: &Token) -> Result<()> {
+    pub fn write_token(&mut self, token: &Token) -> Result<'alloc, ()> {
         // Shift the token with the associated StackValue.
         let accept = self.shift(TermValue {
             term: Term::Terminal(token.terminal_id),
@@ -115,7 +115,7 @@ impl<'alloc> Parser<'alloc> {
         Ok(())
     }
 
-    pub fn close(&mut self, position: usize) -> Result<StackValue<'alloc>> {
+    pub fn close(&mut self, position: usize) -> Result<'alloc, StackValue<'alloc>> {
         // Shift the End terminal with the associated StackValue.
         let loc = SourceLocation::new(position, position);
         let token = Token::basic_token(TerminalId::End, loc);
@@ -138,7 +138,7 @@ impl<'alloc> Parser<'alloc> {
         Ok(self.node_stack.pop().unwrap().value)
     }
 
-    pub(crate) fn parse_error(t: &Token) -> ParseError {
+    pub(crate) fn parse_error(t: &Token) -> ParseError<'alloc> {
         if t.terminal_id == TerminalId::End {
             ParseError::UnexpectedEnd
         } else {
@@ -146,7 +146,7 @@ impl<'alloc> Parser<'alloc> {
         }
     }
 
-    fn try_error_handling(&mut self, t: TermValue<StackValue<'alloc>>) -> Result<bool> {
+    fn try_error_handling(&mut self, t: TermValue<StackValue<'alloc>>) -> Result<'alloc, bool> {
         if let StackValue::Token(ref token) = t.value {
             // Error tokens might them-self cause more errors to be reported.
             // This happens due to the fact that the ErrorToken can be replayed,
@@ -179,7 +179,7 @@ impl<'alloc> Parser<'alloc> {
         Err(ParseError::ParserCannotUnpackToken)
     }
 
-    pub(crate) fn recover(t: &Token, error_code: ErrorCode) -> Result<()> {
+    pub(crate) fn recover(t: &Token, error_code: ErrorCode) -> Result<'alloc, ()> {
         match error_code {
             ErrorCode::Asi => {
                 if t.is_on_new_line

--- a/crates/parser/src/simulator.rs
+++ b/crates/parser/src/simulator.rs
@@ -32,7 +32,7 @@ pub struct Simulator<'alloc, 'parser> {
 }
 
 impl<'alloc, 'parser> ParserTrait<'alloc, ()> for Simulator<'alloc, 'parser> {
-    fn shift(&mut self, tv: TermValue<()>) -> Result<bool> {
+    fn shift(&mut self, tv: TermValue<()>) -> Result<'alloc, bool> {
         // Shift the new terminal/nonterminal and its associated value.
         let mut state = self.state();
         assert!(state < TABLES.shift_count);
@@ -92,7 +92,7 @@ impl<'alloc, 'parser> ParserTrait<'alloc, ()> for Simulator<'alloc, 'parser> {
         self.sp -= 1;
         TermValue { term: t, value: () }
     }
-    fn check_not_on_new_line(&mut self, _peek: usize) -> Result<bool> {
+    fn check_not_on_new_line(&mut self, _peek: usize) -> Result<'alloc, bool> {
         Ok(true)
     }
 }
@@ -122,7 +122,7 @@ impl<'alloc, 'parser> Simulator<'alloc, 'parser> {
         }
     }
 
-    pub fn write_token(&mut self, token: &Token) -> Result<()> {
+    pub fn write_token(&mut self, token: &Token) -> Result<'alloc, ()> {
         // Shift the token with the associated StackValue.
         let accept = self.shift(TermValue {
             term: Term::Terminal(token.terminal_id),
@@ -134,7 +134,7 @@ impl<'alloc, 'parser> Simulator<'alloc, 'parser> {
         Ok(())
     }
 
-    pub fn close(&mut self, _position: usize) -> Result<()> {
+    pub fn close(&mut self, _position: usize) -> Result<'alloc, ()> {
         // Shift the End terminal with the associated StackValue.
         let accept = self.shift(TermValue {
             term: Term::Terminal(TerminalId::End),
@@ -152,7 +152,7 @@ impl<'alloc, 'parser> Simulator<'alloc, 'parser> {
     }
 
     // Simulate the action of Parser::try_error_handling.
-    fn try_error_handling(&mut self, t: TermValue<()>) -> Result<bool> {
+    fn try_error_handling(&mut self, t: TermValue<()>) -> Result<'alloc, bool> {
         if let Term::Terminal(term) = t.term {
             let bogus_loc = SourceLocation::new(0, 0);
             let token = &Token::basic_token(term, bogus_loc);

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -63,7 +63,7 @@ fn chunks_to_string<'a, T: IntoChunks<'a>>(code: T) -> String {
 fn try_parse<'alloc, 'source, Source>(
     allocator: &'alloc Bump,
     code: Source,
-) -> Result<arena::Box<'alloc, Script<'alloc>>>
+) -> Result<'alloc, arena::Box<'alloc, Script<'alloc>>>
 where
     Source: IntoChunks<'source>,
 {

--- a/jsparagus/emit/rust.py
+++ b/jsparagus/emit/rust.py
@@ -433,7 +433,7 @@ class RustParserWriter:
         self.write(0, "}")
         self.write(0, "")
         self.write(0, "pub trait ParserTrait<'alloc, Value> {")
-        self.write(1, "fn shift(&mut self, tv: TermValue<Value>) -> Result<bool>;")
+        self.write(1, "fn shift(&mut self, tv: TermValue<Value>) -> Result<'alloc, bool>;")
         self.write(1, "fn replay(&mut self, tv: TermValue<Value>);")
         self.write(1, "fn rewind(&mut self, n: usize) {")
         self.write(2, "for _ in 0..n {")
@@ -443,7 +443,7 @@ class RustParserWriter:
         self.write(1, "}")
         self.write(1, "fn epsilon(&mut self, state: usize);")
         self.write(1, "fn pop(&mut self) -> TermValue<Value>;")
-        self.write(1, "fn check_not_on_new_line(&mut self, peek: usize) -> Result<bool>;")
+        self.write(1, "fn check_not_on_new_line(&mut self, peek: usize) -> Result<'alloc, bool>;")
         self.write(0, "}")
         self.write(0, "")
 
@@ -620,7 +620,7 @@ class RustParserWriter:
             used_variables = set()
             traits = mode_traits
             has_ast_builder = ast_builder in traits
-            self.write(0, "pub fn {}<'alloc, Handler>(parser: &mut Handler, state: usize) -> Result<bool>",
+            self.write(0, "pub fn {}<'alloc, Handler>(parser: &mut Handler, state: usize) -> Result<'alloc, bool>",
                        mode)
             self.write(0, "where")
             self.write(1, "Handler: {}", ' + '.join(map(self.type_to_rust, traits)))
@@ -661,7 +661,7 @@ class RustParserWriter:
         self.write(1, "handler: &mut AstBuilder<'alloc>,")
         self.write(1, "prod: usize,")
         self.write(1, "stack: &mut std::vec::Vec<StackValue<'alloc>>,")
-        self.write(0, ") -> Result<NonterminalId> {")
+        self.write(0, ") -> Result<'alloc, NonterminalId> {")
         self.write(1, "match prod {")
         for i, prod in enumerate(self.prods):
             # If prod.nt is not in nonterminals, that means it's a goal


### PR DESCRIPTION
3 changesets:
  * 1st one adds `'alloc` to `ParserError` and parser `Result`.  with temporary `PhantomData` to consume the lifetime parameter
  * 2nd one changes the `SourceAtomSet` to store `&'alloc str` instead of `String`, and change `String` to `&'alloc str` in other structs, and also remove `PhantomData` added in previous one
  * 3ed one changes `SourceAtomSet` to use `IndexSet` instead of `HashMap`

the corresponding change will be in https://bugzilla.mozilla.org/show_bug.cgi?id=1623172