### PR TITLE
Fix interpreter tests

### DIFF
--- a/crates/interpreter/src/evaluate.rs
+++ b/crates/interpreter/src/evaluate.rs
@@ -166,6 +166,10 @@ pub fn evaluate(emit: &EmitResult, global: Rc<RefCell<Object>>) -> Result<JSValu
                 stack.push(value);
             }
 
+            Opcode::DebugLeaveLexicalEnv => {
+                // This opcode should not be necessary for the debugger.
+            }
+
             Opcode::InitProp => {
                 let value = stack.pop().ok_or(EvalError::EmptyStack)?;
                 let obj = stack.pop().ok_or(EvalError::EmptyStack)?;

--- a/crates/interpreter/src/tests.rs
+++ b/crates/interpreter/src/tests.rs
@@ -1,20 +1,26 @@
+use ast::source_atom_set::SourceAtomSet;
 use bumpalo::Bump;
 use emitter::{emit, EmitOptions};
 use parser::{parse_script, ParseOptions};
+use std::cell::RefCell;
+use std::rc::Rc;
 
-use crate::{evaluate, EvalError, JSValue};
+use crate::{create_global, evaluate, EvalError, JSValue};
 
 fn try_evaluate(source: &str) -> Result<JSValue, EvalError> {
     let alloc = &Bump::new();
     let parse_options = ParseOptions::new();
-    let parse_result = parse_script(alloc, source, &parse_options).expect("Failed to parse");
+    let atoms = Rc::new(RefCell::new(SourceAtomSet::new()));
+    let parse_result =
+        parse_script(alloc, source, &parse_options, atoms.clone()).expect("Failed to parse");
     let emit_options = EmitOptions::new();
     let emit_result = emit(
         &mut ast::types::Program::Script(parse_result.unbox()),
         &emit_options,
+        atoms.replace(SourceAtomSet::new_uninitialized()),
     )
     .expect("Should work!");
-    evaluate(&emit_result)
+    evaluate(&emit_result, create_global())
 }
 
 #[test]
@@ -100,6 +106,16 @@ fn test_if() {
 
     match try_evaluate("if (false) 1;") {
         Ok(JSValue::Undefined) => (),
+        _ => panic!("wrong result"),
+    }
+
+    match try_evaluate("var x; if (true) { x = 1; } else { x = 2; } x") {
+        Ok(JSValue::Number(n)) if n == 1.0 => (),
+        _ => panic!("wrong result"),
+    }
+
+    match try_evaluate("var x; if (false) { x = 1; } else { x = 2; } x") {
+        Ok(JSValue::Number(n)) if n == 2.0 => (),
         _ => panic!("wrong result"),
     }
 }


### PR DESCRIPTION
I also added a test for if statements with statement blocks :tada:
I think it might be useful to run interpreter tests as well, this would basically allow us to test a very small subset and bytecode generation. So far updating the interpreter has been quite painless, and we can just not test stuff that is too complicated.