### PR TITLE
Interpreter improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,9 +139,13 @@ version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 dependencies = [
+ "ansi_term",
+ "atty",
  "bitflags",
+ "strsim",
  "textwrap",
  "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -393,6 +406,7 @@ dependencies = [
  "log",
  "rustyline",
  "rustyline-derive",
+ "structopt",
 ]
 
 [[package]]
@@ -506,7 +520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
  "memchr",
- "version_check",
+ "version_check 0.1.5",
 ]
 
 [[package]]
@@ -544,6 +558,32 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7959c6467d962050d639361f7703b2051c43036d03493c36f01d440fdd3138a"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check 0.9.1",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4002d9f55991d5e019fb940a90e1a95eb80c24e77cb2462dd4dc869604d543a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "syn-mid",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -761,6 +801,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8faa2719539bbe9d77869bfb15d4ee769f99525e707931452c97b693b3f159d"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88b8e18c69496aad6f9ddf4630dd7d585bcaf765786cb415b9aec2fe5a0430"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +839,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -874,10 +955,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
 
 [[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+
+[[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
+[[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 
 [[package]]
 name = "void"

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -15,6 +15,7 @@ rustyline = "6.0.0"
 rustyline-derive = "0.3.0"
 log = { version = "0.4.0", features = ["max_level_debug", "release_max_level_warn"] }
 env_logger = "0.7.1"
+structopt = "0.3"
 
 # jemalloc is temporarily disabled due to a known upstream bug (macOS crashes
 # in release builds): <https://github.com/gnzlbg/jemallocator/issues/136>

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -1,7 +1,8 @@
 mod demo;
 
 use env_logger;
-use std::env;
+use std::path::PathBuf;
+use structopt::StructOpt;
 
 // jemalloc is temporarily disabled due to a known upstream bug (macOS crashes
 // in release builds): <https://github.com/gnzlbg/jemallocator/issues/136>
@@ -11,19 +12,47 @@ use std::env;
 // #[global_allocator]
 // static ALLOC: Jemalloc = Jemalloc;
 
+#[derive(StructOpt, Debug)]
+#[structopt(name = "driver")]
+struct Opt {
+    /// Print AST
+    #[structopt(long)]
+    ast: bool,
+
+    /// Disassemble bytecode
+    #[structopt(short = "D", long)]
+    bytecode: bool,
+
+    /// Debug print EmitResult
+    #[structopt(long)]
+    emit_result: bool,
+
+    /// JavaScript (.js) file or directory to execute
+    #[structopt(name = "PATH", parse(from_os_str))]
+    path: Option<PathBuf>
+}
+
+
 fn main() {
     env_logger::init();
-    let args: Vec<String> = env::args().collect();
-    match args.len() {
-        1 => demo::read_print_loop(),
-        2 => match demo::parse_file_or_dir(&args[1]) {
+
+    let opt = Opt::from_args();
+
+    if let Some(path) = opt.path {
+        match demo::parse_file_or_dir(&path) {
             Ok(stats) => {
                 println!("{:#?}", stats);
             }
             Err(err) => {
                 eprintln!("{}", err);
             }
-        },
-        _ => eprintln!("usage: parser [FILE/DIR]"),
+        }
+        return;
     }
+
+    demo::read_print_loop(demo::Verbosity {
+        ast: opt.ast,
+        bytecode: opt.bytecode,
+        emit_result: opt.emit_result
+    });
 }

--- a/crates/interpreter/src/evaluate.rs
+++ b/crates/interpreter/src/evaluate.rs
@@ -59,6 +59,10 @@ impl<'alloc> Helpers for EmitResult<'alloc> {
     }
 }
 
+/// This functions can partially interpreter the bytecode shared with SpiderMonkey.
+///
+/// Note: This is not meant to be a spec compliant implementation of ECMAScript,
+/// instead the goal is to make basic programs testable with pure Rust.
 pub fn evaluate(emit: &EmitResult, global: Rc<RefCell<Object>>) -> Result<JSValue, EvalError> {
     let mut pc = 0;
     let mut stack = Vec::new();
@@ -105,6 +109,32 @@ pub fn evaluate(emit: &EmitResult, global: Rc<RefCell<Object>>) -> Result<JSValu
                 let rhs = stack.pop().ok_or(EvalError::EmptyStack)?;
                 let lhs = stack.pop().ok_or(EvalError::EmptyStack)?;
                 stack.push(JSValue::Boolean(strict_equality(&lhs, &rhs)))
+            }
+
+            Opcode::Lt => {
+                // TODO: This and below does not actually implement
+                // "Abstract Relational Comparison".
+                let rhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                let lhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                stack.push(JSValue::Boolean(to_number(&lhs) < to_number(&rhs)))
+            }
+
+            Opcode::Le => {
+                let rhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                let lhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                stack.push(JSValue::Boolean(to_number(&lhs) <= to_number(&rhs)))
+            }
+
+            Opcode::Gt => {
+                let rhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                let lhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                stack.push(JSValue::Boolean(to_number(&lhs) > to_number(&rhs)))
+            }
+
+            Opcode::Ge => {
+                let rhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                let lhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                stack.push(JSValue::Boolean(to_number(&lhs) >= to_number(&rhs)))
             }
 
             Opcode::Void => {

--- a/crates/interpreter/src/evaluate.rs
+++ b/crates/interpreter/src/evaluate.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::rc::Rc;
 
 use crate::object::Object;
-use crate::value::{to_boolean, to_number, JSValue};
+use crate::value::*;
 
 /// The error of evaluating JS bytecode.
 #[derive(Clone, Debug)]
@@ -99,6 +99,12 @@ pub fn evaluate(emit: &EmitResult, global: Rc<RefCell<Object>>) -> Result<JSValu
             Opcode::Neg => {
                 let v = stack.pop().ok_or(EvalError::EmptyStack)?;
                 stack.push(JSValue::Number(-to_number(&v)));
+            }
+
+            Opcode::StrictEq => {
+                let rhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                let lhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                stack.push(JSValue::Boolean(strict_equality(&lhs, &rhs)))
             }
 
             Opcode::Void => {

--- a/crates/interpreter/src/evaluate.rs
+++ b/crates/interpreter/src/evaluate.rs
@@ -95,6 +95,18 @@ pub fn evaluate(emit: &EmitResult, global: Rc<RefCell<Object>>) -> Result<JSValu
                 stack.push(JSValue::Number(to_number(&lhs) - to_number(&rhs)))
             }
 
+            Opcode::Mul => {
+                let rhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                let lhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                stack.push(JSValue::Number(to_number(&lhs) * to_number(&rhs)))
+            }
+
+            Opcode::Div => {
+                let rhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                let lhs = stack.pop().ok_or(EvalError::EmptyStack)?;
+                stack.push(JSValue::Number(to_number(&lhs) / to_number(&rhs)))
+            }
+
             Opcode::Pos => {
                 let v = stack.pop().ok_or(EvalError::EmptyStack)?;
                 stack.push(JSValue::Number(to_number(&v)));

--- a/crates/interpreter/src/globals.rs
+++ b/crates/interpreter/src/globals.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::object::Object;
-use crate::value::{to_number, JSValue};
+use crate::value::{to_number, strict_equality, JSValue};
 
 fn print(_this_value: JSValue, args: &[JSValue]) -> JSValue {
     println!("{:?}", args);
@@ -12,6 +12,18 @@ fn print(_this_value: JSValue, args: &[JSValue]) -> JSValue {
 fn sqrt(_this_value: JSValue, args: &[JSValue]) -> JSValue {
     let n = to_number(args.first().unwrap_or(&JSValue::Undefined));
     JSValue::Number(n.sqrt())
+}
+
+fn assert_eq(_this_value: JSValue, args: &[JSValue]) -> JSValue {
+    if args.len() != 2 {
+        panic!("assertEq expects exactly two arguments");
+    }
+
+    if !strict_equality(&args[0], &args[1]) {
+        panic!("{:?} is not equal to {:?}", args[0], args[1]);
+    }
+
+    JSValue::Undefined
 }
 
 pub fn create_global() -> Rc<RefCell<Object>> {
@@ -30,6 +42,10 @@ pub fn create_global() -> Rc<RefCell<Object>> {
     global
         .borrow_mut()
         .set("Math".to_owned(), JSValue::Object(math));
+
+    global
+        .borrow_mut()
+        .set("assertEq".to_owned(), JSValue::NativeFunction(assert_eq));
 
     global
 }

--- a/crates/interpreter/src/tests.js
+++ b/crates/interpreter/src/tests.js
@@ -14,3 +14,6 @@ if (1 < 100) {
 assertEq(x, 42)
 
 assertEq(Math.sqrt(36), 6);
+
+assertEq(4 * 5, 20);
+assertEq(20 / 4, 5);

--- a/crates/interpreter/src/tests.js
+++ b/crates/interpreter/src/tests.js
@@ -1,0 +1,16 @@
+assertEq(true, true);
+
+assertEq(1 < 2, true);
+assertEq(2 < 1, false);
+
+assertEq(undefined ?? "abc", "abc");
+
+var x = 1;
+if (1 < 100) {
+	x = 42;
+} else {
+	x = 12;
+}
+assertEq(x, 42)
+
+assertEq(Math.sqrt(36), 6);

--- a/crates/interpreter/src/tests.rs
+++ b/crates/interpreter/src/tests.rs
@@ -132,3 +132,11 @@ fn test_call() {
         _ => panic!("wrong result"),
     }
 }
+
+#[test]
+fn test_file() {
+    match try_evaluate(include_str!("tests.js")) {
+        Ok(JSValue::Undefined) => (),
+        _ => panic!("rval of tests.js should be 'undefined'"),
+    }
+}

--- a/crates/interpreter/src/value.rs
+++ b/crates/interpreter/src/value.rs
@@ -58,3 +58,16 @@ pub fn to_boolean(v: &JSValue) -> bool {
         JSValue::Object(_) | JSValue::NativeFunction(_) => true,
     }
 }
+
+pub fn strict_equality(x: &JSValue, y: &JSValue) -> bool {
+    match (x, y) {
+        (JSValue::Undefined, JSValue::Undefined) => true,
+        (JSValue::Null, JSValue::Null) => true,
+        (JSValue::Boolean(a), JSValue::Boolean(b)) => a == b,
+        (JSValue::Number(a), JSValue::Number(b)) => a == b,
+        (JSValue::String(ref a), JSValue::String(ref b)) => a == b,
+        (JSValue::Object(ref a), JSValue::Object(ref b)) => a.as_ptr() == b.as_ptr(),
+        (JSValue::NativeFunction(a), JSValue::NativeFunction(b)) => std::ptr::eq(a, b),
+        _ => false
+    }
+}


### PR DESCRIPTION
I changed the driver to not output any of the verbose debug info like AST etc. by default. If that is to controversial we could probably change the default value. Personally I find the EmitResult especially too verbose.

The rest are just incremental improvements to the interpreter. Adding `assertEq` especially makes it possible to write tests in JS. Together with `include_str` we can add all new tests to `tests.js` going forward.