### PR TITLE
Fold reduce actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ jsparagus/grammar.py \
 jsparagus/extension.py \
 jsparagus/utils.py \
 jsparagus/actions.py \
+jsparagus/aps.py \
 jsparagus/types.py \
 js_parser/esgrammar.pgen \
 js_parser/generate_js_parser_tables.py \

--- a/jsparagus/actions.py
+++ b/jsparagus/actions.py
@@ -1,5 +1,6 @@
+import itertools
 from .ordered import OrderedFrozenSet
-from .grammar import InitNt, Nt
+from .grammar import InitNt, Nt, Some
 
 class Action:
     __slots__ = [
@@ -21,23 +22,32 @@ class Action:
         its current location in the parse table. Such as CheckNotOnNewLine.
         """
         return False
+
     def is_condition(self):
         "Unordered condition, which accept or not to reach the next state."
         return False
+
     def condition(self):
         "Return the conditional action."
         raise TypeError("Action::condition_flag not implemented")
+
     def update_stack(self):
         """Change the parser stack, and resume at a different location. If this function
         is defined, then the function reduce_with should be implemented."""
         return False
+
     def reduce_with(self):
         "Returns the non-terminal with which this action is reducing with."
         assert self.update_stack()
         raise TypeError("Action::reduce_to not implemented.")
+
     def shifted_action(self, shifted_term):
         "Returns the same action shifted by a given amount."
         return self
+
+    def contains_accept(self):
+        "Returns whether the current action stops the parser."
+        return False
 
     def maybe_add(self, other):
         """Implement the fact of concatenating actions into a new action which can have
@@ -97,6 +107,7 @@ class Reduce(Action):
     number of stack elements which would have to be popped and pushed again
     using the parser table after reducing this operation. """
     __slots__ = 'nt', 'replay', 'pop'
+
     def __init__(self, nt, pop, replay = 0):
         name = nt.name
         if isinstance(name, InitNt):
@@ -105,12 +116,16 @@ class Reduce(Action):
         self.nt = nt    # Non-terminal which is reduced
         self.pop = pop  # Number of stack elements which should be replayed.
         self.replay = replay # List of terms to shift back
+
     def __str__(self):
         return "Reduce({}, {}, {})".format(self.nt, self.pop, self.replay)
+
     def update_stack(self):
         return True
+
     def reduce_with(self):
         return self
+
     def shifted_action(self, shifted_term):
         return Reduce(self.nt, self.pop, replay = self.replay + 1)
 
@@ -118,6 +133,7 @@ class Lookahead(Action):
     """Define a Lookahead assertion which is meant to either accept or reject
     sequences of terminal/non-terminals sequences."""
     __slots__ = 'terms', 'accept'
+
     def __init__(self, terms, accept):
         assert isinstance(terms, (OrderedFrozenSet, frozenset))
         assert all(not isinstance(t, Nt) for t in terms)
@@ -125,16 +141,21 @@ class Lookahead(Action):
         super().__init__([], [])
         self.terms = terms
         self.accept = accept
+
     def is_inconsistent(self):
         # A lookahead restriction cannot be encoded in code, it has to be
         # solved using fix_with_lookahead.
         return True
+
     def is_condition(self):
         return True
+
     def condition(self):
         return self
+
     def __str__(self):
         return "Lookahead({}, {})".format(self.terms, self.accept)
+
     def shifted_action(self, shifted_term):
         if isinstance(shifted_term, Nt):
             return True
@@ -147,24 +168,30 @@ class CheckNotOnNewLine(Action):
     not. If not this would produce an Error, otherwise this rule would be
     shifted."""
     __slots__ = 'offset',
+
     def __init__(self, offset = 0):
         # assert offset >= -1 and "Smaller offsets are not supported on all backends."
         super().__init__([], [])
         self.offset = offset
+
     def is_inconsistent(self):
         # We can only look at stacked terminals. Having an offset of 0 implies
         # that we are looking for the next terminal, which is not yet shifted.
         # Therefore this action is inconsistent as long as the terminal is not
         # on the stack.
         return self.offset >= 0
+
     def is_condition(self):
         return True
+
     def condition(self):
         return self
+
     def shifted_action(self, shifted_term):
         if isinstance(shifted_term, Nt):
             return True
         return CheckNotOnNewLine(self.offset - 1)
+
     def __str__(self):
         return "CheckNotOnNewLine({})".format(self.offset)
 
@@ -172,14 +199,18 @@ class FilterFlag(Action):
     """Define a filter which check for one value of the flag, and continue to the
     next state if the top of the flag stack matches the expected value."""
     __slots__ = 'flag', 'value'
+
     def __init__(self, flag, value):
         super().__init__(["flag_" + flag], [])
         self.flag = flag
         self.value = value
+
     def is_condition(self):
         return True
+
     def condition(self):
         return self
+
     def __str__(self):
         return "FilterFlag({}, {})".format(self.flag, self.value)
 
@@ -190,19 +221,23 @@ class PushFlag(Action):
     reduce action. This is particularly useful to raise the parse table from a
     LR(0) to an LR(k) without needing as much state duplications."""
     __slots__ = 'flag', 'value'
+
     def __init__(self, flag, value):
         super().__init__([], ["flag_" + flag])
         self.flag = flag
         self.value = value
+
     def __str__(self):
         return "PushFlag({}, {})".format(self.flag, self.value)
 
 class PopFlag(Action):
     """Define an action which pops a flag from the flag bit stack."""
     __slots__ = 'flag',
+
     def __init__(self, flag):
         super().__init__(["flag_" + flag], ["flag_" + flag])
         self.flag = flag
+
     def __str__(self):
         return "PopFlag({})".format(self.flag)
 
@@ -212,6 +247,7 @@ class FunCall(Action):
     to the number of stack elements which would have to be popped and pushed
     again using the parser table after reducing this operation. """
     __slots__ = 'trait', 'method', 'offset', 'args', 'fallible', 'set_to'
+
     def __init__(self, method, args,
                  trait = "AstBuilder",
                  fallible = False,
@@ -226,17 +262,41 @@ class FunCall(Action):
         self.offset = offset     # Offset to add to each argument offset.
         self.args = args         # Tuple of arguments offsets.
         self.set_to = set_to     # Temporary variable name to set with the result.
+
     def __str__(self):
         return "{} = {}::{}({}){} [off: {}]".format(
             self.set_to, self.trait, self.method,
             ", ".join(map(str, self.args)),
             self.fallible and '?' or '',
             self.offset)
+
     def __repr__(self):
         return "FunCall({})".format(', '.join(map(repr, [
             self.trait, self.method, self.fallible, self.read, self.write,
             self.args, self.set_to, self.offset
         ])))
+
+    def contains_accept(self):
+        return self.method == "accept"
+
+    def map_args(self, f):
+        return FunCall(self.method, tuple(f(self.offset, a) for a in self.args),
+                       trait = self.trait,
+                       fallible = self.fallible,
+                       set_to = self.set_to,
+                       offset = 0,
+                       alias_read = self.read,
+                       alias_write = self.write)
+
+    def replace_set_to(self, name):
+        return FunCall(self.method, self.args,
+                       trait = self.trait,
+                       fallible = self.fallible,
+                       set_to = name,
+                       offset = self.offset,
+                       alias_read = self.read,
+                       alias_write = self.write)
+
     def shifted_action(self, shifted_term):
         return FunCall(self.method, self.args,
                        trait = self.trait,
@@ -247,10 +307,11 @@ class FunCall(Action):
                        alias_write = self.write)
 
 class Seq(Action):
-    """Aggregate multiple actions in one statement. Note, that the aggregated
+    """Aggregate multiple actions in one sequence. Note, that the aggregated
     actions should not contain any condition or action which are mutating the
     state. Only the last action aggregated can update the parser stack"""
     __slots__ = 'actions',
+
     def __init__(self, actions):
         assert isinstance(actions, list)
         read = [ rd for a in actions for rd in a.read ]
@@ -259,18 +320,135 @@ class Seq(Action):
         self.actions = tuple(actions)   # Ordered list of actions to execute.
         assert all([not a.is_condition() for a in actions[1:]])
         assert all([not a.update_stack() for a in actions[:-1]])
+
     def __str__(self):
         return "{{ {} }}".format("; ".join(map(str, self.actions)))
+
     def __repr__(self):
         return "Seq({})".format(repr(self.actions))
+
     def is_condition(self):
         return self.actions[0].is_condition()
+
     def condition(self):
         return self.actions[0]
+
     def update_stack(self):
         return self.actions[-1].update_stack()
+
     def reduce_with(self):
         return self.actions[-1].reduce_with()
+
     def shifted_action(self, shift):
         actions = list(map(lambda a: a.shifted_action(shift), self.actions))
         return Seq(actions)
+
+    def contains_accept(self):
+        return any(a.contains_accept() for a in self.actions)
+
+class SeqBuilder:
+    """Aggregate multiple actions in one sequence. Reduce actions added to this
+    sequence are implicitly removed except for the last one but are still
+    considered for rewriting arguments of FunCall. """
+
+    def __init__(self):
+        # offset_stack is used for rewritting offsets which are matching the
+        # value of non-terminals.
+        self.offset_stack = [1] # list(reversed(range(1, 16)))
+        self.popped = 0
+        self.replay = []
+        # Until a Reduce action is seen, actions are stashed in the
+        # stashed_actions list.
+        self.actions = []
+        self.stashed_actions = []
+        self.last_reduce = None
+
+    def ensure_stack(self, n):
+        # Always add margin such that the first element is always an integer.
+        n = n + 2 - len(self.offset_stack)
+        if n < 0:
+            return
+        base = self.offset_stack[0] + 1
+        self.offset_stack = list(itertools.chain(reversed(range(base, base + n)), self.offset_stack))
+
+    def args_rewrite(self, offset, a):
+        if isinstance(a, int):
+            a = a + offset
+            self.ensure_stack(a)
+            # Return the variable name associated with the value pushed by
+            # the shifted token.
+            return self.offset_stack[-a]
+        if isinstance(a, str):
+            return a
+        if isinstance(a, Some):
+            return Some(self.args_rewrite(offset, a.inner))
+        return a
+
+    def can_shift(self, term):
+        if not isinstance(term, Action):
+            return len(self.replay) > 0
+        assert not term.contains_accept()
+        return not term.is_condition() or self.actions == []
+
+    def shift(self, term):
+        assert self.can_shift(term)
+        if not isinstance(term, Action):
+            # Push the token value of the lookahead, as a stack offset.
+            self.offset_stack.append(self.replay.pop())
+            self.popped -= 1
+        elif isinstance(term, FunCall):
+            term = term.map_args(self.args_rewrite)
+            self.stashed_actions.append(term)
+        elif isinstance(term, Reduce):
+            self.ensure_stack(term.replay + term.pop)
+            # Note, if we consume a reduce action before consuming all the
+            # lookahead of previous reduce actions, the final reduce should
+            # still have the remaining number of lookahead terms to replay.
+            replay = term.replay
+            while replay > 0:
+                self.replay.append(self.offset_stack.pop())
+                self.popped += 1
+                replay -= 1
+
+            # Remove all the terms pop-ed by all reduce actions seen until now.
+            pop = term.pop
+            while pop > 0:
+                self.offset_stack.pop()
+                self.popped += 1
+                pop -= 1
+
+            # New reduce action to be added if this is the last one.
+            self.last_reduce = Reduce(term.nt, self.popped - len(self.replay), len(self.replay))
+
+            # Move stashed actions to the list of actions to appear in this
+            # sequence. The reason being that we end with a reduce action.
+            # Therefore as we do not want code to be executed twice, we do not
+            # want to append FunCall coming from the path where we reduced
+            # into.
+            self.actions.extend(self.stashed_actions)
+            self.stashed_actions = []
+
+            # The value of the non-terminal pushed on the stack after a
+            # replayed action is going to be stored in the "value" variable.
+            name = "action" + str(len(self.actions))
+            self.popped -= 1
+            if len(self.actions) >= 1 and isinstance(self.actions[-1], FunCall):
+                self.offset_stack.append(name)
+                self.actions[-1] = self.actions[-1].replace_set_to(name)
+            else:
+                self.offset_stack.append(len(self.replay) + 1)
+
+        elif isinstance(term, Seq):
+            for act in term.actions:
+                self.shift(act)
+        else:
+            raise ValueError("Unsupported Action: {}".format(str(term)))
+
+    def finish(self):
+        if self.last_reduce is not None:
+            if isinstance(self.actions[-1], FunCall):
+                self.actions[-1] = self.actions[-1].replace_set_to("value")
+            self.actions.append(self.last_reduce)
+        if len(self.actions) == 1:
+            return self.actions[0]
+        return Seq(self.actions)

--- a/jsparagus/aps.py
+++ b/jsparagus/aps.py
@@ -1,0 +1,207 @@
+import collections
+from .actions import Action
+
+# An edge in a Parse table is a tuple of a source state and the term followed
+# to exit this state. The destination is not saved here as it can easily be
+# inferred by looking it up in the parse table.
+#
+# Note, the term might be `None` if no term is specified yet. This is useful
+# when manipulating a list of edges and we know that we are taking transitions
+# from a given state, but not yet with which term.
+#
+#   state: Index of the state from which this directed edge is coming from.
+#
+#   term: Edge transition value, this can be a terminal, non-terminal or an
+#       action to be executed on an epsilon transition.
+Edge = collections.namedtuple("Edge", "src term")
+
+def edge_str(edge):
+    assert isinstance(edge, Edge)
+    return "{} -- {} -->".format(edge.src, str(edge.term))
+
+class APS:
+    # To fix inconsistencies of the grammar, we have to traverse the grammar
+    # both forward by using the lookahead and backward by using the state
+    # recovered from following reduce actions.
+    #
+    # To do so we define the notion of abstract parser state (APS), which is a
+    # class which represents the known state of the parser, relative to its
+    # starting point.
+    #
+    # An APS does not exclusively start at the parser entry point, but starts
+    # from any state of the parse table by calling `APS.start`. Then we walk
+    # the parse table forward, as-if we were shifting tokens or epsilon edges
+    # in the parse table. The function `aps.shift_next(parse_table)` will
+    # explore all possible futures reachable from the starting point.
+    #
+    # As the parse table is explored, new APS are produced by
+    # `aps.shift_next(parse_table)`, which are containing the new state of the
+    # parser and the history which has been seen by the APS since it started.
+    #
+    #   stack: This is the known stack at the location where we started
+    #          investigating. As more history is discovered by resolving reduce
+    #          actions, this stack would be filled with the predecessors which
+    #          have been visited before reaching the starting state.
+    #
+    #   shift: This is the stack as manipulated by an LR parser. States are
+    #          shifted to it, including actions, and popped from it when
+    #          visiting a reduce action.
+    #
+    #   lookahead: This is the list of terminals and non-terminals encountered
+    #          by shifting edges which are not replying tokens.
+    #
+    #   replay: This is the list of lookahead terminals and non-terminals which
+    #          remains to be shifted. This list corresponds to terminals and
+    #          non-terminals which were necessary for removing inconsistencies,
+    #          but have to be replayed after shifting the reduced
+    #          non-terminals.
+    #
+    #   history: This is the list of edges visited since the starting state.
+    #
+    slots = 'stack', 'shift', 'lookahead', 'replay', 'history'
+    def __init__(self, st, sh, la, rp, hs):
+        self.stack = st
+        self.shift = sh
+        self.lookahead = la
+        self.replay = rp
+        self.history = hs
+        assert self.is_valid_self()
+
+    def is_valid_self(self):
+        "Returns whether this structure contains the right content."
+        check = True
+        check &= all(isinstance(st, Edge) for st in self.stack)
+        check &= all(isinstance(sh, Edge) for sh in self.shift)
+        check &= all(not isinstance(la, Action) for la in self.lookahead)
+        check &= all(not isinstance(rp, Action) for rp in self.replay)
+        check &= all(isinstance(ac, Edge) for ac in self.history)
+        return check
+
+    @staticmethod
+    def start(state):
+        "Return an Abstract Parser State starting at a given state of a parse table"
+        edge = Edge(state, None)
+        return APS([edge], [edge], [], [], [])
+
+    def shift_next(self, pt):
+        """Visit all the states of the parse table, as-if we were running a
+        Generalized LR parser.
+
+        However, instead parsing content, we use this algorithm to generate
+        both the content which remains to be parsed as well as the context
+        which might lead us to be in the state which from which we started.
+
+        This algorithm takes an APS (Abstract Parser State), and consider all
+        edges of the parse table, unless restricted by one of the previously
+        encountered actions. These restrictions, such as replayed lookahead or
+        the path which might be reduced are used for filtering out states which
+        are not handled by this parse table.
+
+        For each edge, this functions recursively calls it-self and calls the
+        visit functions to know whether to stop or continue, and to capture the
+        result.
+
+        """
+        st, sh, la, rp, hs = self.stack, self.shift, self.lookahead, self.replay, self.history
+        last_edge = sh[-1]
+        state = pt.states[last_edge.src]
+        if self.replay == []:
+            for term, to in state.shifted_edges():
+                edge = Edge(last_edge.src, term)
+                new_sh = self.shift[:-1] + [edge]
+                to = Edge(to, None)
+                yield APS(st, new_sh + [to], la + [term], rp, hs + [edge])
+        else:
+            term = self.replay[0]
+            rp = self.replay[1:]
+            if term in state:
+                edge = Edge(last_edge.src, term)
+                new_sh = self.shift[:-1] + [edge]
+                to = state[term]
+                to = Edge(to, None)
+                yield APS(st, new_sh + [to], la, rp, hs + [edge])
+
+        term = None
+        rp = self.replay
+        for a, to in state.epsilon:
+            edge = Edge(last_edge.src, a)
+            prev_sh = self.shift[:-1] + [edge]
+            # TODO: Add support for Lookahead and flag manipulation rules, as
+            # both of these would invalide potential reduce paths.
+            if a.update_stack():
+                reducer = a.reduce_with()
+                for path, reduced_path in pt.reduce_path(prev_sh):
+                    # reduce_paths contains the chains of state shifted,
+                    # including epsilon transitions, in order to reduce the
+                    # nonterminal. When reducing, the stack is resetted to
+                    # head, and the nonterminal `term.nt` is pushed, to resume
+                    # in the state `to`.
+
+                    # print("Compare shifted path, with reduced path:\n\tshifted = {}\n\treduced = {}, \n\taction = {},\n\tnew_path = {}\n".format(
+                    #     " ".join(edge_str(e) for e in prev_sh),
+                    #     " ".join(edge_str(e) for e in path),
+                    #     str(a),
+                    #     " ".join(edge_str(e) for e in reduced_path),
+                    # ))
+                    if prev_sh[-len(path):] != path[-len(prev_sh):]:
+                        # If the reduced production does not match the shifted
+                        # state, then this reduction does not apply. This is
+                        # the equivalent result as splitting the parse table
+                        # based on the predecessor.
+                        continue
+
+                    # The stack corresponds to the stack present at the
+                    # starting point. The shift list correspond to the actual
+                    # parser stack as we iterate through the state machine.
+                    # Each time we consume all the shift list, this implies
+                    # that we had extra stack elements which were not present
+                    # initially, and therefore we are learning about the
+                    # context.
+                    new_st = path[:max(len(path) - len(prev_sh), 0)] + st
+                    assert pt.is_valid_path(new_st)
+
+                    # The shift list corresponds to the stack which is used in
+                    # an LR parser, in addition to all the states which are
+                    # epsilon transitions. We pop from this list the reduced
+                    # path, as long as it matches. Then all popped elements are
+                    # replaced by the state that we visit after replaying the
+                    # non-terminal reduced by this action.
+                    new_sh = prev_sh[:-len(path)] + reduced_path
+                    assert pt.is_valid_path(new_sh)
+
+                    # When reducing, we replay terms which got previously
+                    # pushed on the stack as our lookahead. These terms are
+                    # computed here such that we can traverse the graph from
+                    # `to` state, using the replayed terms.
+                    new_replay = []
+                    if reducer.replay > 0:
+                        new_replay = [ edge.term for edge in path if pt.term_is_stacked(edge.term) ]
+                        new_replay = new_replay[-reducer.replay:]
+                    new_replay = new_replay + rp
+                    new_la = la[:max(len(la) - reducer.replay, 0)]
+                    yield APS(new_st, new_sh, new_la, new_replay, hs + [edge])
+            else:
+                to = Edge(to, None)
+                yield APS(st, prev_sh + [to], la, rp, hs + [edge])
+
+    def string(self, name = "aps"):
+        return """{}.stack = [{}]
+{}.shift = [{}]
+{}.lookahead = [{}]
+{}.replay = [{}]
+{}.history = [{}]
+        """.format(
+            name, " ".join(edge_str(e) for e in self.stack),
+            name, " ".join(edge_str(e) for e in self.shift),
+            name, ", ".join(repr(e) for e in self.lookahead),
+            name, ", ".join(repr(e) for e in self.replay),
+            name, " ".join(edge_str(e) for e in self.history)
+        )
+
+    def __str__(self):
+        return self.string()
+
+def aps_lanes_str(aps_lanes, header = "lanes:", name = "\taps"):
+    return "{}\n{}".format(header, "\n".join(aps.string(name) for aps in aps_lanes))
+
+

--- a/jsparagus/emit/rust.py
+++ b/jsparagus/emit/rust.py
@@ -567,8 +567,13 @@ class RustParserWriter:
                     set_var = "let {} = ".format(act.set_to)
                 if act.method == "id":
                     assert len(act.args) == 1
+                    if isinstance(act.args[0], str):
+                        packed = is_packed[act.args[0]]
+                    else:
+                        assert isinstance(act.args[0], int)
+                        packed = True
                     self.write(indent, "{}{};", set_var, next(map_with_offset(act.args, no_unpack)))
-                    is_packed[act.set_to] = True
+                    is_packed[act.set_to] = packed
                 elif act.method == "accept":
                     assert len(act.args) == 0
                     self.write(indent, "return Ok(true);")

--- a/jsparagus/gen.py
+++ b/jsparagus/gen.py
@@ -47,6 +47,7 @@ from . import emit
 from .runtime import ACCEPT, ErrorToken
 from .utils import keep_until
 from . import types
+from .aps import Edge, APS
 
 # *** Operations on grammars **************************************************
 
@@ -1601,24 +1602,6 @@ class CanonicalGrammar:
         self.prods_with_indexes_by_nt = prods_with_indexes_by_nt
         self.grammar = grammar
 
-# An edge in a Parse table is a tuple of a source state and the term followed
-# to exit this state. The destination is not saved here as it can easily be
-# inferred by looking it up in the parse table.
-#
-# Note, the term might be `None` if no term is specified yet. This is useful
-# when manipulating a list of edges and we know that we are taking transitions
-# from a given state, but not yet with which term.
-#
-#   state: Index of the state from which this directed edge is coming from.
-#
-#   term: Edge transition value, this can be a terminal, non-terminal or an
-#       action to be executed on an epsilon transition.
-Edge = collections.namedtuple("Edge", "src term")
-
-def edge_str(edge):
-    assert isinstance(edge, (Edge, Edge))
-    return "{} -- {} -->".format(edge.src, str(edge.term))
-
 # Structure used to report conflict while creating or merging states.
 class Conflict(Exception):
     pass
@@ -2017,66 +2000,6 @@ class LR0Generator:
                     followed_by = tuple(),
                 ), followed_by)
 
-# To fix inconsistencies of the grammar, we have to traverse the grammar both
-# forward by using the lookahead and backward by using the parser's emulated
-# stack recovered from reduce actions.
-#
-# To do so we define the notion of abstract parser state (APS), which is a
-# tuple which represent the known state of the parser, as:
-#   (stack, shift, lookahead, actions)
-#
-#   stack: This is the stack at the location where we started investigating.
-#          Which means that the last element of the stack would be the location
-#          where we started.
-#
-#   shift: This is the stack computed after the traversal of edges. It is
-#          reduced each time a reduce action is encountered, and the rest of
-#          the production content is added back to the stack, as newly acquired
-#          context. The last element is the last state reached through the
-#          sequence of lookahead and actions.
-#
-#   lookahead: This is the list of terminals encountered while pushing edges
-#          through the list of terminals.
-#
-#   actions: This is the list of actions that would be executed as we push
-#          edges. Maybe we should rename this history. This is a list of edges
-#          taken, which helps tracking which state got visited since we
-#          started.
-#
-#   replay: This is the list of lookahead terminals and non-terminals which
-#          remains to be executed. This represents the fact that reduce actions
-#          are popping elements which are below the top of the stack, and add
-#          them back to the stack.
-#
-APS = collections.namedtuple("APS", "stack shift lookahead actions replay")
-
-def aps_str(aps, name = "aps"):
-    return """{}.stack = [{}]
-{}.shift = [{}]
-{}.lookahead = [{}]
-{}.actions = [{}]
-{}.replay = [{}]
-    """.format(
-        name, " ".join(edge_str(e) for e in aps.stack),
-        name, " ".join(edge_str(e) for e in aps.shift),
-        name, ", ".join(repr(e) for e in aps.lookahead),
-        name, " ".join(edge_str(e) for e in aps.actions),
-        name, ", ".join(repr(e) for e in aps.replay)
-    )
-
-def aps_lanes_str(aps_lanes, header = "lanes:", name = "\taps"):
-    return "{}\n{}".format(header, "\n".join(aps_str(aps, name) for aps in aps_lanes))
-
-def is_valid_aps(aps):
-    "Returns whether an APS contains the right content."
-    check = True
-    check &= all(isinstance(st, Edge) for st in aps.stack)
-    check &= all(isinstance(sh, Edge) for sh in aps.shift)
-    check &= all(not isinstance(la, Action) for la in aps.lookahead)
-    check &= all(isinstance(ac, Edge) for ac in aps.actions)
-    check &= all(not isinstance(rp, Action) for rp in aps.replay)
-    return check
-
 class ParseTable:
     """The parser can be represented as a matrix of state transitions where on one
     side we have the current state, and on the other we have the expected
@@ -2442,113 +2365,6 @@ class ParseTable:
     def term_is_stacked(self, term):
         return not isinstance(term, Action)
 
-    def aps_start(self, state, replay = []):
-        "Return a parser state only knowing the state at which we are currently."
-        edge = Edge(state, None)
-        return APS([edge], [edge], [], [], replay)
-
-    def aps_next(self, aps):
-        """Visit all the states of the parse table, as-if we were running a
-        Generalized LR parser.
-
-        However, instead parsing content, we use this algorithm to generate
-        both the content which remains to be parsed as well as the context
-        which might lead us to be in the state which from which we started.
-
-        This algorithm takes an APS (Abstract Parser State), and consider all
-        edges of the parse table, unless restricted by one of the previously
-        encountered actions. These restrictions, such as replayed lookahead or
-        the path which might be reduced are used for filtering out states which
-        are not handled by this parse table.
-
-        For each edge, this functions recursively calls it-self and calls the
-        visit functions to know whether to stop or continue, and to capture the
-        result.
-
-        """
-        assert is_valid_aps(aps)
-        st, sh, la, ac, rp = aps
-        last_edge = sh[-1]
-        state = self.states[last_edge.src]
-        if aps.replay == []:
-            for term, to in state.shifted_edges():
-                edge = Edge(last_edge.src, term)
-                new_sh = aps.shift[:-1] + [edge]
-                to = Edge(to, None)
-                yield APS(st, new_sh + [to], la + [term], ac + [edge], rp)
-        else:
-            term = aps.replay[0]
-            rp = aps.replay[1:]
-            if term in state:
-                edge = Edge(last_edge.src, term)
-                new_sh = aps.shift[:-1] + [edge]
-                to = state[term]
-                to = Edge(to, None)
-                yield APS(st, new_sh + [to], la, ac + [edge], rp)
-
-        term = None
-        rp = aps.replay
-        for a, to in state.epsilon:
-            edge = Edge(last_edge.src, a)
-            prev_sh = aps.shift[:-1] + [edge]
-            # TODO: Add support for Lookahead and flag manipulation rules, as
-            # both of these would invalide potential reduce paths.
-            if a.update_stack():
-                reducer = a.reduce_with()
-                for path, reduced_path in self.reduce_path(prev_sh):
-                    # reduce_paths contains the chains of state shifted,
-                    # including epsilon transitions, in order to reduce the
-                    # nonterminal. When reducing, the stack is resetted to
-                    # head, and the nonterminal `term.nt` is pushed, to resume
-                    # in the state `to`.
-
-                    # print("Compare shifted path, with reduced path:\n\tshifted = {}\n\treduced = {}, \n\taction = {},\n\tnew_path = {}\n".format(
-                    #     " ".join(edge_str(e) for e in prev_sh),
-                    #     " ".join(edge_str(e) for e in path),
-                    #     str(a),
-                    #     " ".join(edge_str(e) for e in reduced_path),
-                    # ))
-                    if prev_sh[-len(path):] != path[-len(prev_sh):]:
-                        # If the reduced production does not match the shifted
-                        # state, then this reduction does not apply. This is
-                        # the equivalent result as splitting the parse table
-                        # based on the predecessor.
-                        continue
-
-                    # The stack corresponds to the stack present at the
-                    # starting point. The shift list correspond to the actual
-                    # parser stack as we iterate through the state machine.
-                    # Each time we consume all the shift list, this implies
-                    # that we had extra stack elements which were not present
-                    # initially, and therefore we are learning about the
-                    # context.
-                    new_st = path[:max(len(path) - len(prev_sh), 0)] + st
-                    assert self.is_valid_path(new_st)
-
-                    # The shift list corresponds to the stack which is used in
-                    # an LR parser, in addition to all the states which are
-                    # epsilon transitions. We pop from this list the reduced
-                    # path, as long as it matches. Then all popped elements are
-                    # replaced by the state that we visit after replaying the
-                    # non-terminal reduced by this action.
-                    new_sh = prev_sh[:-len(path)] + reduced_path
-                    assert self.is_valid_path(new_sh)
-
-                    # When reducing, we replay terms which got previously
-                    # pushed on the stack as our lookahead. These terms are
-                    # computed here such that we can traverse the graph from
-                    # `to` state, using the replayed terms.
-                    new_replay = []
-                    if reducer.replay > 0:
-                        new_replay = [ edge.term for edge in path if self.term_is_stacked(edge.term) ]
-                        new_replay = new_replay[-reducer.replay:]
-                    new_replay = new_replay + rp
-                    new_la = la[:max(len(la) - reducer.replay, 0)]
-                    yield APS(new_st, new_sh, new_la, ac + [edge], new_replay)
-            else:
-                to = Edge(to, None)
-                yield APS(st, prev_sh + [to], la, ac + [edge], rp)
-
     def aps_visitor(self, aps, visit):
         todo = []
         todo.append(aps)
@@ -2557,7 +2373,7 @@ class ParseTable:
             cont = visit(aps)
             if not cont:
                 continue
-            todo.extend(self.aps_next(aps))
+            todo.extend(aps.shift_next(self))
 
     def lanes(self, state):
         """Compute the lanes from the amount of lookahead available. Only consider
@@ -2577,7 +2393,7 @@ class ParseTable:
                 print(aps_str(aps, "\trecord"))
                 record.append(aps)
             return not stop
-        self.aps_visitor(self.aps_start(state), visit)
+        self.aps_visitor(APS.start(state), visit)
         return record
 
     def context_lanes(self, state):
@@ -2595,7 +2411,7 @@ class ParseTable:
         enough context to disambiguate the inconsistency of the given state."""
         assert isinstance(state, int)
         def not_interesting(aps):
-            reduce_list = [e for e in aps.actions if self.is_term_shifted(e.term)]
+            reduce_list = [e for e in aps.history if self.is_term_shifted(e.term)]
             has_reduce_loop = len(reduce_list) != len(set(reduce_list))
             return has_reduce_loop
 
@@ -2605,7 +2421,7 @@ class ParseTable:
         context = collections.defaultdict(lambda: [])
         def has_enough_context(aps):
             try:
-                assert aps.actions[0] in context[tuple(aps.stack)]
+                assert aps.history[0] in context[tuple(aps.stack)]
                 # Check the number of different actions which can reach this
                 # location. If there is more than 1, then we do not have enough
                 # context.
@@ -2613,7 +2429,7 @@ class ParseTable:
             except IndexError:
                 return False
 
-        collect = [self.aps_start(state)]
+        collect = [APS.start(state)]
         enough_context = False
         while not enough_context:
             # print("collect.len = {}".format(len(collect)))
@@ -2624,10 +2440,10 @@ class ParseTable:
             while collect:
                 aps = collect.pop()
                 recurse.append(aps)
-                if aps.actions == []:
+                if aps.history == []:
                     continue
                 for i in range(len(aps.stack)):
-                    context[tuple(aps.stack[i:])].append(aps.actions[0])
+                    context[tuple(aps.stack[i:])].append(aps.history[0])
             assert collect == []
 
             # print("recurse.len = {}".format(len(recurse)))
@@ -2653,7 +2469,7 @@ class ParseTable:
                     return True, []
                 enough_context = False
                 # print("extend starting at:\n{}".format(aps_str(aps, "\tcontext")))
-                collect.extend(self.aps_next(aps))
+                collect.extend(aps.shift_next(self))
             assert recurse == []
 
         # print("context_lanes:")
@@ -2663,7 +2479,7 @@ class ParseTable:
         return False, collect
 
         def visit(aps):
-            reduce_list = [e for e in aps.actions if self.is_term_shifted(e.term)]
+            reduce_list = [e for e in aps.history if self.is_term_shifted(e.term)]
             has_reduce_loop = len(reduce_list) != len(set(reduce_list))
             has_lookahead = len(aps.lookahead) >= 1
             stop = has_shift_loop or has_stack_loop or has_lookahead
@@ -2675,7 +2491,7 @@ class ParseTable:
                 print(aps_str(aps, "\trecord"))
                 record.append(aps)
             return not stop
-        self.aps_visitor(self.aps_start(state), visit)
+        self.aps_visitor(APS.start(state), visit)
         return record
 
     def lookahead_lanes(self, state):
@@ -2695,9 +2511,9 @@ class ParseTable:
         def visit(aps):
             # Note, this suppose that we are not considering flags when
             # computing, as flag might prevent some lookahead investigations.
-            first_reduce = next((e for e in aps.actions[:-1] if not self.is_term_shifted(e.term)), None)
+            first_reduce = next((e for e in aps.history[:-1] if not self.is_term_shifted(e.term)), None)
             if first_reduce:
-                reduce_key = (first_reduce, aps.shift[0].src, aps.actions[-1].term)
+                reduce_key = (first_reduce, aps.shift[0].src, aps.history[-1].term)
             has_seen_edge_after_reduce = first_reduce and reduce_key in seen_edge_after_reduce
             has_lookahead = len(aps.lookahead) >= 1
             stop = has_seen_edge_after_reduce or has_lookahead
@@ -2708,7 +2524,7 @@ class ParseTable:
             if first_reduce:
                 seen_edge_after_reduce.add(reduce_key)
             return not stop
-        self.aps_visitor(self.aps_start(state), visit)
+        self.aps_visitor(APS.start(state), visit)
         return record
 
     def fix_with_context(self, s, aps_lanes):
@@ -2934,7 +2750,7 @@ class ParseTable:
         # would have to be executed.
         shift_map = collections.defaultdict(lambda: [])
         for aps in aps_lanes:
-            actions = aps.actions
+            actions = aps.history
             assert isinstance(actions[-1], Edge)
             assert actions[-1].term == aps.lookahead[0]
             src = actions[-1].src
@@ -3239,9 +3055,9 @@ class ParseTable:
         record = []
         def visit(aps):
             # Stop after reducing once.
-            if aps.actions == []:
+            if aps.history == []:
                 return True
-            last = aps.actions[-1].term
+            last = aps.history[-1].term
             is_reduce = not self.is_term_shifted(last)
             has_shift_loop = len(aps.shift) != 1 + len(set(zip(aps.shift, aps.shift[1:])))
             can_reduce_later = True
@@ -3253,20 +3069,20 @@ class ParseTable:
             # Record state which are reducing at most all the shifted states.
             save = stop and len(aps.shift) == 2
             save = save and isinstance(aps.shift[0].term, Nt)
-            save = save and not self.is_term_shifted(aps.actions[-1].term)
+            save = save and not self.is_term_shifted(aps.history[-1].term)
             if save:
                 record.append(aps)
             return not stop
-        self.aps_visitor(self.aps_start(state), visit)
+        self.aps_visitor(APS.start(state), visit)
 
         context = OrderedSet()
         for aps in record:
-            assert aps.actions != []
-            assert aps.actions[-1].term.update_stack()
-            reducer = aps.actions[-1].term.reduce_with()
+            assert aps.history != []
+            assert aps.history[-1].term.update_stack()
+            reducer = aps.history[-1].term.reduce_with()
             replay = reducer.replay
             before = [repr(e.term) for e in aps.stack[:-1]]
-            after = [repr(e.term) for e in aps.actions[:-1]]
+            after = [repr(e.term) for e in aps.history[:-1]]
             prod = before + ["\N{MIDDLE DOT}"] + after
             if replay < len(after) and replay > 0:
                 del prod[-replay:]
@@ -3277,7 +3093,7 @@ class ParseTable:
                 prod = prod[:-replay] + ["[lookahead:"] + prod[-replay:] + ["]"]
             txt = "{}{} ::= {}".format(
                 prefix,
-                repr(aps.actions[-1].term.reduce_with().nt),
+                repr(aps.history[-1].term.reduce_with().nt),
                 " ".join(prod)
             )
             context.add(txt)


### PR DESCRIPTION
This changes fixes #423 by converting sequences of Reduce actions with functions calls into a single Reduce action. This change reduce the average shift-per-token from 10.5 to 6.8 on real-js-samples benchmark, and result in a 20.5% speed-up on the same benchmark.

This change contains 2 commits:
 - commit 0dea741 : Clean-up the parse table generator code by moving the Abstract Parser State (`APS`) out of the `ParseTable` class.
 - commit d087ba2 : Adds the `SeqBuilder` to fold `Reduce` actions and rewrite `FunCall` arguments. This is used in `fold_reduce_cascade` optimization which looks at the transitions following `Reduce` actions and consider them as candidates as long as all paths contain the same sequence of terms (without lookahead).