### PR TITLE
Factor APS out of gen.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ jsparagus/grammar.py \
 jsparagus/extension.py \
 jsparagus/utils.py \
 jsparagus/actions.py \
+jsparagus/aps.py \
 jsparagus/types.py \
 js_parser/esgrammar.pgen \
 js_parser/generate_js_parser_tables.py \

--- a/jsparagus/aps.py
+++ b/jsparagus/aps.py
@@ -1,0 +1,199 @@
+import collections
+import typing
+from dataclasses import dataclass
+from .grammar import Nt
+from .actions import Action
+
+@dataclass(frozen=True)
+class Edge:
+    """An edge in a Parse table is a tuple of a source state and the term followed
+    to exit this state. The destination is not saved here as it can easily be
+    inferred by looking it up in the parse table.
+
+    Note, the term might be `None` if no term is specified yet. This is useful
+    when manipulating a list of edges and we know that we are taking transitions
+    from a given state, but not yet with which term.
+
+      src: Index of the state from which this directed edge is coming from.
+
+      term: Edge transition value, this can be a terminal, non-terminal or an
+          action to be executed on an epsilon transition.
+    """
+    src: int
+    term: typing.Union[str, Nt, Action]
+
+    def __str__(self):
+        return "{} -- {} -->".format(edge.src, str(edge.term))
+
+
+@dataclass(frozen=True)
+class APS:
+    # To fix inconsistencies of the grammar, we have to traverse the grammar
+    # both forward by using the lookahead and backward by using the state
+    # recovered from following reduce actions.
+    #
+    # To do so we define the notion of abstract parser state (APS), which is a
+    # class which represents the known state of the parser, relative to its
+    # starting point.
+    #
+    # An APS does not exclusively start at the parser entry point, but starts
+    # from any state of the parse table by calling `APS.start`. Then we walk
+    # the parse table forward, as-if we were shifting tokens or epsilon edges
+    # in the parse table. The function `aps.shift_next(parse_table)` will
+    # explore all possible futures reachable from the starting point.
+    #
+    # As the parse table is explored, new APS are produced by
+    # `aps.shift_next(parse_table)`, which are containing the new state of the
+    # parser and the history which has been seen by the APS since it started.
+    slots = ['stack', 'shift', 'lookahead', 'replay', 'history']
+
+    # This is the known stack at the location where we started investigating.
+    # As more history is discovered by resolving reduce actions, this stack
+    # would be filled with the predecessors which have been visited before
+    # reaching the starting state.
+    stack: typing.List[Edge]
+
+    # This is the stack as manipulated by an LR parser. States are shifted to
+    # it, including actions, and popped from it when visiting a reduce action.
+    shift: typing.List[Edge]
+
+    # This is the list of terminals and non-terminals encountered by shifting
+    # edges which are not replying tokens.
+    lookahead: typing.List[typing.Union[str, Nt]]
+
+    # This is the list of lookahead terminals and non-terminals which remains
+    # to be shifted. This list corresponds to terminals and non-terminals which
+    # were necessary for removing inconsistencies, but have to be replayed
+    # after shifting the reduced non-terminals.
+    replay: typing.List[typing.Union[str, Nt]]
+
+    # This is the list of edges visited since the starting state.
+    history: typing.List[Edge]
+
+    @staticmethod
+    def start(state):
+        "Return an Abstract Parser State starting at a given state of a parse table"
+        edge = Edge(state, None)
+        return APS([edge], [edge], [], [], [])
+
+    def shift_next(self, pt):
+        """Yield an APS for each state reachable from this APS in a single step,
+        by handling a single term (terminal, nonterminal, or action).
+
+        All yielded APS are representing context information around the same
+        starting state as `self`, either by having additional lookahead terms,
+        or a larger stack representing the path taken to reach the starting
+        state.
+
+        For each outgoing edge, it builds a new APS which represents the state
+        of the Parser if we were to have taken this edge. Only valid APS are
+        yielded given the context provided by `self`.
+
+        For example, we cannot reduce to a path which is different than what is
+        already present in the `shift` list, or shift a term different than the
+        next term to be shifted from the `replay` list.
+
+        """
+
+        st, sh, la, rp, hs = self.stack, self.shift, self.lookahead, self.replay, self.history
+        last_edge = sh[-1]
+        state = pt.states[last_edge.src]
+        if self.replay == []:
+            for term, to in state.shifted_edges():
+                edge = Edge(last_edge.src, term)
+                new_sh = self.shift[:-1] + [edge]
+                to = Edge(to, None)
+                yield APS(st, new_sh + [to], la + [term], rp, hs + [edge])
+        else:
+            term = self.replay[0]
+            rp = self.replay[1:]
+            if term in state:
+                edge = Edge(last_edge.src, term)
+                new_sh = self.shift[:-1] + [edge]
+                to = state[term]
+                to = Edge(to, None)
+                yield APS(st, new_sh + [to], la, rp, hs + [edge])
+
+        term = None
+        rp = self.replay
+        for a, to in state.epsilon:
+            edge = Edge(last_edge.src, a)
+            prev_sh = self.shift[:-1] + [edge]
+            # TODO: Add support for Lookahead and flag manipulation rules, as
+            # both of these would invalide potential reduce paths.
+            if a.update_stack():
+                reducer = a.reduce_with()
+                for path, reduced_path in pt.reduce_path(prev_sh):
+                    # reduce_paths contains the chains of state shifted,
+                    # including epsilon transitions, in order to reduce the
+                    # nonterminal. When reducing, the stack is resetted to
+                    # head, and the nonterminal `term.nt` is pushed, to resume
+                    # in the state `to`.
+
+                    # print("Compare shifted path, with reduced path:\n\tshifted = {}\n\treduced = {}, \n\taction = {},\n\tnew_path = {}\n".format(
+                    #     " ".join(edge_str(e) for e in prev_sh),
+                    #     " ".join(edge_str(e) for e in path),
+                    #     str(a),
+                    #     " ".join(edge_str(e) for e in reduced_path),
+                    # ))
+                    if prev_sh[-len(path):] != path[-len(prev_sh):]:
+                        # If the reduced production does not match the shifted
+                        # state, then this reduction does not apply. This is
+                        # the equivalent result as splitting the parse table
+                        # based on the predecessor.
+                        continue
+
+                    # The stack corresponds to the stack present at the
+                    # starting point. The shift list correspond to the actual
+                    # parser stack as we iterate through the state machine.
+                    # Each time we consume all the shift list, this implies
+                    # that we had extra stack elements which were not present
+                    # initially, and therefore we are learning about the
+                    # context.
+                    new_st = path[:max(len(path) - len(prev_sh), 0)] + st
+                    assert pt.is_valid_path(new_st)
+
+                    # The shift list corresponds to the stack which is used in
+                    # an LR parser, in addition to all the states which are
+                    # epsilon transitions. We pop from this list the reduced
+                    # path, as long as it matches. Then all popped elements are
+                    # replaced by the state that we visit after replaying the
+                    # non-terminal reduced by this action.
+                    new_sh = prev_sh[:-len(path)] + reduced_path
+                    assert pt.is_valid_path(new_sh)
+
+                    # When reducing, we replay terms which got previously
+                    # pushed on the stack as our lookahead. These terms are
+                    # computed here such that we can traverse the graph from
+                    # `to` state, using the replayed terms.
+                    new_replay = []
+                    if reducer.replay > 0:
+                        new_replay = [ edge.term for edge in path if pt.term_is_stacked(edge.term) ]
+                        new_replay = new_replay[-reducer.replay:]
+                    new_replay = new_replay + rp
+                    new_la = la[:max(len(la) - reducer.replay, 0)]
+                    yield APS(new_st, new_sh, new_la, new_replay, hs + [edge])
+            else:
+                to = Edge(to, None)
+                yield APS(st, prev_sh + [to], la, rp, hs + [edge])
+
+    def string(self, name = "aps"):
+        return """{}.stack = [{}]
+{}.shift = [{}]
+{}.lookahead = [{}]
+{}.replay = [{}]
+{}.history = [{}]
+        """.format(
+            name, " ".join(str(e) for e in self.stack),
+            name, " ".join(str(e) for e in self.shift),
+            name, ", ".join(repr(e) for e in self.lookahead),
+            name, ", ".join(repr(e) for e in self.replay),
+            name, " ".join(str(e) for e in self.history)
+        )
+
+    def __str__(self):
+        return self.string()
+
+def aps_lanes_str(aps_lanes, header = "lanes:", name = "\taps"):
+    return "{}\n{}".format(header, "\n".join(aps.string(name) for aps in aps_lanes))
+

