### PR TITLE
Add parser stack and lookahead in the same container.

### DIFF
--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -3,6 +3,7 @@
 mod lexer;
 pub mod numeric_value;
 mod parser;
+mod queue_stack;
 mod simulator;
 
 #[cfg(test)]

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -1,3 +1,4 @@
+use crate::queue_stack::QueueStack;
 use crate::simulator::Simulator;
 use ast::SourceLocation;
 use generated_parser::{
@@ -9,11 +10,10 @@ use json_log::json_trace;
 pub struct Parser<'alloc> {
     /// Vector of states visited in the LR parse table.
     state_stack: Vec<usize>,
-    /// Vector of terms and their associated values.
-    node_stack: Vec<TermValue<StackValue<'alloc>>>,
-    /// Vector of lookahead terms and their associated value, to be emptied by
-    /// pop-ing elements from it before shifting any new terminals.
-    replay_stack: Vec<TermValue<StackValue<'alloc>>>,
+    /// Stack and Queue of terms and their associated values. The Queue
+    /// corresponds to terms which are added as lookahead as well as terms which
+    /// are replayed, and the stack matches the state_stack.
+    node_stack: QueueStack<TermValue<StackValue<'alloc>>>,
     /// Build the AST stored in the TermValue vectors.
     handler: AstBuilder<'alloc>,
 }
