### PR TITLE
Make visior immutable, and use reference with lifetime (fixes #447)

### DIFF
--- a/crates/ast/generate_ast.py
+++ b/crates/ast/generate_ast.py
@@ -422,7 +422,7 @@ def pass_(ast):
                 # Hack in a quick fix
                 continue
 
-            write(1, "fn {}(&mut self, ast: &mut {}) {{",
+            write(1, "fn {}(&mut self, ast: &'alloc {}) {{",
                   to_method_name(type_decl.name), Type(name).to_rust_type(ast))
 
             write(2, "self.{}(ast);",
@@ -439,13 +439,13 @@ def pass_(ast):
             write(1, "}")
             write(0, "")
 
-            write(1, "fn {}(&mut self, ast: &mut {}) {{",
+            write(1, "fn {}(&mut self, ast: &'alloc {}) {{",
                   to_enter_method_name(type_decl.name),
                   Type(name).to_rust_type(ast))
             write(1, "}")
             write(0, "")
 
-            write(1, "fn {}(&mut self, ast: &mut {}) {{",
+            write(1, "fn {}(&mut self, ast: &'alloc {}) {{",
                   to_leave_method_name(type_decl.name),
                   Type(name).to_rust_type(ast))
             write(1, "}")
@@ -463,7 +463,7 @@ def pass_(ast):
                         def write_field_params(indent, write, variant_type,
                                                ast):
                             for field_name, field_ty in variant_type.items():
-                                write(2, "{}: &mut {},",
+                                write(2, "{}: &'alloc {},",
                                       field_name, field_ty.to_rust_type(ast))
 
                         write(1, "fn {}(",
@@ -513,7 +513,7 @@ def pass_(ast):
                     else:
                         def write_field_params(indent, write, variant_type,
                                                ast):
-                            write(2, "ast: &mut {},",
+                            write(2, "ast: &'alloc {},",
                                   variant_type.to_rust_type(ast))
 
                         write(1, "fn {}(",
@@ -794,7 +794,7 @@ class Struct(AggregateTypeDecl):
                                     emit_variant_tuple_call,
                                     emit_variant_none_call):
         for name, ty in self.fields.items():
-            emit_call(2, ty, "&mut ast.{}".format(name))
+            emit_call(2, ty, "&ast.{}".format(name))
 
     def write_rust_dump_method_body(self, write):
         write(2, 'write!(out, "({}").expect("failed to dump");', self.name)
@@ -879,7 +879,7 @@ class Enum(AggregateTypeDecl):
                                                  variant_type):
         for field_name, field_ty in variant_type.items():
             if field_ty.name == 'Vec':
-                emit_call(2, field_ty, '{}.iter_mut()'.format(field_name))
+                emit_call(2, field_ty, '{}.iter()'.format(field_name))
             else:
                 emit_call(2, field_ty, field_name)
 

--- a/crates/emitter/src/lib.rs
+++ b/crates/emitter/src/lib.rs
@@ -28,7 +28,7 @@ use ast::source_atom_set::SourceAtomSet;
 use ast::source_slice_list::SourceSliceList;
 
 pub fn emit<'alloc>(
-    ast: &mut ast::types::Program,
+    ast: &'alloc ast::types::Program<'alloc>,
     options: &EmitOptions,
     atoms: SourceAtomSet<'alloc>,
     slices: SourceSliceList<'alloc>,

--- a/crates/interpreter/src/tests.rs
+++ b/crates/interpreter/src/tests.rs
@@ -1,3 +1,4 @@
+use ast::arena;
 use ast::source_atom_set::SourceAtomSet;
 use ast::source_slice_list::SourceSliceList;
 use bumpalo::Bump;
@@ -16,8 +17,10 @@ fn try_evaluate(source: &str) -> Result<JSValue, EvalError> {
     let parse_result = parse_script(alloc, source, &parse_options, atoms.clone(), slices.clone())
         .expect("Failed to parse");
     let emit_options = EmitOptions::new();
+    let script = parse_result.unbox();
+    let program = arena::alloc(alloc, ast::types::Program::Script(script)).unbox();
     let emit_result = emit(
-        &mut ast::types::Program::Script(parse_result.unbox()),
+        &program,
         &emit_options,
         atoms.replace(SourceAtomSet::new_uninitialized()),
         slices.replace(SourceSliceList::new()),

--- a/crates/scope/src/lib.rs
+++ b/crates/scope/src/lib.rs
@@ -14,7 +14,7 @@ use ast::visit::Pass;
 pub use data::ScopeDataMap;
 
 /// Visit all nodes in the AST, and create a scope data.
-pub fn generate_scope_data<'alloc>(ast: &mut ast::types::Program<'alloc>) -> ScopeDataMap {
+pub fn generate_scope_data<'alloc>(ast: &'alloc ast::types::Program<'alloc>) -> ScopeDataMap {
     let mut scope_pass = pass::ScopePass::new();
     scope_pass.visit_program(ast);
     scope_pass.context.into()

--- a/crates/scope/src/pass.rs
+++ b/crates/scope/src/pass.rs
@@ -20,23 +20,23 @@ impl<'alloc> ScopePass<'alloc> {
 }
 
 impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
-    fn enter_script(&mut self, _ast: &mut Script<'alloc>) {
+    fn enter_script(&mut self, _ast: &'alloc Script<'alloc>) {
         self.context.before_script();
     }
 
-    fn leave_script(&mut self, _ast: &mut Script<'alloc>) {
+    fn leave_script(&mut self, _ast: &'alloc Script<'alloc>) {
         self.context.after_script();
     }
 
-    fn enter_enum_statement_variant_block_statement(&mut self, block: &mut Block<'alloc>) {
+    fn enter_enum_statement_variant_block_statement(&mut self, block: &'alloc Block<'alloc>) {
         self.context.before_block_statement(block);
     }
 
-    fn leave_enum_statement_variant_block_statement(&mut self, _block: &mut Block<'alloc>) {
+    fn leave_enum_statement_variant_block_statement(&mut self, _block: &'alloc Block<'alloc>) {
         self.context.after_block_statement();
     }
 
-    fn enter_variable_declaration(&mut self, ast: &mut VariableDeclaration<'alloc>) {
+    fn enter_variable_declaration(&mut self, ast: &'alloc VariableDeclaration<'alloc>) {
         match ast.kind {
             VariableDeclarationKind::Var { .. } => {
                 self.context.before_var_declaration();
@@ -50,7 +50,7 @@ impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
         }
     }
 
-    fn leave_variable_declaration(&mut self, ast: &mut VariableDeclaration<'alloc>) {
+    fn leave_variable_declaration(&mut self, ast: &'alloc VariableDeclaration<'alloc>) {
         match ast.kind {
             VariableDeclarationKind::Var { .. } => {
                 self.context.after_var_declaration();
@@ -64,7 +64,7 @@ impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
         }
     }
 
-    fn visit_binding_identifier(&mut self, ast: &mut BindingIdentifier) {
+    fn visit_binding_identifier(&mut self, ast: &'alloc BindingIdentifier) {
         // NOTE: The following should be handled at the parent node,
         // without visiting BindingIdentifier field:
         //   * Function.name
@@ -81,11 +81,11 @@ impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
     // visit_identifier is not called for Identifier inside BindingIdentifier,
     // and this is called only for references, either
     // IdentifierExpression or AssignmentTargetIdentifier.
-    fn visit_identifier(&mut self, ast: &mut Identifier) {
+    fn visit_identifier(&mut self, ast: &'alloc Identifier) {
         self.context.on_non_binding_identifier(ast.value);
     }
 
-    fn enter_enum_statement_variant_function_declaration(&mut self, ast: &mut Function<'alloc>) {
+    fn enter_enum_statement_variant_function_declaration(&mut self, ast: &'alloc Function<'alloc>) {
         let name = if let Some(ref name) = ast.name {
             name.name.value
         } else {


### PR DESCRIPTION
To collect references to inner functions, visitor should use immutable reference
with explicit lifetime parameter.