### PR TITLE
Ignore python parser generated at the top-level for debugging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 target/
 jsparagus_build_venv/
 example_pgen.rs
+parse_with_python.py
 js_parser/parser_tables.py
 jsparagus/emit/collect_handler_info/info.json
 jsparagus/emit/collect_handler_info/target


### PR DESCRIPTION
This file is produced while debugging the generated parser, as it is useful to browse the generated content. It is used for either parsing ESGrammar files, or the tests cases.

Let's ignore it.