### PR TITLE
AST Builder: Use alloc_with instead of alloc to avoid extra copies.

### DIFF
--- a/crates/ast/src/arena.rs
+++ b/crates/ast/src/arena.rs
@@ -61,6 +61,13 @@ pub fn alloc<'alloc, T>(allocator: &'alloc Bump, value: T) -> Box<'alloc, T> {
     Box(allocator.alloc(value))
 }
 
+pub fn alloc_with<'alloc, F, T>(allocator: &'alloc Bump, gen: F) -> Box<'alloc, T>
+where
+    F: FnOnce() -> T,
+{
+    Box(allocator.alloc_with(gen))
+}
+
 pub fn alloc_str<'alloc>(allocator: &'alloc Bump, value: &str) -> &'alloc str {
     String::from_str_in(value, allocator).into_bump_str()
 }


### PR DESCRIPTION
Using `alloc_with` will help the compiler by hinting it that there is no need to
copy the value to the stack as argument before storing it on the heap.

See the [documentation of bumpalo::alloc_with](https://docs.rs/bumpalo/3.0.0/bumpalo/struct.Bump.html#method.alloc_with) for more details.

This change is a `1-3 ns/byte` improvement on real-js-samples. (when inlined in the reduce functions)
