### PR TITLE
`make check -k` dynamic test should run after mypy failure.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,9 @@ rust: $(RS_AST_OUT) $(RS_TABLES_OUT)
 jsparagus/parse_pgen_generated.py:
 	$(PYTHON) -m jsparagus.parse_pgen --regenerate > $@
 
-check: all static-check
+check: all static-check dyn-check
+
+dyn-check:
 	./test.sh
 	cargo fmt
 	cargo test --all
@@ -93,4 +95,4 @@ update-opcodes-m-u:
 	$(PYTHON) crates/emitter/scripts/update_opcodes.py \
 		../mozilla-unified ./
 
-.PHONY: all check static-check jsdemo rust update-opcodes-m-u
+.PHONY: all check static-check dyn-check jsdemo rust update-opcodes-m-u


### PR DESCRIPTION
Without this tiny patch, any mypy failure will prevent all other tests from running.

