### PR TITLE
Parse Table: Add stable state numbering.

### DIFF
--- a/jsparagus/actions.py
+++ b/jsparagus/actions.py
@@ -100,6 +100,12 @@ class Action:
     def __repr__(self):
         return str(self)
 
+    def __str__(self):
+        return repr(self)
+
+    def stable_str(self, state_hash):
+        return str(self)
+
 
 class Reduce(Action):
     """Define a reduce operation which pops N elements of he stack and pushes one

--- a/jsparagus/actions.py
+++ b/jsparagus/actions.py
@@ -100,10 +100,7 @@ class Action:
     def __repr__(self):
         return str(self)
 
-    def __str__(self):
-        return repr(self)
-
-    def stable_str(self, state_hash):
+    def stable_str(self, states):
         return str(self)
 
 

--- a/jsparagus/aps.py
+++ b/jsparagus/aps.py
@@ -22,6 +22,9 @@ class Edge:
     src: int
     term: typing.Union[str, Nt, Action]
 
+    def stable_str(self, state_hash):
+        return "{} -- {} -->".format(state_hash[edge.src], str(edge.term))
+
     def __str__(self):
         return "{} -- {} -->".format(edge.src, str(edge.term))
 
@@ -177,6 +180,20 @@ class APS:
                 to = Edge(to, None)
                 yield APS(st, prev_sh + [to], la, rp, hs + [edge])
 
+    def stable_str(self, state_hash, name = "aps"):
+        return """{}.stack = [{}]
+{}.shift = [{}]
+{}.lookahead = [{}]
+{}.replay = [{}]
+{}.history = [{}]
+        """.format(
+            name, " ".join(e.stable_str(state_hash) for e in self.stack),
+            name, " ".join(e.stable_str(state_hash) for e in self.shift),
+            name, ", ".join(repr(e) for e in self.lookahead),
+            name, ", ".join(repr(e) for e in self.replay),
+            name, " ".join(e.stable_str(state_hash) for e in self.history)
+        )
+
     def string(self, name = "aps"):
         return """{}.stack = [{}]
 {}.shift = [{}]
@@ -196,4 +213,7 @@ class APS:
 
 def aps_lanes_str(aps_lanes, header = "lanes:", name = "\taps"):
     return "{}\n{}".format(header, "\n".join(aps.string(name) for aps in aps_lanes))
+
+def stable_aps_lanes_str(aps_lanes, state_hash, header = "lanes:", name = "\taps"):
+    return "{}\n{}".format(header, "\n".join(aps.stable_str(state_hash, name) for aps in aps_lanes))
 

--- a/jsparagus/aps.py
+++ b/jsparagus/aps.py
@@ -22,11 +22,11 @@ class Edge:
     src: int
     term: typing.Union[str, Nt, Action]
 
-    def stable_str(self, state_hash):
-        return "{} -- {} -->".format(state_hash[edge.src], str(edge.term))
+    def stable_str(self, states):
+        return "{} -- {} -->".format(states[self.src].stable_hash, str(self.term))
 
     def __str__(self):
-        return "{} -- {} -->".format(edge.src, str(edge.term))
+        return "{} -- {} -->".format(self.src, str(self.term))
 
 
 @dataclass(frozen=True)
@@ -180,18 +180,18 @@ class APS:
                 to = Edge(to, None)
                 yield APS(st, prev_sh + [to], la, rp, hs + [edge])
 
-    def stable_str(self, state_hash, name = "aps"):
+    def stable_str(self, states, name = "aps"):
         return """{}.stack = [{}]
 {}.shift = [{}]
 {}.lookahead = [{}]
 {}.replay = [{}]
 {}.history = [{}]
         """.format(
-            name, " ".join(e.stable_str(state_hash) for e in self.stack),
-            name, " ".join(e.stable_str(state_hash) for e in self.shift),
+            name, " ".join(e.stable_str(states) for e in self.stack),
+            name, " ".join(e.stable_str(states) for e in self.shift),
             name, ", ".join(repr(e) for e in self.lookahead),
             name, ", ".join(repr(e) for e in self.replay),
-            name, " ".join(e.stable_str(state_hash) for e in self.history)
+            name, " ".join(e.stable_str(states) for e in self.history)
         )
 
     def string(self, name = "aps"):
@@ -214,6 +214,6 @@ class APS:
 def aps_lanes_str(aps_lanes, header = "lanes:", name = "\taps"):
     return "{}\n{}".format(header, "\n".join(aps.string(name) for aps in aps_lanes))
 
-def stable_aps_lanes_str(aps_lanes, state_hash, header = "lanes:", name = "\taps"):
-    return "{}\n{}".format(header, "\n".join(aps.stable_str(state_hash, name) for aps in aps_lanes))
+def stable_aps_lanes_str(aps_lanes, states, header = "lanes:", name = "\taps"):
+    return "{}\n{}".format(header, "\n".join(aps.stable_str(states, name) for aps in aps_lanes))
 

--- a/jsparagus/gen.py
+++ b/jsparagus/gen.py
@@ -1475,6 +1475,16 @@ class ParseTable:
                 return True
         return False
 
+    def debug_dump(self):
+        # Sort the grammar by state hash, such that it can be compared
+        # before/after grammar modifications.
+        temp = sorted(enumerate(self.state_hash), key=lambda x: x[1])
+        for i, _ in temp:
+            s = self.states[i]
+            if s is None:
+                continue
+            print(s.stable_str(self.state_hash))
+
     def get_flag_for(self, nts):
         nts = OrderedFrozenSet(nts)
         self.flags.add(nts)
@@ -1521,6 +1531,10 @@ class ParseTable:
                     # Add the edge from s to sk with k.
                     self.add_edge(s, k, sk.index)
         consume(visit_grammar(), progress)
+
+        if verbose:
+            print("Create LR(0) Table Result:")
+            self.debug_dump()
 
     def is_term_shifted(self, term):
         return not (isinstance(term, Action) and term.update_stack())
@@ -2233,6 +2247,10 @@ class ParseTable:
                 "\tNumber of inconsistencies solved = {}"]).format(
                     len(self.states), count))
         assert not self.is_inconsistent()
+
+        if verbose:
+            print("Fix Inconsistent Table Result:")
+            self.debug_dump()
 
     def remove_all_unreachable_state(self, verbose, progress):
         self.states = [s for s in self.states if s is not None]


### PR DESCRIPTION
When doing grammar changes or parser passes, the state might be renumbered.
While this is a useful thing for optimization, this makes thing terribly hard
for debugging.

This change introduces a stable_hash, which relies on the stringification of
productions and actions.

NOTE, this is a work in progress because I have not tested the correctness of the hash (for example whether we get a different state number for the reduce action) and have not checked whether we have collision or not while shrinking the hash number.
