### PR TITLE
Add type annotations to some Python methods (and miscellaneous minor fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+.mypy_cache/
 target/
 jsparagus_build_venv/
 example_pgen.rs

--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,13 @@ rust: $(RS_AST_OUT) $(RS_TABLES_OUT)
 jsparagus/parse_pgen_generated.py:
 	$(PYTHON) -m jsparagus.parse_pgen --regenerate > $@
 
-check: all
+check: all static-check
 	./test.sh
 	cargo fmt
 	cargo test --all
+
+static-check:
+	$(VENV_BIN_DIR)/mypy -m jsparagus.ordered
 
 jsdemo: $(PY_OUT)
 	$(PYTHON) -m js_parser.try_it
@@ -90,4 +93,4 @@ update-opcodes-m-u:
 	$(PYTHON) crates/emitter/scripts/update_opcodes.py \
 		../mozilla-unified ./
 
-.PHONY: all check jsdemo rust update-opcodes-m-u
+.PHONY: all check static-check jsdemo rust update-opcodes-m-u

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ check: all static-check
 	cargo test --all
 
 static-check:
-	$(VENV_BIN_DIR)/mypy -m jsparagus.ordered
+	$(VENV_BIN_DIR)/mypy -p jsparagus -p tests -p js_parser
 
 jsdemo: $(PY_OUT)
 	$(PYTHON) -m js_parser.try_it

--- a/js_parser/extract_es_grammar.py
+++ b/js_parser/extract_es_grammar.py
@@ -20,7 +20,7 @@ You can also use this script on a random HTTPS URL, like:
 
 import argparse
 import urllib
-import html5lib
+import html5lib  # type: ignore
 import re
 from textwrap import dedent
 

--- a/js_parser/load_es_grammar.py
+++ b/js_parser/load_es_grammar.py
@@ -1,12 +1,12 @@
 """ Functions for loading the ECMAScript lexical and syntactic grammars. """
 
 from jsparagus.ordered import OrderedSet, OrderedFrozenSet
-from jsparagus import gen
+from jsparagus import gen, grammar
 from .lexer import ECMASCRIPT_FULL_KEYWORDS, ECMASCRIPT_CONDITIONAL_KEYWORDS
 from .parse_esgrammar import parse_esgrammar
 
 
-ECMASCRIPT_LEXICAL_SYNTHETIC_TERMINALS = {
+ECMASCRIPT_LEXICAL_SYNTHETIC_TERMINALS: grammar.SyntheticTerminalsDict = {
     # Theoretically, this should be the set of all Unicode characters, but that
     # would take a lot of memory, and in practice, the set is not used.
     'SourceCharacter': OrderedFrozenSet([]),

--- a/js_parser/parse_esgrammar.py
+++ b/js_parser/parse_esgrammar.py
@@ -295,7 +295,7 @@ class ESGrammarBuilder:
         # information to produce a JSON file.
         if self.method_trait == "AstBuilder":
             fallible = None
-        return grammar.CallMethod(method, args or (), self.method_trait,
+        return grammar.CallMethod(method, args or (), types.Type(self.method_trait),
                                   fallible is not None)
 
     def expr_some(self, expr):

--- a/js_parser/parse_esgrammar.py
+++ b/js_parser/parse_esgrammar.py
@@ -263,7 +263,7 @@ class ESGrammarBuilder:
         return types.Lifetime(name)
 
     def parameterized_type(self, name, args):
-        return types.Type(name, args)
+        return types.Type(name, tuple(args))
 
     def t_list_line(self, terminals):
         return terminals

--- a/jsparagus/actions.py
+++ b/jsparagus/actions.py
@@ -1,5 +1,6 @@
 from .ordered import OrderedFrozenSet
 from .grammar import InitNt, Nt
+from . import types
 
 
 class Action:
@@ -254,7 +255,7 @@ class FunCall(Action):
     __slots__ = 'trait', 'method', 'offset', 'args', 'fallible', 'set_to'
 
     def __init__(self, method, args,
-                 trait="AstBuilder",
+                 trait=types.Type("AstBuilder"),
                  fallible=False,
                  set_to="val",
                  offset=0,

--- a/jsparagus/emit/python.py
+++ b/jsparagus/emit/python.py
@@ -8,6 +8,9 @@ from ..ordered import OrderedSet
 
 
 def write_python_parse_table(out, parse_table):
+    # Disable MyPy type checking for everything in this module.
+    out.write("# type: ignore\n\n")
+
     out.write("from jsparagus import runtime\n")
     if any(isinstance(key, Nt) for key in parse_table.nonterminals):
         out.write(

--- a/jsparagus/extension.py
+++ b/jsparagus/extension.py
@@ -1,9 +1,9 @@
 """Data structure extracted from parsing the EDSL which are added within the
 Rust code."""
 
-import collections
-from .utils import keep_until
 from dataclasses import dataclass
+from .utils import keep_until
+from . import grammar
 
 
 @dataclass(frozen=True)
@@ -42,14 +42,11 @@ def merge_productions(grammar, prod1, prod2):
     return prod1.copy_with(body=body)
 
 
-class ExtPatch(collections.namedtuple("ExtPatch", "prod")):
+@dataclass(frozen=True)
+class ExtPatch:
     "Patch an existing grammar rule by adding Code"
-    def __new__(cls, prod):
-        self = super(ExtPatch, cls).__new__(cls, prod)
-        return self
 
-    def __eq__(self, other):
-        return isinstance(other, ExtPatch) and super(ExtPatch, self).__eq__(other)
+    prod: grammar.NtDef
 
     def apply_patch(self, filename, grammar, nonterminals):
         # - name: non-terminal.

--- a/jsparagus/extension.py
+++ b/jsparagus/extension.py
@@ -3,15 +3,15 @@ Rust code."""
 
 import collections
 from .utils import keep_until
+from dataclasses import dataclass
 
 
-class ImplFor(collections.namedtuple("ImplFor", "param trait for_type")):
-    def __new__(cls, param, trait, for_type):
-        self = super(ImplFor, cls).__new__(cls, param, trait, for_type)
-        return self
-
-    def __eq__(self, other):
-        return isinstance(other, ImplFor) and super(ImplFor, self).__eq__(other)
+@dataclass(frozen=True)
+class ImplFor:
+    __slots__ = ['param', 'trait', 'for_type']
+    param: str
+    trait: str
+    for_type: str
 
 
 def eq_productions(grammar, prod1, prod2):

--- a/jsparagus/gen.py
+++ b/jsparagus/gen.py
@@ -30,11 +30,14 @@ import collections
 import io
 import pickle
 import sys
+import typing
+from dataclasses import dataclass
 
 from .ordered import OrderedSet, OrderedFrozenSet
 
 from .grammar import (Grammar,
                       NtDef, Production, Some, CallMethod, InitNt,
+                      ReduceExprOrAccept,
                       is_concrete_element,
                       Optional, Exclude, Literal, UnicodeCategory, Nt, Var,
                       End, NoLineTerminatorHere, ErrorSymbol,
@@ -540,7 +543,12 @@ def follow_sets(grammar, prods_with_indexes_by_nt, start_set_cache):
 #
 # There may be many productions in a grammar that all have the same `nt` and
 # `index` because they were all produced from the same source production.
-Prod = collections.namedtuple("Prod", "nt index rhs reducer")
+@dataclass
+class Prod:
+    nt: str
+    index: int
+    rhs: typing.List
+    reducer: ReduceExprOrAccept
 
 
 def expand_optional_symbols_in_rhs(rhs, grammar, empties, start_index=0):

--- a/jsparagus/grammar.py
+++ b/jsparagus/grammar.py
@@ -1056,6 +1056,7 @@ Element = typing.Union[
     CallMethod]
 
 
+@dataclass
 class NtDef:
     """Definition of a nonterminal.
 
@@ -1112,23 +1113,11 @@ class NtDef:
 
     __slots__ = ['params', 'rhs_list', 'type']
 
-    def __init__(self, params, rhs_list, type):
-        assert isinstance(params, tuple)
-        self.params = params
-        self.rhs_list = rhs_list
-        self.type = type
+    params: typing.Tuple[str, ...]
+    rhs_list: typing.List[Production]
+    type: typing.Optional[types.Type]
 
-    def __eq__(self, other):
-        return (isinstance(other, NtDef)
-                and ((self.params, self.rhs_list, self.type)
-                     == (other.params, other.rhs_list, other.type)))
-
-    __hash__ = None
-
-    def __repr__(self):
-        return "NtDef({!r}, {!r}, {!r})".format(self.params, self.rhs_list, self.type)
-
-    def with_rhs_list(self, new_rhs_list):
+    def with_rhs_list(self, new_rhs_list: typing.List[Production]) -> NtDef:
         return NtDef(self.params, new_rhs_list, self.type)
 
 

--- a/jsparagus/grammar.py
+++ b/jsparagus/grammar.py
@@ -741,8 +741,6 @@ class Grammar:
                     condition = "{} == {!r}".format(param, value)
                 prefix = "#[if {}] ".format(condition)
             return prefix + self.rhs_to_str(rhs.body)
-        elif isinstance(rhs, Production):
-            return self.rhs_to_str(rhs.body)
         elif len(rhs) == 0:
             return "[empty]"
         else:

--- a/jsparagus/grammar.py
+++ b/jsparagus/grammar.py
@@ -18,8 +18,8 @@ from . import types
 #
 # The most common elements are terminals and nonterminals, so a grammar usually
 # looks something like this:
-def example_grammar():
-    rules = {
+def example_grammar() -> Grammar:
+    rules: typing.Dict[typing.Union[str, InitNt, Nt], LenientNtDef] = {
         'expr': [
             ['term'],
             ['expr', '+', 'term'],
@@ -71,19 +71,23 @@ class Production:
     reducer: ReduceExprOrAccept
     condition: typing.Optional[Condition]
 
-    def __init__(self, body, reducer, *, condition=None):
+    def __init__(self,
+                 body: typing.List[Element],
+                 reducer: ReduceExprOrAccept,
+                 *,
+                 condition: typing.Optional[Condition] = None):
         self.body = body
         self.reducer = reducer
         self.condition = condition
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.condition is None:
             return "Production({!r}, reducer={!r})".format(self.body, self.reducer)
         else:
             return ("Production({!r}, reducer={!r}, condition={!r})"
                     .format(self.body, self.reducer, self.condition))
 
-    def copy_with(self, **kwargs):
+    def copy_with(self, **kwargs) -> Production:
         return Production(body=kwargs.get('body', self.body),
                           reducer=kwargs.get('reducer', self.reducer),
                           condition=kwargs.get('condition', self.condition))
@@ -137,11 +141,7 @@ class Some:
     inner: ReduceExpr
 
 
-ReduceExpr = typing.Union[int, CallMethod, None, Some]
-ReduceExprOrAccept = typing.Union[ReduceExpr, str]
-
-
-def expr_to_str(expr):
+def expr_to_str(expr: ReduceExprOrAccept) -> str:
     if isinstance(expr, int):
         return "${}".format(expr)
     elif isinstance(expr, CallMethod):
@@ -159,24 +159,27 @@ def expr_to_str(expr):
         raise ValueError("unrecognized expression: {!r}".format(expr))
 
 
+# Type parameter for Grammar.intern().
+Internable = typing.TypeVar("Internable")
+
 SyntheticTerminalsDict = typing.Dict[str, OrderedFrozenSet[str]]
 
 
 class Grammar:
     """A collection of productions.
 
-    *   self.variable_terminals - OrderedFrozenSet(str) - Terminals that carry
+    *   self.variable_terminals - OrderedFrozenSet[str] - Terminals that carry
         data, like (in JS) numeric literals and RegExps.
 
-    *   self.terminals - OrderedFrozenSet(str) - All terminals used in the
+    *   self.terminals - OrderedFrozenSet[str] - All terminals used in the
         language, including those in self.variable_terminals and
         self.synthetic_terminals.
 
-    *   self.synthetic_terminals - {str: OrderedFrozenSet(str)} - Maps terminals
+    *   self.synthetic_terminals - {str: OrderedFrozenSet[str]} - Maps terminals
         to sets of terminals. An entry `name: set` in this dictionary means
         that `name` is shorthand for "one of the terminals in `set`".
 
-    *   self.nonterminals - {key: NtDef} - Keys are either (str|InitNt), early
+    *   self.nonterminals - {LenientNt: NtDef} - Keys are either (str|InitNt), early
         in the pipeline, or Nt objects later on. Values are the NtDef objects
         that contain the actual Productions.
 
@@ -185,21 +188,34 @@ class Grammar:
     *   self.init_nts - [InitNt or Nt] - The list of all elements of
         self.nonterminals.keys() that are init nonterminals.
 
+    *   self.exec_modes - DefaultDict{str, OrderedSet[Type]} or None - ?
+
+    *   self.type_to_mods - {Type: [str]} or None - ?
+
     *   self._cache - {object: object} - Cache of immutable objects used by
         Grammar.intern().
-
     """
+
+    variable_terminals: OrderedFrozenSet[str]
+    terminals: OrderedFrozenSet[typing.Union[str, End]]
+    synthetic_terminals: SyntheticTerminalsDict
+    nonterminals: typing.Dict[LenientNt, NtDef]
+    methods: typing.Dict[str, types.MethodType]
+    init_nts: typing.List[typing.Union[Nt, InitNt]]
+    exec_modes: typing.Optional[typing.DefaultDict[str, OrderedSet[types.Type]]]
+    type_to_modes: typing.Optional[typing.Mapping[types.Type, typing.List[str]]]
+    _cache: typing.Dict[object, object]
 
     def __init__(
             self,
-            nonterminals,
+            nonterminals: typing.Mapping[LenientNt, LenientNtDef],
             *,
-            goal_nts=None,
-            variable_terminals=(),
-            synthetic_terminals=None,
-            method_types=None,
-            exec_modes=None,
-            type_to_modes=None):
+            goal_nts: typing.Optional[typing.Iterable[LenientNt]] = None,
+            variable_terminals: typing.Iterable[str] = (),
+            synthetic_terminals: typing.Dict[str, OrderedFrozenSet] = None,
+            method_types: typing.Optional[typing.Dict[str, types.MethodType]] = None,
+            exec_modes: typing.Optional[typing.DefaultDict[str, OrderedSet[types.Type]]] = None,
+            type_to_modes: typing.Optional[typing.Mapping[types.Type, typing.List[str]]] = None):
 
         # This constructor supports passing in a sort of jumbled blob of
         # strings, lists, and actual objects, and normalizes it all to a more
@@ -210,15 +226,15 @@ class Grammar:
         # any other nice properties.
 
         # Copy/infer the arguments.
-        nonterminals = dict(nonterminals.items())
+        my_nonterminals: typing.Dict[LenientNt, LenientNtDef] = dict(nonterminals.items())
         if goal_nts is None:
             # Default to the first nonterminal in the dictionary.
-            goal_nts = []
-            for name in nonterminals:
-                goal_nts.append(name)
+            my_goal_nts = []
+            for name in my_nonterminals:
+                my_goal_nts.append(name)
                 break
         else:
-            goal_nts = list(goal_nts)
+            my_goal_nts = list(goal_nts)
         self.variable_terminals = OrderedFrozenSet(variable_terminals)
         if synthetic_terminals is None:
             synthetic_terminals = {}
@@ -227,13 +243,13 @@ class Grammar:
                 name: OrderedFrozenSet(set)
                 for name, set in synthetic_terminals.items()
             }
-            for key, values in synthetic_terminals.items():
-                if key in nonterminals:
+            for synthetic_key, values in synthetic_terminals.items():
+                if synthetic_key in my_nonterminals:
                     raise ValueError(
                         "invalid grammar: {!r} is both a terminal and a nonterminal"
-                        .format(key))
+                        .format(synthetic_key))
                 for t in values:
-                    if t in nonterminals:
+                    if t in my_nonterminals:
                         raise ValueError(
                             "invalid grammar: {!r} is both ".format(t)
                             + "a representation of a synthetic terminal and a nonterminal")
@@ -246,11 +262,12 @@ class Grammar:
                         raise ValueError(
                             "unsupported: synthetic terminals can't include other "
                             "synthetic terminals; {!r} includes {!r}"
-                            .format(key, t))
+                            .format(synthetic_key, t))
         # self.synthetic_terminals = synthetic_terminals
         self.synthetic_terminals = {}
 
-        keys_are_nt = isinstance(next(iter(nonterminals)), Nt)
+        keys_are_nt = isinstance(next(iter(my_nonterminals)), Nt)
+        key_type: typing.Union[typing.Type, typing.Tuple[typing.Type, ...]]
         key_type = Nt if keys_are_nt else (str, InitNt)
 
         self._cache = {}
@@ -260,50 +277,64 @@ class Grammar:
         #
         # str_to_nt maps the name of each non-parameterized
         # nonterminal to `Nt(name)`, a cache.
-        str_to_nt = {}  # {str: Nt}
+        str_to_nt: typing.Dict[typing.Union[str, InitNt], Nt] = {}
         # nt_params lists the names of each nonterminal's parameters (empty
         # tuple for non-parameterized nts).
-        nt_params = {}  # {str: tuple(str)}
-        for key in nonterminals:
+        nt_params: typing.Dict[typing.Union[str, InitNt], typing.Tuple[str, ...]] = {}
+        for key in my_nonterminals:
             if not isinstance(key, key_type):
                 raise ValueError(
                     "invalid grammar: conflicting key types in nonterminals dict - "
                     "expected either all str or all Nt, got {!r}"
                     .format(key.__class__.__name__))
+            nt_name: typing.Union[str, InitNt]
+            param_names: typing.Tuple[str, ...]
             if keys_are_nt:
-                name = key.name
+                assert isinstance(key, Nt)
+                nt_name = key.name
                 param_names = tuple(name for name, value in key.args)
             else:
-                name = key
+                assert isinstance(key, (str, InitNt))
+                nt_name = key
                 param_names = ()
-                if isinstance(nonterminals[key], NtDef):
-                    param_names = tuple(nonterminals[key].params)
-            if name not in nt_params:
-                nt_params[name] = param_names
+                my_nt = my_nonterminals[key]
+                if isinstance(my_nt, NtDef):
+                    param_names = tuple(my_nt.params)
+            if nt_name not in nt_params:
+                nt_params[nt_name] = param_names
             else:
-                if nt_params[name] != param_names:
+                if nt_params[nt_name] != param_names:
                     raise ValueError(
                         "conflicting parameter name lists for nt {!r}: "
                         "both {!r} and {!r}"
-                        .format(name, nt_params[name], param_names))
-            if param_names == () and name not in str_to_nt:
-                str_to_nt[name] = self.intern(Nt(name))
+                        .format(nt_name, nt_params[nt_name], param_names))
+            if param_names == () and nt_name not in str_to_nt:
+                str_to_nt[nt_name] = self.intern(Nt(nt_name))
 
         # Validate, desugar, and copy the grammar. As a side effect, calling
         # validate_element on every element of the grammar populates
         # all_terminals.
-        all_terminals = OrderedSet(self.variable_terminals)
+        all_terminals: OrderedSet[typing.Union[str, End]] = OrderedSet(self.variable_terminals)
         all_terminals.add(End())
 
-        def note_terminal(t):
+        def note_terminal(t: str) -> None:
             """Add t (and all representations of it, if synthetic) to all_terminals."""
             if t not in all_terminals:
                 all_terminals.add(t)
-                if t in synthetic_terminals:
-                    for k in synthetic_terminals[t]:
+                if t in self.synthetic_terminals:
+                    for k in self.synthetic_terminals[t]:
                         note_terminal(k)
 
-        def validate_element(nt, i, j, e, context_params):
+        # Note: i and j are normally list indexes, but they are sometimes the
+        # special string '?'. It's OK because they are used only in error
+        # messages.
+        def validate_element(
+                nt: LenientNt,
+                i: typing.Union[int, str],
+                j: typing.Union[int, str],
+                e: Element,
+                context_params: typing.Tuple[str, ...]
+        ) -> Element:
             if isinstance(e, str):
                 if e in nt_params:
                     if nt_params[e] != ():
@@ -357,7 +388,7 @@ class Grammar:
             elif isinstance(e, Nt):
                 # Either the application or the original parameterized
                 # production must be present in the dictionary.
-                if e not in nonterminals and e.name not in nonterminals:
+                if e not in my_nonterminals and e.name not in my_nonterminals:
                     raise ValueError(
                         "invalid grammar: unrecognized nonterminal "
                         "in production `grammar[{!r}][{}][{}]`: {!r}"
@@ -391,7 +422,11 @@ class Grammar:
                     .format(nt, i, j, e))
             assert False, "unreachable"
 
-        def check_reduce_expr(nt, i, rhs, expr):
+        def check_reduce_expr(
+                nt: LenientNt,
+                i: int,
+                rhs: Production,
+                expr: ReduceExprOrAccept) -> None:
             if isinstance(expr, int):
                 concrete_len = sum(1 for e in rhs.body
                                    if is_concrete_element(e))
@@ -427,11 +462,17 @@ class Grammar:
                     "in grammar[{!r}][{}].reducer"
                     .format(expr, nt, i))
 
-        def copy_rhs(nt, i, sole_production, rhs, context_params):
+        def copy_rhs(
+                nt: LenientNt,
+                i: int,
+                sole_production: bool,
+                rhs: LenientProduction,
+                context_params: typing.Tuple[str, ...]) -> Production:
             if isinstance(rhs, list):
                 # Bare list, no reducer. Desugar to a Production, inferring a
                 # reasonable default reducer.
                 nargs = sum(1 for e in rhs if is_concrete_element(e))
+                reducer: ReduceExpr
                 if len(rhs) == 1 and nargs == 1:
                     reducer = 0  # don't call a method, just propagate the value
                 else:
@@ -466,7 +507,11 @@ class Grammar:
                 for j, e in enumerate(rhs.body)
             ])
 
-        def copy_nt_def(nt, nt_def, params):
+        def copy_nt_def(
+                nt: LenientNt,
+                nt_def: typing.Union[NtDef, typing.List[LenientProduction]],
+        ) -> NtDef:
+            rhs_list: typing.Sequence[LenientProduction]
             if isinstance(nt_def, NtDef):
                 for i, param in enumerate(nt_def.params):
                     if not isinstance(param, str):
@@ -489,11 +534,11 @@ class Grammar:
                     .format(nt, type(rhs_list).__name__))
 
             sole_production = len(rhs_list) == 1
