### PR TITLE
Separate ScriptStencil from EmitResult (fixes #452)

### DIFF
--- a/crates/driver/src/demo.rs
+++ b/crates/driver/src/demo.rs
@@ -150,15 +150,17 @@ fn handle_script<'alloc>(
         Err(err) => {
             eprintln!("error: {}", err);
         }
-        Ok(emit_result) => {
+        Ok(result) => {
+            let script = &result.scripts[0];
+
             if verbosity.emit_result {
-                println!("\n{:#?}", emit_result);
+                println!("\n{:#?}", script);
             }
             if verbosity.bytecode {
-                println!("\n{}", emitter::dis(&emit_result.bytecode));
+                println!("\n{}", emitter::dis(&script.bytecode));
             }
 
-            match evaluate(&emit_result, global) {
+            match evaluate(&result, global) {
                 Err(err) => print!("error: {}", err),
                 Ok(value) => println!("{:?}", value),
             }

--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -5,7 +5,7 @@
 use crate::array_emitter::*;
 use crate::block_emitter::BlockEmitter;
 use crate::compilation_info::CompilationInfo;
-use crate::emitter::{EmitError, EmitOptions, EmitResult, InstructionWriter};
+use crate::emitter::{EmitError, EmitOptions, InstructionWriter};
 use crate::emitter_scope::{EmitterScopeStack, NameLocation};
 use crate::expression_emitter::*;
 use crate::object_emitter::*;
@@ -17,6 +17,7 @@ use crate::reference_op_emitter::{
 };
 use crate::regexp::RegExpItem;
 use crate::script_emitter::ScriptEmitter;
+use crate::stencil::{EmitResult, ScriptStencil};
 use ast::source_atom_set::{CommonSourceAtomSetIndices, SourceAtomSet, SourceAtomSetIndex};
 use ast::source_slice_list::SourceSliceList;
 use ast::types::*;
@@ -35,7 +36,9 @@ pub fn emit_program<'alloc>(
     slices: SourceSliceList<'alloc>,
     scope_data_map: ScopeDataMap,
 ) -> Result<EmitResult<'alloc>, EmitError> {
-    let mut emitter = AstEmitter::new(options, atoms, slices, scope_data_map);
+    let mut compilation_info = CompilationInfo::new(atoms, slices, scope_data_map);
+    let mut scripts: Vec<ScriptStencil> = Vec::new();
+    let emitter = AstEmitter::new(options, &mut compilation_info, &mut scripts);
 
     match ast {
         Program::Script(script) => emitter.emit_script(script)?,
@@ -44,30 +47,31 @@ pub fn emit_program<'alloc>(
         }
     }
 
-    Ok(emitter.emit.into_emit_result(emitter.compilation_info))
+    Ok(EmitResult::new(compilation_info, scripts))
 }
 
 pub struct AstEmitter<'alloc, 'opt> {
     pub emit: InstructionWriter,
     pub options: &'opt EmitOptions,
-    pub compilation_info: CompilationInfo<'alloc>,
+    pub compilation_info: &'opt mut CompilationInfo<'alloc>,
     pub scope_stack: EmitterScopeStack,
     pub loop_stack: LoopStack,
+    pub scripts: &'opt mut Vec<ScriptStencil>,
 }
 
 impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
     fn new(
         options: &'opt EmitOptions,
-        atoms: SourceAtomSet<'alloc>,
-        slices: SourceSliceList<'alloc>,
-        scope_data_map: ScopeDataMap,
+        compilation_info: &'opt mut CompilationInfo<'alloc>,
+        scripts: &'opt mut Vec<ScriptStencil>,
     ) -> Self {
         Self {
             emit: InstructionWriter::new(),
             options,
-            compilation_info: CompilationInfo::new(atoms, slices, scope_data_map),
+            compilation_info,
             scope_stack: EmitterScopeStack::new(),
             loop_stack: LoopStack::new(),
+            scripts,
         }
     }
 
@@ -75,12 +79,16 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
         self.scope_stack.lookup_name(name)
     }
 