--- a/jsparagus/gen.py
+++ b/jsparagus/gen.py
@@ -50,6 +50,7 @@ from . import emit
 from .runtime import ACCEPT, ErrorToken
 from .utils import keep_until
 from . import types
+from .aps import Edge, APS
 
 
 # *** Operations on grammars **************************************************
@@ -1616,31 +1617,6 @@ class CanonicalGrammar:
         self.prods_with_indexes_by_nt = prods_with_indexes_by_nt
         self.grammar = grammar
 
-
-@dataclass(frozen=True)
-class Edge:
-    """An edge in a Parse table is a tuple of a source state and the term followed
-    to exit this state. The destination is not saved here as it can easily be
-    inferred by looking it up in the parse table.
-
-    Note, the term might be `None` if no term is specified yet. This is useful
-    when manipulating a list of edges and we know that we are taking transitions
-    from a given state, but not yet with which term.
-
-      src: Index of the state from which this directed edge is coming from.
-
-      term: Edge transition value, this can be a terminal, non-terminal or an
-          action to be executed on an epsilon transition.
-    """
-    src: int
-    term: typing.Union[str, Nt, Action]
-
-
-def edge_str(edge):
-    assert isinstance(edge, Edge)
-    return "{} -- {} -->".format(edge.src, str(edge.term))
-
-
 # Structure used to report conflict while creating or merging states.
 class Conflict(Exception):
     pass
