### PR TITLE
Fix parser benchmark

### DIFF
--- a/crates/parser/benches/parser.rs
+++ b/crates/parser/benches/parser.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use bumpalo::Bump;
 use jsparagus_ast::source_atom_set::SourceAtomSet;
 use jsparagus_parser::{parse_script, ParseOptions};
+use jsparagus_ast::source_slice_list::SourceSliceList;
 
 fn parser_bench(c: &mut Criterion) {
     let tests = &["simple", "__finStreamer-proto"];
@@ -27,7 +28,8 @@ fn parser_bench(c: &mut Criterion) {
                 let allocator = &Bump::new();
                 let options = ParseOptions::new();
                 let atoms = Rc::new(RefCell::new(SourceAtomSet::new()));
-                let _ = parse_script(allocator, program, &options, atoms.clone());
+                let slices = Rc::new(RefCell::new(SourceSliceList::new()));
+                let _ = parse_script(allocator, program, &options, atoms, slices);
             });
         },
         tests,


### PR DESCRIPTION
Fixes the `cargo bench` command on the parser.