@@ -26,14 +26,17 @@ impl<'alloc> AstBuilderDelegate<'alloc> for Parser<'alloc> {
 
 impl<'alloc> ParserTrait<'alloc, StackValue<'alloc>> for Parser<'alloc> {
     fn shift(&mut self, tv: TermValue<StackValue<'alloc>>) -> Result<'alloc, bool> {
+        // The shift function should exit either by accepting the input or
+        // emptying its queue of lookahead.
+        debug_assert!(self.node_stack.queue_empty());
+        self.node_stack.enqueue(tv);
         // Shift the new terminal/nonterminal and its associated value.
         json_trace!({ "enter": "shift" });
         let mut state = self.state();
-        assert!(state < TABLES.shift_count);
-        let mut tv = tv;
-        loop {
-            let term_index: usize = tv.term.into();
-            assert!(term_index < TABLES.shift_width);
+        debug_assert!(state < TABLES.shift_count);
+        while !self.node_stack.queue_empty() {
+            let term_index: usize = self.node_stack.next().unwrap().term.into();
+            debug_assert!(term_index < TABLES.shift_width);
             let index = state * TABLES.shift_width + term_index;
             let goto = TABLES.shift_table[index];
             json_trace!({
@@ -42,16 +45,16 @@ impl<'alloc> ParserTrait<'alloc, StackValue<'alloc>> for Parser<'alloc> {
                 "term": format!("{:?}", { let s: &'static str = tv.term.into(); s }),
             });
             if goto < 0 {
+                self.node_stack.shift();
+                let tv = self.node_stack.pop().unwrap();
                 // Error handling is in charge of shifting an ErrorSymbol from the
                 // current state.
                 self.try_error_handling(tv)?;
-                tv = self.replay_stack.pop().unwrap();
-                json_trace!({ "replay_term": true });
                 continue;
             }
             state = goto as usize;
             self.state_stack.push(state);
-            self.node_stack.push(tv);
+            self.node_stack.shift();
             // Execute any actions, such as reduce actions ast builder actions.
             while state >= TABLES.shift_count {
                 assert!(state < TABLES.action_count + TABLES.shift_count);
@@ -61,28 +64,29 @@ impl<'alloc> ParserTrait<'alloc, StackValue<'alloc>> for Parser<'alloc> {
                 }
                 state = self.state();
             }
-            assert!(state < TABLES.shift_count);
-            if let Some(tv_temp) = self.replay_stack.pop() {
-                json_trace!({ "replay_term": true });
-                tv = tv_temp;
-            } else {
-                break;
-            }
+            debug_assert!(state < TABLES.shift_count);
         }
         Ok(false)
     }
-    fn replay(&mut self, tv: TermValue<StackValue<'alloc>>) {
-        self.replay_stack.push(tv)
-    }
-    fn epsilon(&mut self, state: usize) {
-        *self.state_stack.last_mut().unwrap() = state;
+    fn unshift(&mut self) {
+        self.state_stack.pop().unwrap();
+        self.node_stack.unshift()
     }
     fn pop(&mut self) -> TermValue<StackValue<'alloc>> {
         self.state_stack.pop().unwrap();
         self.node_stack.pop().unwrap()
     }
+    fn replay(&mut self, tv: TermValue<StackValue<'alloc>>) {
+        self.node_stack.push_next(tv)
+    }
+    fn epsilon(&mut self, state: usize) {
+        *self.state_stack.last_mut().unwrap() = state;
+    }
     fn check_not_on_new_line(&mut self, peek: usize) -> Result<'alloc, bool> {
-        let sv = &self.node_stack[self.node_stack.len() - peek].value;
+        let sv = {
+            let stack = self.node_stack.stack_slice();
+            &stack[stack.len() - peek].value
+        };
         if let StackValue::Token(ref token) = sv {
             if !token.is_on_new_line {
                 return Ok(true);
@@ -100,11 +104,12 @@ impl<'alloc> Parser<'alloc> {
     pub fn new(handler: AstBuilder<'alloc>, entry_state: usize) -> Self {
         TABLES.check();
         assert!(entry_state < TABLES.shift_count);
+        let mut state_stack = Vec::with_capacity(128);
+        state_stack.push(entry_state);
 
         Self {
-            state_stack: vec![entry_state],
-            node_stack: vec![],
-            replay_stack: vec![],
+            state_stack,
+            node_stack: QueueStack::with_capacity(128),
             handler,
         }
     }
@@ -150,9 +155,9 @@ impl<'alloc> Parser<'alloc> {
 
         // We can either reduce a Script/Module, or a Script/Module followed by
         // an <End> terminal.
-        assert!(self.node_stack.len() >= 1);
-        assert!(self.node_stack.len() <= 2);
-        if self.node_stack.len() > 1 {
+        assert!(self.node_stack.stack_len() >= 1);
+        assert!(self.node_stack.stack_len() <= 2);
+        if self.node_stack.stack_len() > 1 {
             self.node_stack.pop();
         }
         Ok(self.node_stack.pop().unwrap().value)
@@ -222,8 +227,8 @@ impl<'alloc> Parser<'alloc> {
     }
 
     fn simulator<'a>(&'a self) -> Simulator<'alloc, 'a> {
-        assert_eq!(self.replay_stack.len(), 0);
-        Simulator::new(&self.state_stack, &self.node_stack)
+        assert_eq!(self.node_stack.queue_len(), 0);
+        Simulator::new(&self.state_stack, self.node_stack.stack_slice())
     }
 
     pub fn can_accept_terminal(&self, t: TerminalId) -> bool {

--- a/crates/parser/src/queue_stack.rs
+++ b/crates/parser/src/queue_stack.rs
@@ -1,0 +1,255 @@
+//! This module implements a Stack, which is useful for implementing a parser
+//! with variable lookahead, as it would allow to pop elements which are below
+//! the top-element, and maintain a top counter which would be in charge of
+//! moving these elements once shifted.
+use std::ptr;
+
+/// This container implements a stack and a queue in a single vector:
+///   - stack: buf[..top]
+///   - queue: buf[top + gap..]
+///
+/// This structure is meant to avoid moving data when the head of the queue is
+/// transfered to the top of the stack. Also, sometimes we need to set items
+/// aside from the top of a stack, and then push them back onto the stack later.
+/// The queue is for storing these set-aside values. Since they live in the same
+/// buffer as the stack, values can be "set aside" and "pushed back on" without
+/// moving them at all.
+///
+/// In the context of an LR parser, the stack contains shifted elements, and the
+/// queue contains the lookahead. If the lexer is completely independent of the
+/// parser, all tokens could be queued before starting the parser.
+///
+/// The following statements describe how this structure is meant to be used and
+/// is described as a stack and a queue displayed as follow:
+///    [...stack...] <gap> [...queue...]
+///
+/// New elements are always inserted in the queue with `enqueue`:
+///    [a, b] <no gap> []
+///    * enqueue(c)
+///    [a, b] <no gap> [c]
+///
+/// These elements are then moved to the stack with `shift`:
+///    [a, b] <no gap> [c]
+///    * shift()
+///    [a, b, c] <no gap> []
+///
+/// The stack top can be set aside in the queue with `unshift`:
+///    [a, b, c] <no gap> []
+///    * unshift()
+///    [a, b] <no gap> [c]
+///
+/// The stack top can be removed with `pop`:
+///    [a, b] <no gap> [c]
+///    * pop() -> b
+///    [a] <gap: 1> [c]
+///    * pop() -> a
+///    [] <gap: 2> [c]
+///
+/// New elements can be added to the front of the queue with `push_next`, which
+/// also moves the content of the queue to ensure that `shift` can be used
+/// afterward:
+///    [] <gap: 2> [c]
+///    * push_next(d)
+///    [] <no gap> [d, c]
+///
+/// These operations are used by LR parser, to add lookahead with `enqueue`, to
+/// shift tokens with `shift`, to save tokens to be replayed with `unshift`, to
+/// reduce a set of tokens and replace it by a non-terminal with `pop` and
+/// `push_next`.
+pub struct QueueStack<T> {
+    /// Buffer containing the stack and the queue.
+    ///
+    ///   [a, b, c, d, e, f, g, h, i, j]
+    ///    '-----------'<------>'-----'
+    ///       stack     ^  gap   queue
+    ///                 |
+    ///            top -'
+    buf: Vec<T>,
+    /// Length of the stack, self.buf[top - 1] being the last element of the
+    /// stack.
+    top: usize,
+    /// Length of the gap between the stack top and the queue head.
+    gap: usize,
+}
+
+impl<T> QueueStack<T> {
+    /// Create a queue and stack with the given number of reserved elements.
+    pub fn with_capacity(n: usize) -> QueueStack<T> {
+        QueueStack {
+            buf: Vec::with_capacity(n),
+            top: 0,
+            gap: 0,
+        }
+    }
+
+    /// Add an element to the back of the queue.
+    pub fn enqueue(&mut self, value: T) {
+        self.buf.push(value);
+    }
+
+    /// Add an element to the front of the queue.
+    pub fn push_next(&mut self, value: T) {
+        self.compact_with_gap(1);
+        self.gap -= 1;
+        unsafe {
+            // Write over the gap without reading nor dropping the old entry.
+            let ptr = self.buf.as_mut_ptr().add(self.top + self.gap);
+            ptr.write(value);
+        }
+    }
+
+    /// Whether elements can be shifted.
+    pub fn can_shift(&self) -> bool {
+        self.gap == 0 && !self.queue_empty()
+    }
+
+    /// Whether elements can be unshifted.
+    pub fn can_unshift(&self) -> bool {
+        self.gap == 0 && !self.stack_empty()
+    }
+
+    /// Transfer an element from the top of the stack to the front of the queue.
+    ///
+    /// The gap must be empty. This does not move the value from one address to
+    /// another in memory; it just adjusts the boundary between the stack and
+    /// the queue.
+    ///
+    /// # Panics
+    /// If the stack is empty or there is a gap.
+    pub fn unshift(&mut self) {
+        assert!(self.can_unshift());
+        self.top -= 1;
+    }
+
+    /// Transfer an element from the front of the queue to the top of the stack.
+    ///
+    /// The gap must be empty. This does not move the value from one address to
+    /// another in memory; it just adjusts the boundary between the stack and
+    /// the queue.
+    ///
+    /// # Panics
+    /// If the queue is empty or there is a gap.
+    pub fn shift(&mut self) {
+        assert!(self.can_shift());
+        self.top += 1;
+    }
+
+    /// Remove the top element of the stack and return it, or None if the stack
+    /// is empty.
+    ///
+    /// This increases the gap size by 1.
+    pub fn pop(&mut self) -> Option<T> {
+        if self.top == 0 {
+            None
+        } else {
+            self.top -= 1;
+            self.gap += 1;
+            unsafe {
+                // Take ownership of the content.
+                let ptr = self.buf.as_mut_ptr().add(self.top);
+                Some(ptr.read())
+            }
+        }
+    }
+
+    /// Set the gap size to `new_gap`, memmove-ing the contents of the queue as
+    /// needed.
+    fn compact_with_gap(&mut self, new_gap: usize) {
+        assert!(new_gap <= (std::isize::MAX as usize));
+        assert!(self.gap <= (std::isize::MAX as usize));
+        let diff = new_gap as isize - self.gap as isize;
+        if diff == 0 {
+            return;
+        }
+        // Ensure there is enough capacity.
+        if diff > 0 {
+            self.buf.reserve(diff as usize);
+        }
+        // Number of elements to be copied.
+        let count = self.queue_len();
+        let new_len = self.top + new_gap + count;
+        assert!(new_len < self.buf.capacity());
+        unsafe {
+            let src_ptr = self.buf.as_mut_ptr().add(self.top + self.gap);
+            let dst_ptr = src_ptr.offset(diff);
+
+            // Shift everything down/up to have the expected gap.
+            ptr::copy(src_ptr, dst_ptr, count);
+
+            // Update the buffer length to newly copied elements.
+            self.buf.set_len(new_len);
+            // Update the gap to the new gap value.
+            self.gap = new_gap;
+        }
+        debug_assert_eq!(self.queue_len(), count);
+    }
+
+    /// Returns a reference to the front element of the queue.
+    pub fn next(&self) -> Option<&T> {
+        if self.queue_empty() {
+            None
+        } else {
+            Some(&self.buf[self.top + self.gap])
+        }
+    }
+
+    /// Returns a reference to the top element of the stack.
+    #[allow(dead_code)]
+    pub fn top(&self) -> Option<&T> {
+        if self.top == 0 {
+            None
+        } else {
+            Some(&self.buf[self.top - 1])
+        }
+    }
+
+    /// Returns a mutable reference to the top of the stack.
+    #[allow(dead_code)]
+    pub fn top_mut(&mut self) -> Option<&mut T> {
+        if self.top == 0 {
+            None
+        } else {
+            Some(&mut self.buf[self.top - 1])
+        }
+    }
+
+    /// Number of elements in the stack.
+    pub fn stack_len(&self) -> usize {
+        self.top
+    }
+
+    /// Number of elements in the queue.
+    pub fn queue_len(&self) -> usize {
+        self.buf.len() - self.top - self.gap
+    }
+
+    /// Whether the stack is empty.
+    pub fn stack_empty(&self) -> bool {
+        self.top == 0
+    }
+
+    /// Whether the queue is empty.
+    pub fn queue_empty(&self) -> bool {
+        self.top == self.buf.len()
+    }
+
+    /// Create a slice which corresponds the stack.
+    pub fn stack_slice(&self) -> &[T] {
+        &self.buf[..self.top]
+    }
+
+    /// Create a slice which corresponds the queue.
+    #[allow(dead_code)]
+    pub fn queue_slice(&self) -> &[T] {
+        &self.buf[self.top + self.gap..]
+    }
+}
+
+impl<T> Drop for QueueStack<T> {
+    fn drop(&mut self) {
+        // QueueStack contains a gap of non-initialized values, before releasing
+        // the vector, we move all initialized values from the queue into the
+        // remaining gap.
+        self.compact_with_gap(0);
+    }
+}

--- a/crates/parser/src/simulator.rs
+++ b/crates/parser/src/simulator.rs
@@ -69,6 +69,19 @@ impl<'alloc, 'parser> ParserTrait<'alloc, ()> for Simulator<'alloc, 'parser> {
         }
         Ok(false)
     }
+    fn unshift(&mut self) {
+        let tv = self.pop();
+        self.replay(tv)
+    }
+    fn pop(&mut self) -> TermValue<()> {
+        if let Some(s) = self.sim_node_stack.pop() {
+            self.sim_state_stack.pop();
+            return s;
+        }
+        let t = self.node_stack[self.sp - 1].term;
+        self.sp -= 1;
+        TermValue { term: t, value: () }
+    }
     fn replay(&mut self, tv: TermValue<()>) {
         self.replay_stack.push(tv)
     }
@@ -82,15 +95,6 @@ impl<'alloc, 'parser> ParserTrait<'alloc, ()> for Simulator<'alloc, 'parser> {
             self.sp -= 1;
         }
         *self.sim_state_stack.last_mut().unwrap() = state;
-    }
-    fn pop(&mut self) -> TermValue<()> {
-        if let Some(s) = self.sim_node_stack.pop() {
-            self.sim_state_stack.pop();
-            return s;
-        }
-        let t = self.node_stack[self.sp - 1].term;
-        self.sp -= 1;
-        TermValue { term: t, value: () }
     }
     fn check_not_on_new_line(&mut self, _peek: usize) -> Result<'alloc, bool> {
         Ok(true)


### PR DESCRIPTION
This work is described here: https://github.com/mozilla-spidermonkey/jsparagus/issues/378#issuecomment-602742753

Doing more runs with the `real-js-samples` highlighted that this change improved the performance from: `~84 ns/byte` to `~73 ns/byte`. (13% improvement)