@@ -2043,79 +2019,6 @@ class LR0Generator:
                     followed_by=tuple(),
                 ), followed_by)
 
-
-@dataclass(frozen=True)
-class APS:
-    """Abstract parser state.
-
-    To fix inconsistencies of the grammar, we have to traverse the grammar both
-    forward by using the lookahead and backward by using the parser's emulated
-    stack recovered from reduce actions.
-
-    To do so we define the notion of abstract parser state (APS), which is a
-    tuple which represent the known state of the parser, as:
-      (stack, shift, lookahead, actions)
-
-      stack: This is the stack at the location where we started investigating.
-             Which means that the last element of the stack would be the location
-             where we started.
-
-      shift: This is the stack computed after the traversal of edges. It is
-             reduced each time a reduce action is encountered, and the rest of
-             the production content is added back to the stack, as newly acquired
-             context. The last element is the last state reached through the
-             sequence of lookahead and actions.
-
-      lookahead: This is the list of terminals encountered while pushing edges
-             through the list of terminals.
-
-      actions: This is the list of actions that would be executed as we push
-             edges. Maybe we should rename this history. This is a list of edges
-             taken, which helps tracking which state got visited since we
-             started.
-
-      replay: This is the list of lookahead terminals and non-terminals which
-             remains to be executed. This represents the fact that reduce actions
-             are popping elements which are below the top of the stack, and add
-             them back to the stack.
-    """
-    stack: typing.List[Edge]
-    shift: typing.List[Edge]
-    lookahead: typing.List[str]
-    actions: typing.List[Edge]
-    replay: typing.List[typing.Union[str, Nt]]
-
-
-def aps_str(aps, name="aps"):
-    return """{}.stack = [{}]
-{}.shift = [{}]
-{}.lookahead = [{}]
-{}.actions = [{}]
-{}.replay = [{}]
-    """.format(
-        name, " ".join(edge_str(e) for e in aps.stack),
-        name, " ".join(edge_str(e) for e in aps.shift),
-        name, ", ".join(repr(e) for e in aps.lookahead),
-        name, " ".join(edge_str(e) for e in aps.actions),
-        name, ", ".join(repr(e) for e in aps.replay)
-    )
-
-
-def aps_lanes_str(aps_lanes, header="lanes:", name="\taps"):
-    return "{}\n{}".format(header, "\n".join(aps_str(aps, name) for aps in aps_lanes))
-
-
-def is_valid_aps(aps):
-    "Returns whether an APS contains the right content."
-    check = True
-    check &= all(isinstance(st, Edge) for st in aps.stack)
-    check &= all(isinstance(sh, Edge) for sh in aps.shift)
-    check &= all(not isinstance(la, Action) for la in aps.lookahead)
-    check &= all(isinstance(ac, Edge) for ac in aps.actions)
-    check &= all(not isinstance(rp, Action) for rp in aps.replay)
-    return check
-
-
 class ParseTable:
     """The parser can be represented as a matrix of state transitions where on one
     side we have the current state, and on the other we have the expected
@@ -2481,12 +2384,7 @@ class ParseTable:
     def term_is_stacked(self, term):
         return not isinstance(term, Action)
 
-    def aps_start(self, state, replay=[]):
-        "Return a parser state only knowing the state at which we are currently."
-        edge = Edge(state, None)
-        return APS([edge], [edge], [], [], replay)
-
-    def aps_next(self, aps):
+    def aps_visitor(self, aps, visit):
         """Visit all the states of the parse table, as-if we were running a
         Generalized LR parser.
 
