### PR TITLE
Track free names for each scope (fixes #416)

### DIFF
--- a/crates/emitter/src/free_name_tracker.rs
+++ b/crates/emitter/src/free_name_tracker.rs
@@ -1,0 +1,95 @@
+use ast::source_atom_set::SourceAtomSetIndex;
+use std::collections::hash_map::RandomState;
+use std::collections::hash_set::Difference;
+use std::collections::HashSet;
+
+/// Tracks free names in a scope, to compute which binding is closed over.
+///
+/// The scope is either script-scope or non-script scope.
+/// Script-scope is a scope that's associated with a global or a function.
+/// Non-script-scope is everything else.
+/// A non-script-scope belongs to a script-scope.
+///
+/// If a scope S1 uses names [A, B, C], and defines [A, B],
+/// name C is a free name, that's considered to be defined in outer scope
+/// (or maybe dynamic name).
+///
+/// If C is defined in a scope S2 that corresponds to different
+/// script-scope than S1's script-scope, C in S2 is marked "closed over".
+#[derive(Debug)]
+pub struct FreeNameTracker {
+    /// Names closed over in inner script-scopes, that's not yet
+    /// defined up to (excluding) the current scope.
+    /// The name might be defined in the current scope.
+    ///
+    /// The name defined in this or outer scope is marked "closed over", and
+    /// no more propagated to outer scope.
+    closed_over_names: HashSet<SourceAtomSetIndex>,
+
+    /// Names used in the current scope, and nested non-script scopes.
+    /// The name might be defined in the current scope.
+    used_names: HashSet<SourceAtomSetIndex>,
+
+    /// Names defined in the current scope.
+    def_names: HashSet<SourceAtomSetIndex>,
+}
+
+impl FreeNameTracker {
+    pub fn new() -> Self {
+        Self {
+            closed_over_names: HashSet::new(),
+            used_names: HashSet::new(),
+            def_names: HashSet::new(),
+        }
+    }
+
+    fn note_closed_over(&mut self, atom: SourceAtomSetIndex) {
+        self.closed_over_names.insert(atom);
+    }
+
+    /// Note that the given name is used in this scope.
+    pub fn note_use(&mut self, atom: SourceAtomSetIndex) {
+        self.used_names.insert(atom);
+    }
+
+    pub fn note_def(&mut self, atom: SourceAtomSetIndex) {
+        self.def_names.insert(atom);
+    }
+
+    /// Names closed over in inner script-scopes, that's not yet defined.
+    fn closed_over_freevars(&self) -> Difference<'_, SourceAtomSetIndex, RandomState> {
+        self.closed_over_names.difference(&self.def_names)
+    }
+
+    /// Names used in this and inner non-script scopes, that's not yet defined.
+    fn used_freevars(&self) -> Difference<'_, SourceAtomSetIndex, RandomState> {
+        self.used_names.difference(&self.def_names)
+    }
+
+    pub fn is_closed_over_def(&self, atom: &SourceAtomSetIndex) -> bool {
+        return self.def_names.contains(atom) && self.closed_over_names.contains(atom);
+    }
+
+    /// Propagate free closed over names and used names from the inner
+    /// non-script scope.
+    pub fn propagate_from_inner_non_script(&mut self, inner: &FreeNameTracker) {
+        for atom in inner.closed_over_freevars() {
+            self.note_closed_over(*atom);
+        }
+        for atom in inner.used_freevars() {
+            self.note_use(*atom);
+        }
+    }
+
+    #[allow(dead_code)]
+    /// Propagate free closed over names and used names from the inner
+    /// script scope, converting everything into free closed over names
+    pub fn propagate_from_inner_script(&mut self, inner: &FreeNameTracker) {
+        for atom in inner.closed_over_freevars() {
+            self.note_closed_over(*atom);
+        }
+        for atom in inner.used_freevars() {
+            self.note_closed_over(*atom);
+        }
+    }
+}

--- a/crates/emitter/src/lib.rs
+++ b/crates/emitter/src/lib.rs
@@ -5,6 +5,7 @@ mod emitter;
 mod emitter_scope;
 mod forward_jump_emitter;
 mod frame_slot;
+mod free_name_tracker;
 mod gcthings;
 pub mod opcode;
 pub mod opcode_info;

