### PR TITLE
Add ScriptEmitter and BlockEmitter (fixes #434)

### DIFF
--- a/crates/emitter/src/block_emitter.rs
+++ b/crates/emitter/src/block_emitter.rs
@@ -1,0 +1,33 @@
+use crate::ast_emitter::AstEmitter;
+use crate::emitter::EmitError;
+use scope::data::ScopeIndex;
+
+pub struct BlockEmitter<'a, StmtT, StmtF>
+where
+    StmtF: Fn(&mut AstEmitter, &StmtT) -> Result<(), EmitError>,
+{
+    pub scope_index: ScopeIndex,
+    pub statements: std::slice::Iter<'a, StmtT>,
+    pub statement: StmtF,
+}
+
+impl<'a, StmtT, StmtF> BlockEmitter<'a, StmtT, StmtF>
+where
+    StmtF: Fn(&mut AstEmitter, &StmtT) -> Result<(), EmitError>,
+{
+    pub fn emit(self, emitter: &mut AstEmitter) -> Result<(), EmitError> {
+        emitter.scope_stack.enter_lexical(
+            &mut emitter.emit,
+            &mut emitter.compilation_info.scope_data_map,
+            self.scope_index,
+        );
+
+        for statement in self.statements {
+            (self.statement)(emitter, statement)?;
+        }
+
+        emitter.scope_stack.leave_lexical(&mut emitter.emit);
+
+        Ok(())
+    }
+}

--- a/crates/emitter/src/emitter_scope.rs
+++ b/crates/emitter/src/emitter_scope.rs
@@ -139,6 +139,10 @@ impl EmitterScopeStack {
         let scope_index = scope_data_map.get_global_index();
         let scope_data = scope_data_map.get_global_at(scope_index);
 
+        if scope_data.bindings.len() > 0 {
+            emit.check_global_or_eval_decl();
+        }
+
         for item in scope_data.iter() {
             let name_index = emit.get_atom_index(item.name());
 

--- a/crates/emitter/src/lib.rs
+++ b/crates/emitter/src/lib.rs
@@ -1,5 +1,6 @@
 mod array_emitter;
 mod ast_emitter;
+mod block_emitter;
 mod compilation_info;
 mod dis;
 mod emitter;

--- a/crates/emitter/src/lib.rs
+++ b/crates/emitter/src/lib.rs
@@ -14,6 +14,7 @@ mod reference_op_emitter;
 mod regexp;
 mod scope_notes;
 mod script_atom_set;
+mod script_emitter;
 
 extern crate jsparagus_ast as ast;
 extern crate jsparagus_scope as scope;

--- a/crates/emitter/src/script_emitter.rs
+++ b/crates/emitter/src/script_emitter.rs
@@ -1,0 +1,31 @@
+use crate::ast_emitter::AstEmitter;
+use crate::emitter::EmitError;
+
+pub struct ScriptEmitter<'a, StmtT, StmtF>
+where
+    StmtF: Fn(&mut AstEmitter, &StmtT) -> Result<(), EmitError>,
+{
+    pub statements: std::slice::Iter<'a, StmtT>,
+    pub statement: StmtF,
+}
+
+impl<'a, StmtT, StmtF> ScriptEmitter<'a, StmtT, StmtF>
+where
+    StmtF: Fn(&mut AstEmitter, &StmtT) -> Result<(), EmitError>,
+{
+    pub fn emit(self, emitter: &mut AstEmitter) -> Result<(), EmitError> {
+        emitter
+            .scope_stack
+            .enter_global(&mut emitter.emit, &emitter.compilation_info.scope_data_map);
+
+        for statement in self.statements {
+            (self.statement)(emitter, statement)?;
+        }
+
+        emitter.emit.ret_rval();
+
+        emitter.scope_stack.leave_global(&mut emitter.emit);
+
+        Ok(())
+    }
+}

--- a/crates/interpreter/src/evaluate.rs
+++ b/crates/interpreter/src/evaluate.rs
@@ -386,6 +386,11 @@ pub fn evaluate(emit: &EmitResult, global: Rc<RefCell<Object>>) -> Result<JSValu
             Opcode::Undefined => stack.push(JSValue::Undefined),
             Opcode::Null => stack.push(JSValue::Null),
 
+            Opcode::CheckGlobalOrEvalDecl => {
+                // FIXME: Port CheckGlobalOrEvalDeclarationConflicts
+                //        from js/src/vm/EnvironmentObject.cpp.
+            }
+
             _ => return Err(EvalError::NotImplemented(format!("{:?}", op))),
         }
 


### PR DESCRIPTION
Moved script and block related code into helper, with a fix for #434 that adds newly added CheckGlobalOrEvalDecl opcode before script