@@ -2494,110 +2392,17 @@ class ParseTable:
         both the content which remains to be parsed as well as the context
         which might lead us to be in the state which from which we started.
 
-        This algorithm takes an APS (Abstract Parser State), and consider all
-        edges of the parse table, unless restricted by one of the previously
-        encountered actions. These restrictions, such as replayed lookahead or
-        the path which might be reduced are used for filtering out states which
-        are not handled by this parse table.
+        This algorithm takes an APS (Abstract Parser State) and a callback, and
+        consider all edges of the parse table, unless restricted by one of the
+        previously encountered actions. These restrictions, such as replayed
+        lookahead or the path which might be reduced are used for filtering out
+        states which are not handled by this parse table.
 
-        For each edge, this functions recursively calls it-self and calls the
-        visit functions to know whether to stop or continue, and to capture the
-        result.
+        For each edge, this functions calls the visit functions to know whether
+        to stop or continue. The visit function might capture APS given as
+        argument to be used for other analysis.
 
         """
-        assert is_valid_aps(aps)
-        st = aps.stack
-        sh = aps.shift
-        la = aps.lookahead
-        ac = aps.actions
-        rp = aps.replay
-
-        last_edge = sh[-1]
-        state = self.states[last_edge.src]
-        if aps.replay == []:
-            for term, to in state.shifted_edges():
-                edge = Edge(last_edge.src, term)
-                new_sh = aps.shift[:-1] + [edge]
-                to = Edge(to, None)
-                yield APS(st, new_sh + [to], la + [term], ac + [edge], rp)
-        else:
-            term = aps.replay[0]
-            rp = aps.replay[1:]
-            if term in state:
-                edge = Edge(last_edge.src, term)
-                new_sh = aps.shift[:-1] + [edge]
-                to = state[term]
-                to = Edge(to, None)
-                yield APS(st, new_sh + [to], la, ac + [edge], rp)
-
-        term = None
-        rp = aps.replay
-        for a, to in state.epsilon:
-            edge = Edge(last_edge.src, a)
-            prev_sh = aps.shift[:-1] + [edge]
-            # TODO: Add support for Lookahead and flag manipulation rules, as
-            # both of these would invalide potential reduce paths.
-            if a.update_stack():
-                reducer = a.reduce_with()
-                for path, reduced_path in self.reduce_path(prev_sh):
-                    # reduce_paths contains the chains of state shifted,
-                    # including epsilon transitions, in order to reduce the
-                    # nonterminal. When reducing, the stack is resetted to
-                    # head, and the nonterminal `term.nt` is pushed, to resume
-                    # in the state `to`.
-
-                    # print(
-                    #    "Compare shifted path, with reduced path:\n"
-                    #    "\tshifted = {}\n\treduced = {},\n\taction = {},\n\tnew_path = {}\n"
-                    #    .format(
-                    #         " ".join(edge_str(e) for e in prev_sh),
-                    #         " ".join(edge_str(e) for e in path),
-                    #         str(a),
-                    #         " ".join(edge_str(e) for e in reduced_path),
-                    #     )
-                    # )
-                    if prev_sh[-len(path):] != path[-len(prev_sh):]:
-                        # If the reduced production does not match the shifted
-                        # state, then this reduction does not apply. This is
-                        # the equivalent result as splitting the parse table
-                        # based on the predecessor.
-                        continue
-
-                    # The stack corresponds to the stack present at the
-                    # starting point. The shift list correspond to the actual
-                    # parser stack as we iterate through the state machine.
-                    # Each time we consume all the shift list, this implies
-                    # that we had extra stack elements which were not present
-                    # initially, and therefore we are learning about the
-                    # context.
-                    new_st = path[:max(len(path) - len(prev_sh), 0)] + st
-                    assert self.is_valid_path(new_st)
-
-                    # The shift list corresponds to the stack which is used in
-                    # an LR parser, in addition to all the states which are
-                    # epsilon transitions. We pop from this list the reduced
-                    # path, as long as it matches. Then all popped elements are
-                    # replaced by the state that we visit after replaying the
-                    # non-terminal reduced by this action.
-                    new_sh = prev_sh[:-len(path)] + reduced_path
-                    assert self.is_valid_path(new_sh)
-
-                    # When reducing, we replay terms which got previously
-                    # pushed on the stack as our lookahead. These terms are
-                    # computed here such that we can traverse the graph from
-                    # `to` state, using the replayed terms.
-                    new_replay = []
-                    if reducer.replay > 0:
-                        new_replay = [edge.term for edge in path if self.term_is_stacked(edge.term)]
-                        new_replay = new_replay[-reducer.replay:]
-                    new_replay = new_replay + rp
-                    new_la = la[:max(len(la) - reducer.replay, 0)]
-                    yield APS(new_st, new_sh, new_la, ac + [edge], new_replay)
-            else:
-                to = Edge(to, None)
-                yield APS(st, prev_sh + [to], la, ac + [edge], rp)
-
-    def aps_visitor(self, aps, visit):
         todo = []
         todo.append(aps)
         while todo:
@@ -2605,7 +2410,7 @@ class ParseTable:
             cont = visit(aps)
             if not cont:
                 continue
-            todo.extend(self.aps_next(aps))
+            todo.extend(aps.shift_next(self))
 
     def lanes(self, state):
         """Compute the lanes from the amount of lookahead available. Only consider
