### PR TITLE
Fix ignored lookahead in inconsistent parse tables

### DIFF
--- a/jsparagus/gen.py
+++ b/jsparagus/gen.py
@@ -2421,7 +2421,7 @@ def generate_parser(out, source, *, verbose=False, progress=False, debug=False,
 def compile(grammar, verbose=False):
     assert isinstance(grammar, Grammar)
     out = io.StringIO()
-    generate_parser(out, grammar)
+    generate_parser(out, grammar, verbose=verbose)
     scope = {}
     if verbose:
         with open("parse_with_python.py", "w") as f:

--- a/tests/test.py
+++ b/tests/test.py
@@ -1194,16 +1194,10 @@ LazyArrowFunction :
         def try_it(goals):
             self.compile_as_js(grammar_source, goals=goals)
             self.assertParse("? ? ^ =>", goal='Script')
-            try:
-                self.assertParse("? ? ^ of", goal='Script')
-            except jsparagus.lexer.SyntaxError:
-                return 'fail'
-            else:
-                return 'pass'
+            self.assertParse("? ? ^ of", goal='Script')
 
-        # Assert the bad status quo. This is issue #464.
-        self.assertEqual(try_it(['Script', 'LazyArrowFunction']), 'fail')
-        self.assertEqual(try_it(['Script']), 'pass')
+        try_it(['Script', 'LazyArrowFunction'])
+        try_it(['Script'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -1127,7 +1127,8 @@ class GenTestCase(unittest.TestCase):
     def compile_as_js(
             self,
             grammar_source: str,
-            goals: typing.Optional[typing.Iterable[str]] = None
+            goals: typing.Optional[typing.Iterable[str]] = None,
+            verbose: bool = False,
     ) -> None:
         """Like self.compile(), but generate a parser from ESGrammar,
         with ASI support, using the JS lexer.
@@ -1144,7 +1145,7 @@ class GenTestCase(unittest.TestCase):
             synthetic_terminals=load_es_grammar.ECMASCRIPT_SYNTHETIC_TERMINALS,
             terminal_names=load_es_grammar.TERMINAL_NAMES_FOR_SYNTACTIC_GRAMMAR)
         grammar = generate_js_parser_tables.hack_grammar(grammar)
-        base_parser_class = gen.compile(grammar)
+        base_parser_class = gen.compile(grammar, verbose=verbose)
 
         # "type: ignore" because poor mypy can't cope with the runtime codegen
         # we're doing here.


### PR DESCRIPTION
This issue fixes the #464 , by changing the way we handle reduce actions.
Instead of handling reduce actions by always reducing the non-terminal which is being reduced, we let the APS discover which state allow the non-terminal to be replayed, even after a Lookahead action.

This work is based on top of #465 and extracted from [the branch](https://github.com/nbp/jsparagus/tree/filter-states-and-replay-actions) which aim to solve #430 by adding Replay action.

However, to handle this case, we had to remove the guarantee that `reduce_path` should always reduce to a state capable of shifting the reduced non-terminals, as long as the grammar is inconsistent. Thus, a new flag is added to the parse table to quickly check whether we expect to be working with an inconsistent parse table or not, in order to keep this assertion for any transformation happening after `fix_inconsistent_table`.