-            rhs_list = [copy_rhs(nt, i, sole_production, rhs, params)
-                        for i, rhs in enumerate(rhs_list)]
-            return NtDef(params, rhs_list, ty)
+            productions = [copy_rhs(nt, i, sole_production, rhs, params)
+                           for i, rhs in enumerate(rhs_list)]
+            return NtDef(params, productions, ty)
 
-        def check_nt_key(nt):
+        def check_nt_key(nt: LenientNt) -> None:
             if isinstance(nt, str):
                 if not nt.isidentifier():
                     raise ValueError(
@@ -532,8 +577,8 @@ class Grammar:
                         .format(nt))
                 # nt.goal is a "use", not a "def". Check it like a use.
                 # Bogus question marks appear in error messages :-|
-                validate_element(nt, '?', '?', nt.goal, [])
-                if nt.goal not in goal_nts:
+                validate_element(nt, '?', '?', nt.goal, ())
+                if nt.goal not in my_goal_nts:
                     raise TypeError(
                         "invalid grammar: nonterminal referenced by InitNt "
                         "is not in the list of goals: {!r}"
@@ -543,7 +588,10 @@ class Grammar:
                     "invalid grammar: expected string keys in nonterminals dict, got {!r}"
                     .format(nt))
 
-        def validate_nt(nt, nt_def):
+        def validate_nt(
+                nt: LenientNt,
+                nt_def: LenientNtDef
+        ) -> typing.Tuple[LenientNt, NtDef]:
             check_nt_key(nt)
             if isinstance(nt, InitNt):
                 # Check the form of init productions. Initially these look like