@@ -2626,7 +2431,7 @@ class ParseTable:
                 print(aps_str(aps, "\trecord"))
                 record.append(aps)
             return not stop
-        self.aps_visitor(self.aps_start(state), visit)
+        self.aps_visitor(APS.start(state), visit)
         return record
 
     def context_lanes(self, state):
@@ -2646,7 +2451,7 @@ class ParseTable:
         assert isinstance(state, int)
 
         def not_interesting(aps):
-            reduce_list = [e for e in aps.actions if self.is_term_shifted(e.term)]
+            reduce_list = [e for e in aps.history if self.is_term_shifted(e.term)]
             has_reduce_loop = len(reduce_list) != len(set(reduce_list))
             return has_reduce_loop
 
@@ -2657,7 +2462,7 @@ class ParseTable:
 
         def has_enough_context(aps):
             try:
-                assert aps.actions[0] in context[tuple(aps.stack)]
+                assert aps.history[0] in context[tuple(aps.stack)]
                 # Check the number of different actions which can reach this
                 # location. If there is more than 1, then we do not have enough
                 # context.
@@ -2665,7 +2470,7 @@ class ParseTable:
             except IndexError:
                 return False
 
-        collect = [self.aps_start(state)]
+        collect = [APS.start(state)]
         enough_context = False
         while not enough_context:
             # print("collect.len = {}".format(len(collect)))
@@ -2676,10 +2481,10 @@ class ParseTable:
             while collect:
                 aps = collect.pop()
                 recurse.append(aps)
-                if aps.actions == []:
+                if aps.history == []:
                     continue
                 for i in range(len(aps.stack)):
-                    context[tuple(aps.stack[i:])].append(aps.actions[0])
+                    context[tuple(aps.stack[i:])].append(aps.history[0])
             assert collect == []
 
             # print("recurse.len = {}".format(len(recurse)))
@@ -2705,7 +2510,7 @@ class ParseTable:
                     return True, []
                 enough_context = False
                 # print("extend starting at:\n{}".format(aps_str(aps, "\tcontext")))
-                collect.extend(self.aps_next(aps))
+                collect.extend(aps.shift_next(self))
             assert recurse == []
 
         # print("context_lanes:")
@@ -2713,22 +2518,6 @@ class ParseTable:
         #     print(aps_str(aps, "\tcontext"))
 
         return False, collect
