### PR TITLE
Support non-decimal literals (fixes #263)

### DIFF
--- a/crates/driver/src/demo.rs
+++ b/crates/driver/src/demo.rs
@@ -128,9 +128,8 @@ pub struct Verbosity {
     pub bytecode: bool,
 
     /// Debug print EmitResult
-    pub emit_result: bool
+    pub emit_result: bool,
 }
-
 
 fn handle_script<'alloc>(
     verbosity: &Verbosity,

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -29,9 +29,8 @@ struct Opt {
 
     /// JavaScript (.js) file or directory to execute
     #[structopt(name = "PATH", parse(from_os_str))]
-    path: Option<PathBuf>
+    path: Option<PathBuf>,
 }
-
 
 fn main() {
     env_logger::init();
@@ -53,6 +52,6 @@ fn main() {
     demo::read_print_loop(demo::Verbosity {
         ast: opt.ast,
         bytecode: opt.bytecode,
-        emit_result: opt.emit_result
+        emit_result: opt.emit_result,
     });
 }

--- a/crates/interpreter/src/globals.rs
+++ b/crates/interpreter/src/globals.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::object::Object;
-use crate::value::{to_number, strict_equality, JSValue};
+use crate::value::{strict_equality, to_number, JSValue};
 
 fn print(_this_value: JSValue, args: &[JSValue]) -> JSValue {
     println!("{:?}", args);

--- a/crates/interpreter/src/value.rs
+++ b/crates/interpreter/src/value.rs
@@ -68,6 +68,6 @@ pub fn strict_equality(x: &JSValue, y: &JSValue) -> bool {
         (JSValue::String(ref a), JSValue::String(ref b)) => a == b,
         (JSValue::Object(ref a), JSValue::Object(ref b)) => a.as_ptr() == b.as_ptr(),
         (JSValue::NativeFunction(a), JSValue::NativeFunction(b)) => std::ptr::eq(a, b),
-        _ => false
+        _ => false,
     }
 }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(feature = "unstable", feature(test))]
 
 mod lexer;
+pub mod numeric_value;
 mod parser;
 mod simulator;
 

--- a/crates/parser/src/numeric_value.rs
+++ b/crates/parser/src/numeric_value.rs
@@ -1,0 +1,127 @@
+//! Parse NumericLiteral.
+
+#[derive(Debug)]
+pub enum NumericLiteralBase {
+    Decimal,
+    Binary,
+    Octal,
+    Hex,
+}
+
+// To avoid allocating extra buffer when '_' is present, integer cases are
+// handled without Rust standard `parse` function.
+fn parse_decimal_int(s: &str) -> f64 {
+    debug_assert!(!s.is_empty());
+
+    let src = s.as_bytes();
+
+    let mut result = 0.0;
+    for &c in src {
+        match c {
+            b'0'..=b'9' => {
+                let n = c - b'0';
+                result = result * 10.0 + n as f64;
+            }
+            b'_' => {}
+            _ => panic!("invalid syntax"),
+        }
+    }
+    result
+}
+
+fn parse_binary(s: &str) -> f64 {
+    debug_assert!(!s.is_empty());
+
+    let src = s.as_bytes();
+
+    let mut result = 0.0;
+    for &c in src {
+        match c {
+            b'0'..=b'1' => {
+                let n = c - b'0';
+                result = result * 2.0 + n as f64;
+            }
+            b'_' => {}
+            _ => panic!("invalid syntax"),
+        }
+    }
+    result
+}
+
+fn parse_octal(s: &str) -> f64 {
+    debug_assert!(!s.is_empty());
+
+    let src = s.as_bytes();
+
+    let mut result = 0.0;
+    for &c in src {
+        match c {
+            b'0'..=b'7' => {
+                let n = c - b'0';
+                result = result * 8.0 + n as f64;
+            }
+            b'_' => {}
+            _ => panic!("invalid syntax"),
+        }
+    }
+    result
+}
+
+fn parse_hex(s: &str) -> f64 {
+    debug_assert!(!s.is_empty());
+
+    let src = s.as_bytes();
+
+    let mut result = 0.0;
+    for &c in src {
+        match c {
+            b'0'..=b'9' => {
+                let n = c - b'0';
+                result = result * 16.0 + n as f64;
+            }
+            b'A'..=b'F' => {
+                let n = c - b'A' + 10;
+                result = result * 16.0 + n as f64;
+            }
+            b'a'..=b'f' => {
+                let n = c - b'a' + 10;
+                result = result * 16.0 + n as f64;
+            }
+            b'_' => {}
+            _ => panic!("invalid syntax"),
+        }
+    }
+    result
+}
+
+/// Parse integer NumericLiteral.
+///
+/// NonDecimalIntegerLiteral should contain the leading '0x' etc.
+///
+/// FIXME: LegacyOctalIntegerLiteral is not supported.
+pub fn parse_int(s: &str, kind: NumericLiteralBase) -> f64 {
+    match kind {
+        NumericLiteralBase::Decimal => parse_decimal_int(s),
+        NumericLiteralBase::Binary => parse_binary(&s[2..]),
+        NumericLiteralBase::Octal => parse_octal(&s[2..]),
+        NumericLiteralBase::Hex => parse_hex(&s[2..]),
+    }
+}
+
+fn parse_float_with_underscore(s: &str) -> f64 {
+    let filtered: String = s.chars().filter(|c| *c != '_').collect();
+
+    filtered
+        .parse::<f64>()
+        .expect("DecimalLiteral should be accepted")
+}
+
+/// Parse non-integer NumericLiteral.
+pub fn parse_float(s: &str) -> f64 {
+    println!("parse_float: {}", s);
+    if s.contains('_') {
+        return parse_float_with_underscore(s);
+    }
+
+    s.parse::<f64>().expect("DecimalLiteral should be accepted")
+}

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -298,14 +298,32 @@ fn test_numbers() {
     assert_error_eq(".0e+", ParseError::UnexpectedEnd);
     assert_error_eq(".0e-", ParseError::UnexpectedEnd);
 
+    assert_parses("1.0E0");
+    assert_parses("1.E0");
+    assert_parses(".0E0");
+
+    assert_parses("1.0E+0");
+    assert_parses("1.E+0");
+    assert_parses(".0E+0");
+
+    assert_parses("1.0E-0");
+    assert_parses("1.E-0");
+    assert_parses(".0E-0");
+
+    assert_error_eq("1.0E", ParseError::UnexpectedEnd);
+    assert_error_eq("1.E", ParseError::UnexpectedEnd);
+    assert_error_eq(".0E", ParseError::UnexpectedEnd);
+
+    assert_error_eq("1.0E+", ParseError::UnexpectedEnd);
+    assert_error_eq("1.0E-", ParseError::UnexpectedEnd);
+    assert_error_eq(".0E+", ParseError::UnexpectedEnd);
+    assert_error_eq(".0E-", ParseError::UnexpectedEnd);
+
     assert_parses(".0");
     assert_parses("");
 
-    // FIXME: NYI: non-decimal literal
-    // assert_parses("0b0");
-    assert_not_implemented("0b0");
+    assert_parses("0b0");
 
-    /*
     assert_parses("0b1");
     assert_parses("0B01");
     assert_error_eq("0b", ParseError::UnexpectedEnd);
@@ -326,9 +344,75 @@ fn test_numbers() {
     assert_error_eq("0x", ParseError::UnexpectedEnd);
     assert_error_eq("0x ", ParseError::IllegalCharacter(' '));
     assert_error_eq("0xg", ParseError::IllegalCharacter('g'));
-     */
 
     assert_parses("1..x");
+
+    assert_parses("1_1");
+    assert_parses("0b1_1");
+    assert_parses("0o1_1");
+    assert_parses("0x1_1");
+
+    assert_parses("1_1.1_1");
+    assert_parses("1_1.1_1e+1_1");
+
+    assert_error_eq("1_", ParseError::UnexpectedEnd);
+    assert_error_eq("1._1", ParseError::IllegalCharacter('_'));
+    assert_error_eq("1.1_", ParseError::UnexpectedEnd);
+    assert_error_eq("1.1e1_", ParseError::UnexpectedEnd);
+    assert_error_eq("1.1e_1", ParseError::IllegalCharacter('_'));
+}
+
+#[test]
+fn test_bigint() {
+    assert_not_implemented("0n");
+    /*
+        assert_parses("0n");
+        assert_parses("1n");
+        assert_parses("10n");
+
+        assert_error_eq("0na", ParseError::IllegalCharacter('a'));
+        assert_error_eq("1na", ParseError::IllegalCharacter('a'));
+
+        assert_error_eq("1.0n", ParseError::IllegalCharacter('n'));
+        assert_error_eq(".0n", ParseError::IllegalCharacter('n'));
+        assert_error_eq("1.n", ParseError::IllegalCharacter('n'));
+
+        assert_error_eq("1e0n", ParseError::IllegalCharacter('n'));
+        assert_error_eq("1e+0n", ParseError::IllegalCharacter('n'));
+        assert_error_eq("1e-0n", ParseError::IllegalCharacter('n'));
+        assert_error_eq("1E0n", ParseError::IllegalCharacter('n'));
+        assert_error_eq("1E+0n", ParseError::IllegalCharacter('n'));
+        assert_error_eq("1E-0n", ParseError::IllegalCharacter('n'));
+
+        assert_parses("0b0n");
+
+        assert_parses("0b1n");
+        assert_parses("0B01n");
+        assert_error_eq("0bn", ParseError::IllegalCharacter('n'));
+
+        assert_parses("0o0n");
+        assert_parses("0o7n");
+        assert_parses("0O01234567n");
+        assert_error_eq("0on", ParseError::IllegalCharacter('n'));
+
+        assert_parses("0x0n");
+        assert_parses("0xfn");
+        assert_parses("0X0123456789abcdefn");
+        assert_parses("0X0123456789ABCDEFn");
+        assert_error_eq("0xn", ParseError::IllegalCharacter('n'));
+
+        assert_parses("1_1n");
+        assert_parses("0b1_1n");
+        assert_parses("0o1_1n");
+        assert_parses("0x1_1n");
+
+        assert_error_eq("1_1.1_1n", ParseError::IllegalCharacter('n'));
+        assert_error_eq("1_1.1_1e1_1n", ParseError::IllegalCharacter('n'));
+
+        assert_error_eq("1_n", ParseError::IllegalCharacter('n'));
+        assert_error_eq("1.1_n", ParseError::IllegalCharacter('n'));
+        assert_error_eq("1.1e1_n", ParseError::IllegalCharacter('n'));
+    */
 }
 
 #[test]


### PR DESCRIPTION
Supports `NonDecimalIntegerLiteral` and underscores between `DecimalDigits`.
for non-integer case, this still uses Rust standard `parse` function.
I suppose this yields the same result, but have to confirm.
(at least this doesn't hit any problematic case while working on BinAST, and I'd like to avoid porting dtoa.c to rust :P )

`BigInt` is not yet supported, given we don't yet have the storage for the result.