-    fn emit_script(&mut self, ast: &Script) -> Result<(), EmitError> {
+    fn emit_script(mut self, ast: &Script) -> Result<(), EmitError> {
         ScriptEmitter {
             statements: ast.statements.iter(),
             statement: |emitter, statement| emitter.emit_statement(statement),
         }
-        .emit(self)
+        .emit(&mut self)?;
+
+        self.scripts.push(self.emit.into());
+
+        Ok(())
     }
 
     fn emit_statement(&mut self, ast: &Statement) -> Result<(), EmitError> {

--- a/crates/emitter/src/lib.rs
+++ b/crates/emitter/src/lib.rs
@@ -17,14 +17,16 @@ mod regexp;
 mod scope_notes;
 mod script_atom_set;
 mod script_emitter;
+mod stencil;
 
 extern crate jsparagus_ast as ast;
 extern crate jsparagus_scope as scope;
 
-pub use crate::emitter::{EmitError, EmitOptions, EmitResult};
+pub use crate::emitter::{EmitError, EmitOptions};
 pub use crate::gcthings::GCThing;
 pub use crate::regexp::RegExpItem;
 pub use crate::scope_notes::ScopeNote;
+pub use crate::stencil::{EmitResult, ScriptStencil};
 pub use dis::dis;
 
 use ast::source_atom_set::SourceAtomSet;
@@ -66,16 +68,19 @@ mod tests {
         // println!("{:?}", parse_result);
 
         let emit_options = EmitOptions::new();
-        let bc = emit(
-            &mut ast::types::Program::Script(parse_result.unbox()),
+
+        let result = emit(
+            alloc.alloc(ast::types::Program::Script(parse_result.unbox())),
             &emit_options,
             atoms.replace(SourceAtomSet::new_uninitialized()),
             slices.replace(SourceSliceList::new()),
         )
-        .expect("Should work!")
-        .bytecode;
-        println!("{}", dis(&bc));
-        bc
+        .expect("Should work!");
+
+        let bytecode = &result.scripts[0].bytecode;
+
+        println!("{}", dis(&bytecode));
+        bytecode.to_vec()
     }
 
     #[test]

--- a/crates/emitter/src/stencil.rs
+++ b/crates/emitter/src/stencil.rs
@@ -1,0 +1,64 @@
+//! The result of emitter
+
+use crate::compilation_info::CompilationInfo;
+use crate::gcthings::GCThing;
+use crate::regexp::RegExpItem;
+use crate::scope_notes::ScopeNote;
+
+use ast::source_atom_set::SourceAtomSetIndex;
+use scope::data::ScopeData;
+use scope::frame_slot::FrameSlot;
+
+/// The result of emitter.
+pub struct EmitResult<'alloc> {
+    pub atoms: Vec<&'alloc str>,
+    pub slices: Vec<&'alloc str>,
+    pub scopes: Vec<ScopeData>,
+
+    /// Emitted scripts.
+    /// The first item corresponds to the global script, and the remaining
+    /// items correspond to inner functions.
+    pub scripts: Vec<ScriptStencil>,
+}
+
+impl<'alloc> EmitResult<'alloc> {
+    pub fn new(compilation_info: CompilationInfo<'alloc>, scripts: Vec<ScriptStencil>) -> Self {
+        Self {
+            atoms: compilation_info.atoms.into(),
+            slices: compilation_info.slices.into(),
+            scopes: compilation_info.scope_data_map.into(),
+            scripts,
+        }
+    }
+}
+
+/// Data used to instantiate the non-lazy script.
+/// Maps to js::frontend::ScriptStencil in m-c/js/src/frontend/Stencil.h.
+#[derive(Debug)]
+pub struct ScriptStencil {
+    pub bytecode: Vec<u8>,
+    pub atoms: Vec<SourceAtomSetIndex>,
+    pub regexps: Vec<RegExpItem>,
+    pub gcthings: Vec<GCThing>,
+    pub scope_notes: Vec<ScopeNote>,
+    // Line and column numbers for the first character of source.
+    pub lineno: usize,
+    pub column: usize,
+
+    pub main_offset: usize,
+    pub max_fixed_slots: FrameSlot,
+    pub maximum_stack_depth: u32,
+    pub body_scope_index: u32,
+    pub num_ic_entries: u32,
+    pub num_type_sets: u32,
+
+    pub strict: bool,
+    pub bindings_accessed_dynamically: bool,
+    pub has_call_site_obj: bool,
+    pub is_for_eval: bool,
+    pub is_module: bool,
+    pub is_function: bool,
+    pub has_non_syntactic_scope: bool,
+    pub needs_function_environment_objects: bool,
+    pub has_module_goal: bool,
+}

--- a/crates/interpreter/src/tests.rs
+++ b/crates/interpreter/src/tests.rs
@@ -19,14 +19,14 @@ fn try_evaluate(source: &str) -> Result<JSValue, EvalError> {
     let emit_options = EmitOptions::new();
     let script = parse_result.unbox();
     let program = arena::alloc(alloc, ast::types::Program::Script(script)).unbox();
-    let emit_result = emit(
+    let result = emit(
         &program,
         &emit_options,
         atoms.replace(SourceAtomSet::new_uninitialized()),
         slices.replace(SourceSliceList::new()),
     )
     .expect("Should work!");
-    evaluate(&emit_result, create_global())
+    evaluate(&result, create_global())
 }
 
 #[test]


### PR DESCRIPTION
 * moved `EmitResult` fields specific to a script into `ScriptStencil`
 * added `EmitResult.scripts` that's an array of `ScriptStencil`, the first one is global, and others are inner functions
