### PR TITLE
Treat warning as error in automation (fixes #258) and build all crates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Initialize repository
       run: make init
     - name: Build
-      run: make all
+      run: RUSTFLAGS="-D warnings" make all
     - name: Test
       run: make check

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ $(STANDARD_ES_GRAMMAR_OUT): $(ECMA262_SPEC_HTML)
 	$(PYTHON) -m js_parser.extract_es_grammar $(ECMA262_SPEC_HTML) > $@ || rm $@
 
 rust: $(RS_AST_OUT) $(RS_TABLES_OUT)
-	cargo build
+	cargo build --features full
 
 jsparagus/parse_pgen_generated.py:
 	$(PYTHON) -m jsparagus.parse_pgen --regenerate > $@


### PR DESCRIPTION
This should catch non-default crates issue, and also catch warnings.