### PR TITLE
Fix too big decimal integer literals, and return NotImplemented for too big non-decimal integer literals (fixes #445)

### DIFF
--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -2206,7 +2206,7 @@ impl<'alloc> Lexer<'alloc> {
                 (TerminalId::NumericLiteral, TokenValue::Number(n))
             }
             NumericResult::Float => {
-                let n = parse_float(s);
+                let n = parse_float(s).map_err(|s| ParseError::NotImplemented(s))?;
                 (TerminalId::NumericLiteral, TokenValue::Number(n))
             }
             NumericResult::BigInt { .. } => {

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -428,6 +428,8 @@ fn test_numbers_large() {
 
     assert_same_number("0xfffffffffffff", 4503599627370495.0);
     assert_not_implemented("0x10000000000000");
+
+    assert_not_implemented("4.9406564584124654417656879286822e-324");
 }
 
 #[test]


### PR DESCRIPTION
The following were not able to handle the case that number overflows from 53bit (integer part of f64)
  * `parse_decimal_int`
  * `parse_binary`
  * `parse_octal`
  * `parse_hex`

That the resulting number has error around 54+bits.

For `parse_decimal_int`, it can fallback to `parse_float`, that's basically a slow path for the case when the literal contains `_`.

For other cases, I cannot find a simple way to parse too big non-decimal in Rust,
so for now it returns NotImplemented.