@@ -568,18 +616,18 @@ class Grammar:
                         "the expected forms: got {!r}"
                         .format(nt, rhs_list))
 
-            return nt, copy_nt_def(nt, nt_def, [])
+            return nt, copy_nt_def(nt, nt_def)
 
         self.nonterminals = {}
-        for nt, nt_def in nonterminals.items():
-            nt, nt_def = validate_nt(nt, nt_def)
+        for nt1, nt_def1 in my_nonterminals.items():
+            nt, nt_def = validate_nt(nt1, nt_def1)
             self.nonterminals[nt] = nt_def
-        for nt, nt_def in synthetic_terminals.items():
-            nt_def = NtDef((nt,), [Production([e], 0) for e in nt_def], None)
-            nt, nt_def = validate_nt(nt, nt_def)
+        for syn_term_name, t_set in synthetic_terminals.items():
+            nt_def = NtDef((syn_term_name,), [Production([e], 0) for e in t_set], None)
+            nt, nt_def = validate_nt(syn_term_name, nt_def)
             self.nonterminals[nt] = nt_def
             # Remove synthetic terminals from the list of terminals.
-            all_terminals -= OrderedSet([nt])
+            all_terminals.remove(syn_term_name)
 
         self.terminals = OrderedFrozenSet(all_terminals)
 
