### PR TITLE
Fix ScopeNote to store GCThingIndex instead of ScopeIndex

### DIFF
--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -1439,12 +1439,12 @@ impl InstructionWriter {
     ) -> ScopeNoteIndex {
         self.update_max_frame_slots(next_frame_slot);
 
-        self.gcthings.append_scope(scope_index);
+        let gcthing_index = self.gcthings.append_scope(scope_index);
         let offset = self.bytecode_offset();
-        let index = self
-            .scope_notes
-            .enter_scope(scope_index, offset, parent_scope_note_index);
-        index
+        let note_index =
+            self.scope_notes
+                .enter_scope(gcthing_index, offset, parent_scope_note_index);
+        note_index
     }
 
     pub fn leave_lexical_scope(&mut self, index: ScopeNoteIndex) {

--- a/crates/emitter/src/scope_notes.rs
+++ b/crates/emitter/src/scope_notes.rs
@@ -1,19 +1,19 @@
 use crate::emitter::BytecodeOffset;
-use scope::data::ScopeIndex;
+use crate::gcthings::GCThingIndex;
 
 /// Maps to js::ScopeNote in m-c/js/src/vm//JSScript.h.
 #[derive(Debug)]
 pub struct ScopeNote {
-    pub scope_index: ScopeIndex,
+    pub index: GCThingIndex,
     pub start: BytecodeOffset,
     pub end: BytecodeOffset,
     pub parent: Option<ScopeNoteIndex>,
 }
 
 impl ScopeNote {
-    fn new(scope_index: ScopeIndex, start: BytecodeOffset, parent: Option<ScopeNoteIndex>) -> Self {
+    fn new(index: GCThingIndex, start: BytecodeOffset, parent: Option<ScopeNoteIndex>) -> Self {
         Self {
-            scope_index,
+            index,
             start: start.clone(),
             end: start,
             parent,
@@ -53,13 +53,13 @@ impl ScopeNoteList {
 
     pub fn enter_scope(
         &mut self,
-        scope_index: ScopeIndex,
+        index: GCThingIndex,
         offset: BytecodeOffset,
         parent: Option<ScopeNoteIndex>,
     ) -> ScopeNoteIndex {
-        let index = self.notes.len();
-        self.notes.push(ScopeNote::new(scope_index, offset, parent));
-        ScopeNoteIndex::new(index)
+        let note_index = self.notes.len();
+        self.notes.push(ScopeNote::new(index, offset, parent));
+        ScopeNoteIndex::new(note_index)
     }
 
     pub fn leave_scope(&mut self, index: ScopeNoteIndex, offset: BytecodeOffset) {


### PR DESCRIPTION
https://searchfox.org/mozilla-central/rev/064b0f9501ad76802853b43f18e33d8713fd54d3/js/src/vm/SharedStencil.h#76-78
it should be gcthings index, not scope index