--- a/crates/emitter/src/scope.rs
+++ b/crates/emitter/src/scope.rs
@@ -21,18 +21,18 @@ pub struct BindingName {
 }
 
 impl BindingName {
-    pub fn new(name: SourceAtomSetIndex) -> Self {
+    pub fn new(name: SourceAtomSetIndex, is_closed_over: bool) -> Self {
         Self {
             name,
-            is_closed_over: false,
+            is_closed_over,
             is_top_level_function: false,
         }
     }
 
-    pub fn new_top_level_function(name: SourceAtomSetIndex) -> Self {
+    pub fn new_top_level_function(name: SourceAtomSetIndex, is_closed_over: bool) -> Self {
         Self {
             name,
-            is_closed_over: false,
+            is_closed_over,
             is_top_level_function: true,
         }
     }

--- a/crates/emitter/src/scope_pass.rs
+++ b/crates/emitter/src/scope_pass.rs
@@ -301,7 +301,7 @@ impl GlobalContext {
         }
     }
 
-    fn declare_var<'alloc>(&mut self, binding: &BindingIdentifier) {
+    fn declare_var(&mut self, binding: &BindingIdentifier) {
         // Runtime Semantics: GlobalDeclarationInstantiation ( script, env )
         // https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
         //
@@ -326,7 +326,7 @@ impl GlobalContext {
         self.declared_var_names.insert(binding.name.value);
     }
 
-    fn declare_let<'alloc>(&mut self, binding: &BindingIdentifier) {
+    fn declare_let(&mut self, binding: &BindingIdentifier) {
         // Runtime Semantics: GlobalDeclarationInstantiation ( script, env )
         // https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
         //
@@ -335,7 +335,7 @@ impl GlobalContext {
         self.let_names.push(binding.name.value);
     }
 
-    fn declare_const<'alloc>(&mut self, binding: &BindingIdentifier) {
+    fn declare_const(&mut self, binding: &BindingIdentifier) {
         // Runtime Semantics: GlobalDeclarationInstantiation ( script, env )
         // https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
         //
@@ -344,7 +344,7 @@ impl GlobalContext {
         self.const_names.push(binding.name.value);
     }
 
-    fn declare_function<'alloc>(&mut self, fun: &Function) {
+    fn declare_function(&mut self, fun: &Function) {
         // Step 10. For each d in varDeclarations, in reverse list order, do
         // Step 10.a. If d is neither a VariableDeclaration nor a ForBinding
         //            nor a BindingIdentifier, then
@@ -469,7 +469,7 @@ impl BlockContext {
         }
     }
 
-    fn declare_let<'alloc>(&mut self, binding: &BindingIdentifier) {
+    fn declare_let(&mut self, binding: &BindingIdentifier) {
         // https://tc39.es/ecma262/#sec-blockdeclarationinstantiation
         // Runtime Semantics: BlockDeclarationInstantiation ( code, env )
         //
@@ -477,7 +477,7 @@ impl BlockContext {
         self.let_names.push(binding.name.value);
     }
 
-    fn declare_const<'alloc>(&mut self, binding: &BindingIdentifier) {
+    fn declare_const(&mut self, binding: &BindingIdentifier) {
         // https://tc39.es/ecma262/#sec-blockdeclarationinstantiation
         // Runtime Semantics: BlockDeclarationInstantiation ( code, env )
         //
@@ -485,7 +485,7 @@ impl BlockContext {
         self.const_names.push(binding.name.value);
     }
 
-    fn declare_function<'alloc>(&mut self, fun: &Function) {
+    fn declare_function(&mut self, fun: &Function) {
         // https://tc39.es/ecma262/#sec-blockdeclarationinstantiation
         // Runtime Semantics: BlockDeclarationInstantiation ( code, env )
         //

--- a/crates/emitter/src/scope_pass.rs
+++ b/crates/emitter/src/scope_pass.rs
@@ -14,7 +14,6 @@ use std::marker::PhantomData;
 ///
 /// This enum isn't actually used, but just for simplifying comment in
 /// ScopeKind.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 enum VarScopedDeclarationsItemKind {
     /// Static Semantics: VarScopedDeclarations
@@ -29,6 +28,7 @@ enum VarScopedDeclarationsItemKind {
     /// 1. Let declarations be VarScopedDeclarations of VariableDeclarationList.
     /// 2. Append VariableDeclaration to declarations.
     /// 3. Return declarations.
+    #[allow(dead_code)]
     VariableDeclaration,
 
     /// Static Semantics: VarScopedDeclarations
@@ -43,6 +43,7 @@ enum VarScopedDeclarationsItemKind {
     /// 2. Append to declarations the elements of the VarScopedDeclarations of
     ///    Statement.
     /// 3. Return declarations.
+    #[allow(dead_code)]
     ForBinding,
 
     /// Static Semantics: VarScopedDeclarations
@@ -75,21 +76,25 @@ enum VarScopedDeclarationsItemKind {
     /// HoistableDeclaration : FunctionDeclaration
     ///
     /// 1. Return FunctionDeclaration.
+    #[allow(dead_code)]
     FunctionDeclaration,
 
     /// HoistableDeclaration : GeneratorDeclaration
     ///
     /// 1. Return GeneratorDeclaration.
+    #[allow(dead_code)]
     GeneratorDeclaration,
 
     /// HoistableDeclaration : AsyncFunctionDeclaration
     ///
     /// 1. Return AsyncFunctionDeclaration.
+    #[allow(dead_code)]
     AsyncFunctionDeclaration,
 
     /// HoistableDeclaration : AsyncGeneratorDeclaration
     ///
     /// 1. Return AsyncGeneratorDeclaration.
+    #[allow(dead_code)]
     AsyncGeneratorDeclaration,
 
     /// Static Semantics: TopLevelVarScopedDeclarations
@@ -110,6 +115,7 @@ enum VarScopedDeclarationsItemKind {
     /// 2. Append to declarations the elements of the VarScopedDeclarations of
     ///    Statement.
     /// 3. Return declarations.
+    #[allow(dead_code)]
     BindingIdentifier,
 }
 
@@ -117,7 +123,6 @@ enum VarScopedDeclarationsItemKind {
 ///
 /// This enum isn't actually used, but just for simplifying comment in
 /// ScopeKind.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 enum LexicallyScopedDeclarations {
     /// Static Semantics: LexicallyScopedDeclarations
@@ -133,32 +138,39 @@ enum LexicallyScopedDeclarations {
     /// HoistableDeclaration : FunctionDeclaration
     ///
     /// 1. Return FunctionDeclaration.
+    #[allow(dead_code)]
     FunctionDeclaration,
 
     /// HoistableDeclaration : GeneratorDeclaration
     ///
     /// 1. Return GeneratorDeclaration.
+    #[allow(dead_code)]
     GeneratorDeclaration,
 
     /// HoistableDeclaration : AsyncFunctionDeclaration
     ///
     /// 1. Return AsyncFunctionDeclaration.
+    #[allow(dead_code)]
     AsyncFunctionDeclaration,
 
     /// HoistableDeclaration : AsyncGeneratorDeclaration
     ///
     /// 1. Return AsyncGeneratorDeclaration.
+    #[allow(dead_code)]
     AsyncGeneratorDeclaration,
 
     /// Declaration : ClassDeclaration
     ///
     /// 1. Return ClassDeclaration.
+    #[allow(dead_code)]
     ClassDeclaration,
 
     /// Declaration : LexicalDeclaration
     ///
     /// 1. Return LexicalDeclaration.
+    #[allow(dead_code)]
     LexicalDeclarationWithLet,
+    #[allow(dead_code)]
     LexicalDeclarationWithConst,
 
     /// Static Semantics: LexicallyScopedDeclarations
@@ -211,6 +223,7 @@ enum LexicallyScopedDeclarations {
     /// ExportDeclaration : export default AssignmentExpression ;
     ///
     /// 1. Return a new List containing this ExportDeclaration.
+    #[allow(dead_code)]
     ExportDeclarationWithAssignmentExpression,
 }
 


### PR DESCRIPTION
3 changesets with 2 cleanups and 1 main change (the last one).

The main one introduces `FreeNameTracker` that tracks the following:
  * names used in the current scope: `used_names`
  * names used and not yet defined in inner scopes
    * if it's in the same script, it's in `used_names`
    * if it's in the different script, it's in `closed_over_names`
  * names defined in the current scope: `def_names`

when creating `BindingName`, the above info is used to compute `is_closed_over`,
and also when leaving the scope, unresolved (not-yet-defined) use are propagated to outer scope

This patch actually doesn't change anything, given currently we have only one script, that is global,
and haven't supported function.
Once function scope is introduced, `ContextStack::pop` is supposed to call `FreeNameTracker::propagate_from_inner_script`, so that `closed_over_names` is populated, and `is_closed_over` becomes true.

at the same point (or maybe before that), I'm going to introduce `EnvironmentObject`,
to allocate environment on heap, not stack frame.