@@ -591,12 +639,13 @@ class Grammar:
             types.infer_types(self)
         else:
             for nt, nt_def in self.nonterminals.items():
+                assert isinstance(nt_def, NtDef)
                 assert isinstance(nt_def.type, types.Type)
             self.methods = method_types
 
         # Synthesize "init" nonterminals.
         self.init_nts = []
-        for goal in goal_nts:
+        for goal in my_goal_nts:
             # Convert str goals to Nt objects and validate.
             if isinstance(goal, str):
                 ok = goal in str_to_nt
@@ -604,30 +653,38 @@ class Grammar:
                     goal = str_to_nt[goal]
             elif isinstance(goal, Nt):
                 if keys_are_nt:
-                    ok = goal in nonterminals
+                    ok = goal in my_nonterminals
                 else:
-                    ok = goal.name in nonterminals
+                    ok = goal.name in my_nonterminals
             if not ok:
                 raise ValueError(
                     "goal nonterminal {!r} is undefined".format(goal))
+            assert isinstance(goal, Nt)
 
             # Weird, but the key of an init nonterminal really is
             # `Nt(InitNt(Nt(goal_name, goal_args)), ())`. It takes no arguments,
             # but it refers to a goal that might take arguments.
-            init_key = InitNt(goal)
-            init_nt = Nt(init_key, ())
+            init_nt = InitNt(goal)
+            init_key: LenientNt = init_nt
+            goal_nt = Nt(init_nt, ())
             if keys_are_nt:
-                init_key = init_nt
+                init_key = goal_nt
             if init_key not in self.nonterminals:
                 self.nonterminals[init_key] = NtDef(
-                    (), [Production([goal], 0), Production([init_nt, End()], 'accept')], types.NoReturnType)
-            self.init_nts.append(init_nt)
+                    (),
+                    [Production([goal], 0),
+                     Production([goal_nt, End()], 'accept')],
+                    types.NoReturnType)
+            self.init_nts.append(goal_nt)
 
         # Add the various execution backends which would rely on the same parse table.
         self.exec_modes = exec_modes
         self.type_to_modes = type_to_modes
 
-    def patch(self, extensions):
+    # The argument is a list of extension.GrammarExtensions. The annotation is
+    # vague because this module does not import the extension module. It would
+    # be a cyclic dependency.
+    def patch(self, extensions: typing.List) -> None:
         assert self.type_to_modes is not None
         assert self.exec_modes is not None
         if extensions == []:
@@ -644,14 +701,16 @@ class Grammar:
         # Replace with the modified version of nonterminals
         self.nonterminals = nonterminals
 
-    def intern(self, obj):
+    def intern(self, obj: Internable) -> Internable:
         """Return a shared copy of the immutable object `obj`.
 
         This saves memory and consistent use allows code to use `is` for
         equality testing.
         """
         try:
-            return self._cache[obj]
+            # mypy doesn't have enough dependent-typing fanciness to say what
+            # self._cache is and get this return statement to type-check.
+            return self._cache[obj]  # type: ignore
         except KeyError:
             self._cache[obj] = obj
             return obj
@@ -659,33 +718,40 @@ class Grammar:
     # Terminals are tokens that must appear verbatim in the input wherever they
     # appear in the grammar, like the operators '+' '-' *' '/' and brackets '(' ')'
     # in the example grammar.
-    def is_terminal(self, element):
+    def is_terminal(self, element: object) -> bool:
         return type(element) is str
 
-    def expand_set_of_terminals(self, terminals):
+    def expand_set_of_terminals(
+            self,
+            terminals: typing.Iterable[typing.Union[str, None, ErrorSymbol]]
+    ) -> OrderedSet[typing.Union[str, None, ErrorSymbol]]:
         """Copy a set of terminals, replacing any synthetic terminals with their representations.
 
         Returns a new OrderedSet.
 
         terminals - an iterable of terminals and/or other unique elements like
-        None or ErrorToken.
+        None or ErrorSymbol.
         """