-
-        # def visit(aps):
-        #     reduce_list = [e for e in aps.actions if self.is_term_shifted(e.term)]
-        #     has_reduce_loop = len(reduce_list) != len(set(reduce_list))
-        #     has_lookahead = len(aps.lookahead) >= 1
-        #     stop = has_shift_loop or has_stack_loop or has_lookahead
-        #     # print("\t{} = {} or {} or {}".format(
-        #     #     stop, has_shift_loop, has_stack_loop, has_lookahead))
-        #     # print(aps_str(aps, "\tvisitor"))
-        #     if stop:
-        #         print("lanes_visit stop:")
-        #         print(aps_str(aps, "\trecord"))
-        #         record.append(aps)
-        #     return not stop
-        # self.aps_visitor(self.aps_start(state), visit)
-        # return record
 
     def lookahead_lanes(self, state):
         """Compute lanes to collect all lookahead symbols available. After each reduce
@@ -2748,9 +2537,9 @@ class ParseTable:
         def visit(aps):
             # Note, this suppose that we are not considering flags when
             # computing, as flag might prevent some lookahead investigations.
-            first_reduce = next((e for e in aps.actions[:-1] if not self.is_term_shifted(e.term)), None)
+            first_reduce = next((e for e in aps.history[:-1] if not self.is_term_shifted(e.term)), None)
             if first_reduce:
-                reduce_key = (first_reduce, aps.shift[0].src, aps.actions[-1].term)
+                reduce_key = (first_reduce, aps.shift[0].src, aps.history[-1].term)
             has_seen_edge_after_reduce = first_reduce and reduce_key in seen_edge_after_reduce
             has_lookahead = len(aps.lookahead) >= 1
             stop = has_seen_edge_after_reduce or has_lookahead
@@ -2761,7 +2550,7 @@ class ParseTable:
             if first_reduce:
                 seen_edge_after_reduce.add(reduce_key)
             return not stop
-        self.aps_visitor(self.aps_start(state), visit)
+        self.aps_visitor(APS.start(state), visit)
         return record
 
     def fix_with_context(self, s, aps_lanes):
@@ -2984,7 +2773,7 @@ class ParseTable:
         # would have to be executed.
         shift_map = collections.defaultdict(lambda: [])
         for aps in aps_lanes:
-            actions = aps.actions
+            actions = aps.history
             assert isinstance(actions[-1], Edge)
             assert actions[-1].term == aps.lookahead[0]
             src = actions[-1].src
@@ -3291,9 +3080,9 @@ class ParseTable:
 
         def visit(aps):
             # Stop after reducing once.
-            if aps.actions == []:
+            if aps.history == []:
                 return True
-            last = aps.actions[-1].term
+            last = aps.history[-1].term
             is_reduce = not self.is_term_shifted(last)
             has_shift_loop = len(aps.shift) != 1 + len(set(zip(aps.shift, aps.shift[1:])))
             can_reduce_later = True
@@ -3305,20 +3094,20 @@ class ParseTable:
             # Record state which are reducing at most all the shifted states.
             save = stop and len(aps.shift) == 2
             save = save and isinstance(aps.shift[0].term, Nt)
-            save = save and not self.is_term_shifted(aps.actions[-1].term)
+            save = save and not self.is_term_shifted(aps.history[-1].term)
             if save:
                 record.append(aps)
             return not stop
-        self.aps_visitor(self.aps_start(state), visit)
+        self.aps_visitor(APS.start(state), visit)
 
         context = OrderedSet()
         for aps in record:
-            assert aps.actions != []
-            assert aps.actions[-1].term.update_stack()
-            reducer = aps.actions[-1].term.reduce_with()
+            assert aps.history != []
+            assert aps.history[-1].term.update_stack()
+            reducer = aps.history[-1].term.reduce_with()
             replay = reducer.replay
             before = [repr(e.term) for e in aps.stack[:-1]]
-            after = [repr(e.term) for e in aps.actions[:-1]]
+            after = [repr(e.term) for e in aps.history[:-1]]
             prod = before + ["\N{MIDDLE DOT}"] + after
             if replay < len(after) and replay > 0:
                 del prod[-replay:]
@@ -3329,7 +3118,7 @@ class ParseTable:
                 prod = prod[:-replay] + ["[lookahead:"] + prod[-replay:] + ["]"]
             txt = "{}{} ::= {}".format(
                 prefix,
-                repr(aps.actions[-1].term.reduce_with().nt),
+                repr(aps.history[-1].term.reduce_with().nt),
                 " ".join(prod)
             )
             context.add(txt)


### PR DESCRIPTION
This is commit is extracted from #429 and is used in #430 work.
This extract the APS and Edge classes from the ParseTable and move it to its own file.