-        result = OrderedSet()
+        result: OrderedSet[typing.Union[str, None, ErrorSymbol]] = OrderedSet()
         for t in terminals:
-            if t in self.synthetic_terminals:
+            if isinstance(t, str) and t in self.synthetic_terminals:
                 result |= self.expand_set_of_terminals(self.synthetic_terminals[t])
             else:
                 result.add(t)
         return result
 
-    def goals(self):
+    def goals(self) -> typing.List[Nt]:
         """Return a list of this grammar's goal nonterminals."""
-        return [init_nt.name.goal for init_nt in self.init_nts]
+        return [init_nt.name.goal for init_nt in self.init_nts]  # type: ignore
 
-    def with_nonterminals(self, nonterminals):
+    def with_nonterminals(
+            self,
+            nonterminals: typing.Mapping[LenientNt, LenientNtDef]
+    ) -> Grammar:
         """Return a copy of self with the same attributes except different nonterminals."""
         if self.methods is not None:
             for nt_def in nonterminals.values():
+                assert isinstance(nt_def, NtDef)
                 assert nt_def.type is not None
         return Grammar(
             nonterminals,
@@ -698,10 +764,11 @@ class Grammar:
 
     # === A few methods for dumping pieces of grammar.
 
-    def element_to_str(self, e):
+    def element_to_str(self, e: Element) -> str:
         if isinstance(e, Nt):
             return e.pretty()
         elif self.is_terminal(e):
+            assert isinstance(e, str)
             if e in self.variable_terminals or e in self.synthetic_terminals:
                 return e
             return '"' + repr(e)[1:-1] + '"'
@@ -724,10 +791,10 @@ class Grammar:
         else:
             return str(e)
 
-    def symbols_to_str(self, rhs):
+    def symbols_to_str(self, rhs: typing.Iterable[Element]) -> str:
         return " ".join(self.element_to_str(e) for e in rhs)
 
-    def rhs_to_str(self, rhs):
+    def rhs_to_str(self, rhs: LenientProduction):
         if isinstance(rhs, Production):
             if rhs.condition is None:
                 prefix = ''
@@ -746,15 +813,22 @@ class Grammar:
         else:
             return self.symbols_to_str(rhs)
 
-    def production_to_str(self, nt, rhs, reducer=()):
+    def production_to_str(
+            self,
+            nt: typing.Union[str, Nt],
+            rhs: LenientProduction,
+            *reducer: ReduceExpr
+    ) -> str:
         # As we have two ways of representing productions at the moment, just
         # take multiple arguments :(
         return "{} ::= {}{}".format(
             self.element_to_str(nt),
             self.rhs_to_str(rhs),
-            "" if reducer == () else " => " + expr_to_str(reducer))
+            "".join(" => " + expr_to_str(expr) for expr in reducer))
 
-    def lr_item_to_str(self, prods, item):
+    # The type of `item` is `gen.LRItem`. No annotation because this module
+    # does not import `gen`. It would be a cyclic dependency.
+    def lr_item_to_str(self, prods: typing.List, item) -> str:
         prod = prods[item.prod_index]
         if item.lookahead is None:
             la = []
@@ -771,21 +845,31 @@ class Grammar:
                 for t in item.followed_by)
         )
 
-    def item_set_to_str(self, prods, item_set):
+    def item_set_to_str(
+            self,
+            prods: typing.List,
+            item_set: OrderedFrozenSet
+    ) -> str:
         return "{{{}}}".format(
             ",  ".join(self.lr_item_to_str(prods, item) for item in item_set)
         )
 
-    def expand_terminal(self, t):
+    def expand_terminal(self, t: str) -> OrderedFrozenSet[str]:
         return self.synthetic_terminals.get(t) or OrderedFrozenSet([t])
 
-    def compatible_elements(self, e1, e2):
+    def compatible_elements(self, e1: Element, e2: Element) -> bool:
+        # "type: ignore" because mypy doesn't know that `self.is_terminal(e1)`
+        # means `e1` is a terminal, and thus `self.expand_terminal(e1)` is OK.
         return (e1 == e2
                 or (self.is_terminal(e1)
                     and self.is_terminal(e2)
-                    and len(self.expand_terminal(e1) & self.expand_terminal(e2)) > 0))
+                    and len(self.expand_terminal(e1)  # type: ignore
+                            & self.expand_terminal(e2)) > 0))  # type: ignore
 
-    def compatible_sequences(self, seq1, seq2):
+    def compatible_sequences(
+            self,
+            seq1: typing.Sequence[Element],
+            seq2: typing.Sequence[Element]) -> bool:
         """True if the two sequences could be the same terminals."""
         return (len(seq1) == len(seq1)
                 and all(self.compatible_elements(e1, e2) for e1, e2 in zip(seq1, seq2)))
@@ -809,7 +893,7 @@ class Grammar:
                           ", ".join(types.type_to_str(ty) for ty in mty.argument_types),
                           types.type_to_str(mty.return_type)))
 
-    def is_shifted_element(self, e):
+    def is_shifted_element(self, e: Element) -> bool:
         if isinstance(e, Nt):
             return True
         elif self.is_terminal(e):
@@ -864,7 +948,7 @@ class InitNt:
 #     not match anything else.
 
 
-def is_concrete_element(e):
+def is_concrete_element(e: Element) -> bool:
     """True if parsing the element `e` produces a value.
 
     A production's concrete elements can be used in reduce expressions.
@@ -885,25 +969,29 @@ class Nt:
 
     __slots__ = ['name', 'args']
 
-    def __init__(self, name, args=()):
-        assert isinstance(name, (str, InitNt))
+    name: typing.Union[str, InitNt]
+    args: typing.Tuple[typing.Tuple[str, typing.Hashable], ...]
+
+    def __init__(self,
+                 name: typing.Union[str, InitNt],
+                 args: typing.Tuple[typing.Tuple[str, typing.Hashable], ...] = ()):
         self.name = name
         self.args = args
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(('nt', self.name, self.args))
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return (isinstance(other, Nt)
                 and (self.name, self.args) == (other.name, other.args))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.args:
             return 'Nt({!r}, {!r})'.format(self.name, self.args)
         else:
             return 'Nt({!r})'.format(self.name)
 
-    def pretty(self):
+    def pretty(self) -> str:
         """Unique version of this Nt to use in the Python runtime.
 
         Also used in debug/verbose output.
@@ -981,14 +1069,17 @@ class LookaheadRule:
 # -   A negative lookahead restriction instead specifies the set of all tokens
 #     except a few.
 #
-def lookahead_contains(rule, t):
+def lookahead_contains(rule: typing.Optional[LookaheadRule], t: str):
     """True if the given lookahead restriction `rule` allows the terminal `t`."""
     return (rule is None
             or (t in rule.set if rule.positive
                 else t not in rule.set))
 
 
-def lookahead_intersect(a, b):
+def lookahead_intersect(
+        a: typing.Optional[LookaheadRule],
+        b: typing.Optional[LookaheadRule]
+) -> typing.Optional[LookaheadRule]:
     """Returns a single rule enforcing both `a` and `b`, allowing only terminals that pass both."""
     if a is None:
         return b
@@ -1124,3 +1215,17 @@ class Var:
     """Var(name) represents the run-time value of the parameter with the given name."""
 
     name: str
+
+
+ReduceExpr = typing.Union[int, CallMethod, None, Some]
+ReduceExprOrAccept = typing.Union[ReduceExpr, str]
+
+# The Grammar constructor is very lax about the types you pass to it. It can
+# accept a `Dict[str, List[List[str]]]`, for example; it copies the data into
+# NtDef and Production objects.
+#
+# The `Lenient` types below are the relaxed types that Grammar() actually
+# accepts.
+LenientNt = typing.Union[Nt, str, InitNt]
+LenientProduction = typing.Union[Production, typing.List[Element]]
+LenientNtDef = typing.Union[NtDef, typing.List[LenientProduction]]

--- a/jsparagus/grammar.py
+++ b/jsparagus/grammar.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import collections
 import copy
 import typing
 from dataclasses import dataclass
@@ -1130,7 +1129,8 @@ class NtDef:
         return NtDef(self.params, new_rhs_list, self.type)
 
 
-Var = collections.namedtuple("Var", "name")
-Var.__doc__ = """\
-Var(name) represents the run-time value of the parameter with the given name.
-"""
+@dataclass(frozen=True)
+class Var:
+    """Var(name) represents the run-time value of the parameter with the given name."""
+
+    name: str

--- a/jsparagus/grammar.py
+++ b/jsparagus/grammar.py
@@ -439,7 +439,7 @@ class Grammar:
                     # nonterminal has exactly one production, there's no need
                     # to include the production index `i` to the method name.
                     if sole_production:
-                        method = nt
+                        method = str(nt)
                     else:
                         method = '{}_{}'.format(nt, i)
                     reducer = CallMethod(method, tuple(range(nargs)))

--- a/jsparagus/grammar.py
+++ b/jsparagus/grammar.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import typing
+import dataclasses
 from dataclasses import dataclass
 from .ordered import OrderedSet, OrderedFrozenSet
 from . import types
@@ -88,9 +89,7 @@ class Production:
                     .format(self.body, self.reducer, self.condition))
 
     def copy_with(self, **kwargs) -> Production:
-        return Production(body=kwargs.get('body', self.body),
-                          reducer=kwargs.get('reducer', self.reducer),
-                          condition=kwargs.get('condition', self.condition))
+        return dataclasses.replace(self, **kwargs)
 
 
 # *** Reduce expressions ******************************************************
@@ -1207,7 +1206,7 @@ class NtDef:
     type: typing.Optional[types.Type]
 
     def with_rhs_list(self, new_rhs_list: typing.List[Production]) -> NtDef:
-        return NtDef(self.params, new_rhs_list, self.type)
+        return dataclasses.replace(self, rhs_list=new_rhs_list)
 
 
 @dataclass(frozen=True)

--- a/jsparagus/grammar.py
+++ b/jsparagus/grammar.py
@@ -159,6 +159,9 @@ def expr_to_str(expr):
         raise ValueError("unrecognized expression: {!r}".format(expr))
 
 
+SyntheticTerminalsDict = typing.Dict[str, OrderedFrozenSet[str]]
+
+
 class Grammar:
     """A collection of productions.
 

--- a/jsparagus/grammar.py
+++ b/jsparagus/grammar.py
@@ -123,8 +123,7 @@ class CallMethod(collections.namedtuple("CallMethod", "method args trait fallibl
     """Express a method call, and give it a given set of arguments. A trait is
     added as the parser should implement this trait to call this method."""
     def __new__(cls, method, args, trait=types.Type("AstBuilder"), fallible=False):
-        if isinstance(trait, str):
-            trait = types.Type(trait)
+        assert isinstance(trait, types.Type)
         self = super(CallMethod, cls).__new__(cls, method, args, trait, fallible)
         return self
 

--- a/jsparagus/lexer.py
+++ b/jsparagus/lexer.py
@@ -2,9 +2,10 @@
 
 import re
 import linecache
+from builtins import SyntaxError as BaseSyntaxError
 
 
-class SyntaxError(__builtins__['SyntaxError']):
+class SyntaxError(BaseSyntaxError):
     pass
 
 

--- a/jsparagus/ordered.py
+++ b/jsparagus/ordered.py
@@ -1,73 +1,85 @@
 """ Deterministic data structures. """
 
+from __future__ import annotations
+import typing
 
-class OrderedSet:
+
+# Type parameter for OrderedSet[T] and OrderedFrozenSet[T].
+#
+# This should be `bound=Hashable`, but I gather MyPy has some issues with
+# hashability. It doesn't enforce hashability on Dict and Set.
+T = typing.TypeVar('T')
+
+
+class OrderedSet(typing.Generic[T]):
     """Like set(), but iteration order is insertion order.
 
     Two OrderedSets, x and y, that have different insertion order are still
     considered equal (x == y) if they contain the same elements.
     """
-    def __init__(self, values=()):
+    _data: typing.Dict[T, int]
+
+    def __init__(self, values: typing.Iterable[T] = ()):
         self._data = {}
         for v in values:
             self.add(v)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.__class__.__name__ + "(" + repr(list(self)) + ")"
 
-    def add(self, v):
+    def add(self, v: T) -> None:
         self._data[v] = 1
 
-    def extend(self, iterable):
+    def extend(self, iterable: typing.Iterable[T]) -> None:
         for v in iterable:
             self.add(v)
 
-    def remove(self, v):
+    def remove(self, v: T) -> None:
         del self._data[v]
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, OrderedSet) and self._data == other._data
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         raise TypeError("unhashable type: " + self.__class__.__name__)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._data)
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self._data)
 
-    def __contains__(self, v):
+    def __contains__(self, v: T) -> bool:
         return v in self._data
 
-    def __iter__(self):
+    def __iter__(self) -> typing.Iterator[T]:
         return iter(self._data)
 
-    def __ior__(self, other):
+    def __ior__(self, other: OrderedSet[T]) -> OrderedSet[T]:
         for v in other:
             self.add(v)
         return self
 
-    def __or__(self, other):
+    def __or__(self, other: OrderedSet[T]) -> OrderedSet[T]:
         u = self.__class__(self)
         u |= other
         return u
 
-    def __iand__(self, other):
+    def __iand__(self, other: OrderedSet[T]) -> OrderedSet[T]:
         self._data = {v: 1 for v in self if v in other}
         return self
 
-    def __sub__(self, other):
+    def __sub__(self, other: OrderedSet[T]) -> OrderedSet[T]:
         return OrderedSet(v for v in self if v not in other)
 
-    def __isub__(self, other):
+    def __isub__(self, other: OrderedSet[T]) -> OrderedSet[T]:
         for v in other:
             if v in self:
                 self.remove(v)
         return self
 
 
-class OrderedFrozenSet:
+class OrderedFrozenSet(typing.Generic[T]):
     """Like frozenset(), but iteration order is insertion order.
 
     Two OrderedFrozenSets, x and y, that have different insertion order are
@@ -75,38 +87,41 @@ class OrderedFrozenSet:
     """
     __slots__ = ['_data', '_hash']
 
-    def __init__(self, values=()):
+    _data: typing.Dict[T, int]
+    _hash: typing.Optional[int]
+
+    def __init__(self, values: typing.Iterable[T] = ()):
         self._data = {v: 1 for v in values}
         self._hash = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.__class__.__name__ + "(" + repr(list(self)) + ")"
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._data)
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self._data)
 
-    def __contains__(self, v):
+    def __contains__(self, v: T) -> bool:
         return v in self._data
 
-    def __iter__(self):
+    def __iter__(self) -> typing.Iterator[T]:
         return iter(self._data)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, OrderedFrozenSet) and self._data == other._data
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         if self._hash is None:
             self._hash = hash(frozenset(self._data))
         return self._hash
 
-    def __and__(self, other):
+    def __and__(self, other: OrderedFrozenSet[T]) -> OrderedFrozenSet[T]:
         return OrderedFrozenSet(v for v in self._data if v in other)
 
-    def __or__(self, other):
+    def __or__(self, other: OrderedFrozenSet[T]) -> OrderedFrozenSet[T]:
         return OrderedFrozenSet(list(self) + list(other))
 
-    def __sub__(self, other):
+    def __sub__(self, other: OrderedFrozenSet[T]) -> OrderedFrozenSet[T]:
         return OrderedFrozenSet(v for v in self._data if v not in other)

--- a/jsparagus/parse_pgen_generated.py
+++ b/jsparagus/parse_pgen_generated.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 from jsparagus import runtime
 from jsparagus.runtime import (Nt, InitNt, End, ErrorToken, StateTermValue,
                                ShiftError, ShiftAccept)

--- a/jsparagus/runtime.py
+++ b/jsparagus/runtime.py
@@ -4,6 +4,8 @@
 from .grammar import Nt, InitNt, End
 from .lexer import UnexpectedEndError
 import collections
+from dataclasses import dataclass
+
 
 __all__ = ['ACCEPT', 'ERROR', 'Nt', 'InitNt', 'End', 'Parser', 'ErrorToken']
 
@@ -19,9 +21,10 @@ SPECIAL_CASE_TAG = -0x8000_0000_0000_0000
 ACCEPT = 0x_bfff_ffff_ffff_ffff - (1 << 64)
 ERROR = ACCEPT - 1
 
-ErrorToken = collections.namedtuple('ErrorToken', '')
-ErrorToken_default_eq = ErrorToken.__eq__
-ErrorToken.__eq__ = lambda x, y: x.__class__ == y.__class__ and ErrorToken_default_eq(x, y)
+
+@dataclass(frozen=True)
+class ErrorToken:
+    pass
 
 
 def throw_syntax_error(actions, state, t, tokens):

--- a/jsparagus/types.py
+++ b/jsparagus/types.py
@@ -14,19 +14,13 @@ See infer_types() for more.
 """
 
 import collections
+from dataclasses import dataclass
 from . import grammar
 
 
-class Lifetime(collections.namedtuple('Lifetime', 'name')):
-    def __new__(cls, name):
-        self = super(Lifetime, cls).__new__(cls, name)
-        return self
-
-    def __eq__(self, other):
-        return isinstance(other, Lifetime) and super(Lifetime, self).__eq__(other)
-
-    def __hash__(self):
-        return super(Lifetime, self).__hash__()
+@dataclass(frozen=True)
+class Lifetime:
+    name: str
 
     def __str__(self):
         return "'" + self.name

--- a/jsparagus/types.py
+++ b/jsparagus/types.py
@@ -13,8 +13,11 @@ argument types.
 See infer_types() for more.
 """
 
+from __future__ import annotations
+
 import collections
 from dataclasses import dataclass
+import typing
 from . import grammar
 
 
@@ -22,36 +25,30 @@ from . import grammar
 class Lifetime:
     name: str
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "'" + self.name
 
-
-TypeBase = collections.namedtuple('Type', 'name args')
 
 _all_types = {}
 
 
-class Type(TypeBase):
-    def __new__(cls, name, args=()):
-        # type checking
-        if type(name) is not str:
-            raise TypeError("Type() first argument must be a str, not {!r}".format(name))
-        args = tuple(args)
-        for arg in args:
-            if not isinstance(arg, (Type, TypeVar, Lifetime)):
-                raise TypeError("Type parameters must be types, not {!r}".format(arg))
+@dataclass(frozen=True)
+class Type:
+    name: str
+    args: typing.Tuple[TypeParameter, ...] = ()
+
+    def __new__(cls, name: str, args: typing.Tuple[TypeParameter, ...] = ()) -> Type:
+        assert isinstance(args, tuple)
 
         # caching
         key = name, args
         if key not in _all_types:
-            _all_types[key] = super().__new__(cls, name, args)
+            obj = super().__new__(cls)
+            _all_types[key] = obj
         return _all_types[key]
 
-    def __eq__(self, other):
-        return isinstance(other, Type) and super(Type, self).__eq__(other)
-
-    def __hash__(self):
-        return hash((self.name, self.args))
+    def __getnewargs__(self):
+        return (self.name, self.args)
 
     def __str__(self):
         if self.args:
@@ -92,6 +89,10 @@ class TypeVar:
     """
     __slots__ = ['name', 'precedence', 'value']
 
+    name: str
+    precedence: int
+    value: typing.Optional[TypeOrTypeVar]
+
     def __init__(self, name=None, precedence=0):
         assert (precedence > 0) == (name is not None)
         assert name is None or isinstance(name, str)
@@ -101,6 +102,10 @@ class TypeVar:
 
     def __str__(self):
         return 'TypeVar({!r})'.format(self.name)
+
+
+TypeOrTypeVar = typing.Union[Type, TypeVar]
+TypeParameter = typing.Union[Type, TypeVar, Lifetime]
 
 
 class JsparagusTypeError(Exception):
@@ -114,8 +119,7 @@ class JsparagusTypeError(Exception):
         return cls("expected type {}, got type {}".format(expected, actual))
 
 
-def deref(t):
-    assert isinstance(t, (Type, TypeVar))
+def deref(t: TypeOrTypeVar) -> TypeOrTypeVar:
     if isinstance(t, TypeVar):
         if t.value is not None:
             t.value = deref(t.value)
@@ -123,7 +127,14 @@ def deref(t):
     return t
 
 
-def final_deref(ty):
+def final_deref_parameter(ty: TypeParameter) -> TypeParameter:
+    if isinstance(ty, Lifetime):
+        return ty
+    else:
+        return final_deref(ty)
+
+
+def final_deref(ty: TypeOrTypeVar) -> Type:
     """ Like deref(), but also replace any remaining unresolved type variables with
     synthesized Types.
     """
@@ -138,16 +149,19 @@ def final_deref(ty):
         assert isinstance(ty, Type)
         if ty.args:
             assert ty.name != 'Unit'
-            return Type(ty.name, tuple(final_deref(arg) for arg in ty.args))
+            return Type(ty.name, tuple(final_deref_parameter(arg) for arg in ty.args))
         return ty
 
 
-def unify(actual, expected):
+def unify(actual: TypeParameter, expected: TypeParameter) -> None:
+    if isinstance(actual, Lifetime) or isinstance(expected, Lifetime):
+        if actual is expected:
+            return
+        else:
+            raise JsparagusTypeError.clash(expected, actual)
+
     actual = deref(actual)
     expected = deref(expected)
-
-    assert isinstance(actual, (Type, TypeVar))
-    assert isinstance(expected, (Type, TypeVar))
 
     if actual is expected:
         pass
@@ -158,10 +172,10 @@ def unify(actual, expected):
         for i, (actual_arg, expected_arg) in enumerate(zip(actual.args, expected.args)):
             try:
                 unify(actual_arg, expected_arg)
-            except JsparagusTypeError:
+            except JsparagusTypeError as exc:
                 # The error message has to do with the parameter, but we want
                 # to provide the complete problem types.
-                raise JsparagusTypeError.clash(expected, actual)
+                raise JsparagusTypeError.clash(expected, actual) from exc
 
     elif isinstance(expected, TypeVar):
         assert expected.value is None
@@ -177,23 +191,20 @@ def unify(actual, expected):
             actual.value = expected
 
 
+@dataclass
 class MethodType:
     __slots__ = ['argument_types', 'return_type']
 
-    def __init__(self, argument_types, return_type):
-        self.argument_types = argument_types
-        self.return_type = return_type
+    argument_types: typing.List[TypeOrTypeVar]
+    return_type: TypeOrTypeVar
 
-    def resolve(self):
+    def resolve(self) -> MethodType:
         return MethodType(
             [final_deref(t) for t in self.argument_types],
             final_deref(self.return_type))
 
-    def __repr__(self):
-        return 'MethodType({!r}, {!r})'.format(self.argument_types, self.return_type)
 
-
-def infer_types(g):
+def infer_types(g: grammar.Grammar) -> None:
     """Assign a type to each nonterminal and each method in a grammar.
 
     The type system is pretty rigid. We don't have any polymorphism or union
@@ -206,7 +217,7 @@ def infer_types(g):
     each NtDef in `g.nonterminals` and to `g.methods`.
     """
 
-    def type_of_nt(nt, nt_def):
+    def type_of_nt(nt: typing.Union[grammar.Nt, str], nt_def: grammar.NtDef) -> TypeOrTypeVar:
         if nt_def.type is not None:
             return nt_def.type
         else:
@@ -219,36 +230,40 @@ def infer_types(g):
         if not isinstance(nt, grammar.InitNt)
     }
 
-    method_types = {}
+    method_types: typing.Dict[str, MethodType] = {}
 
-    def element_type(e):
+    def element_type(e: grammar.Element) -> TypeOrTypeVar:
         if isinstance(e, str):
             if e in g.nonterminals:
                 return nt_types[e]
             else:
                 return TokenType
         elif isinstance(e, grammar.Optional):
-            return Type('Option', [element_type(e.inner)])
+            return Type('Option', (element_type(e.inner),))
         elif isinstance(e, grammar.Literal):
             return TokenType
         elif isinstance(e, grammar.UnicodeCategory):
             return TokenType
         elif isinstance(e, grammar.Exclude):
-            return Type('Exclude', [element_type(e.inner)] + [element_type(v) for v in e.exclusion_list])
+            return Type('Exclude',
+                        (element_type(e.inner),)
+                        + tuple(element_type(v) for v in e.exclusion_list))
         elif isinstance(e, grammar.Nt):
             # Cope with the awkward fact that g.nonterminals keys may be either
             # strings or Nt objects.
-            return nt_types[e if e in nt_types else e.name]
+            return nt_types[e if e in nt_types else e.name]  # type: ignore
         else:
             assert False, "unexpected element type: {!r}".format(e)
 
-    def expr_type(expr):
+    concrete_element_types: typing.List[TypeOrTypeVar]
+
+    def expr_type(expr: grammar.ReduceExprOrAccept) -> TypeOrTypeVar:
         if isinstance(expr, int):
             return concrete_element_types[expr]
         elif expr is None:
-            return Type('Option', [TypeVar()])
+            return Type('Option', (TypeVar(),))
         elif isinstance(expr, grammar.Some):
-            return Type('Option', [expr_type(expr.inner)])
+            return Type('Option', (expr_type(expr.inner),))
         elif isinstance(expr, grammar.CallMethod):
             arg_types = [expr_type(arg) for arg in expr.args]
             if expr.method in method_types:

--- a/jsparagus/utils.py
+++ b/jsparagus/utils.py
@@ -1,7 +1,15 @@
 """List of functions which are useful in many places."""
 
+import typing
 
-def keep_until(iterable, pred):
+
+T = typing.TypeVar("T")
+
+
+def keep_until(
+        iterable: typing.Iterable[T],
+        pred: typing.Callable[[T], bool]
+) -> typing.Iterable[T]:
     """Filter an iterable generator or list and keep all elements until the first
     time the predicate becomes true, including the element where the predicate
     is true. All elements after are skipped."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,13 @@
 ## The following requirements were added by pip freeze:
+entrypoints==0.3
+flake8==3.7.9
 html5lib==1.0.1
+mccabe==0.6.1
+mypy==0.770
+mypy-extensions==0.4.3
+pycodestyle==2.5.0
+pyflakes==2.1.1
 six==1.11.0
+typed-ast==1.4.1
+typing-extensions==3.7.4.1
 webencodings==0.5.1

--- a/tests/test.py
+++ b/tests/test.py
@@ -13,7 +13,7 @@ LispTokenizer = lexer.LexicalGrammar("( )", SYMBOL=r'[!%&*+:<=>?@A-Z^_a-z~]+')
 
 
 def prod(body, method_name):
-    return Production(body, CallMethod(method_name, list(range(len(body))), "AstBuilder", False))
+    return Production(body, CallMethod(method_name, list(range(len(body)))))
 
 
 class GenTestCase(unittest.TestCase):
@@ -842,7 +842,7 @@ class GenTestCase(unittest.TestCase):
                 [name, "(", ")", ";"],
                 [name, "=", name, ";"],
                 Production(["yield", name, ";"],
-                           reducer=CallMethod("yield_stmt", [1], "AstBuilder", False),
+                           reducer=CallMethod("yield_stmt", [1]),
                            condition=('Yield', True)),
             ], None),
             'name': NtDef(('Yield',), [
@@ -850,7 +850,7 @@ class GenTestCase(unittest.TestCase):
                 # Specifically ask for a method here, because otherwise we
                 # wouldn't get one and then type checking would fail.
                 Production(["yield"],
-                           CallMethod("yield_as_name", [], "AstBuilder", False),
+                           CallMethod("yield_as_name", []),
                            condition=('Yield', False)),
             ], None),
         }, variable_terminals=["IDENT"])
@@ -1079,7 +1079,7 @@ class GenTestCase(unittest.TestCase):
         """A method can be called only in an intermediate reduce expression."""
 
         # The reduce expression `f(g($0))`.
-        reducer = CallMethod("f", [CallMethod("g", [0], "AstBuilder", False)], "AstBuilder", False)
+        reducer = CallMethod("f", [CallMethod("g", [0])])
 
         # The grammar `goal ::= NAME => f(g($1))`.
         grammar = Grammar(

--- a/update.sh
+++ b/update.sh
@@ -23,6 +23,4 @@ cd $(dirname "$0")
 python3 -m jsparagus.parse_pgen --regenerate > jsparagus/parse_pgen_generated_NEW.py
 mv jsparagus/parse_pgen_generated_NEW.py jsparagus/parse_pgen_generated.py
 
-python3 -m jsparagus.main --target=rust pgen.pgen > example_pgen.rs
-
 ./test.sh


### PR DESCRIPTION
Things to know about mypy:

- Annotations are optional, and it's ok (and normal) to have a codebase partially annotated.

- `python` does not use these annotations to type-check values at run time.

- They are only checked when you run the mypy tool.

- If you write `if instanceof(foo, str):` then mypy knows `foo` is a `str` in the `if` body.

- If you write `assert instanceof(foo, str)`, then mypy **assumes** that the assertion is correct and that `foo` is a `str` afterwards. Your assertion might be wrong!! So avoid this where possible. It's actually making mypy do less type checking.
