### PR TITLE
Fix ScopeData::Alias to hold ScopeIndex (fixes #485)

### DIFF
--- a/crates/scope/src/builder.rs
+++ b/crates/scope/src/builder.rs
@@ -678,7 +678,7 @@ impl FunctionExpressionScopeBuilder {
 
                 ScopeData::Lexical(data)
             }
-            None => ScopeData::AliasPrevious,
+            None => ScopeData::Alias(enclosing),
         }
     }
 }
@@ -709,10 +709,10 @@ struct FunctionScopeDataSet {
     /// ScopeData::Function.
     function: ScopeData,
 
-    /// Either ScopeData::Var or ScopeData::AliasPrevious.
+    /// Either ScopeData::Var or ScopeData::Alias.
     extra_body_var: ScopeData,
 
-    /// Either ScopeData::Lexical or ScopeData::AliasPrevious.
+    /// Either ScopeData::Lexical or ScopeData::Alias.
     lexical: ScopeData,
 }
 
@@ -1148,7 +1148,7 @@ impl FunctionParametersScopeBuilder {
 
             // Step 27.d. Let varEnv be env.
             // Step 27.e. Let varEnvRec be envRec.
-            ScopeData::AliasPrevious
+            ScopeData::Alias(self.scope_index)
         }
         // Step 28. Else,
         else {
@@ -1253,7 +1253,7 @@ impl FunctionParametersScopeBuilder {
 
                 ScopeData::Lexical(data)
             } else {
-                ScopeData::AliasPrevious
+                ScopeData::Alias(body_scope_builder.var_scope_index)
             };
 
         // Step 36. For each Parse Node f in functionsToInitialize, do

--- a/crates/scope/src/data.rs
+++ b/crates/scope/src/data.rs
@@ -360,8 +360,9 @@ impl FunctionScopeData {
 
 #[derive(Debug)]
 pub enum ScopeData {
-    /// No scope should be generated. This is used, for example, when we see a
-    /// function, and set aside a ScopeData for its lexical bindings, but upon
+    /// No scope should be generated, but this scope becomes an alias to
+    /// enclosing scope. This is used, for example, when we see a function,
+    /// and set aside a ScopeData for its lexical bindings, but upon
     /// reaching the end of the function body, we find that there were no
     /// lexical bindings and the spec actually says not to generate a Lexical
     /// Environment when this function is called.
@@ -370,8 +371,8 @@ pub enum ScopeData {
     /// it turns out it doesn't have any bindings in it and we can optimize it
     /// away.
     ///
-    /// FIXME: "previous" doesn't work in some case. embed scope index instead.
-    AliasPrevious,
+    /// NOTE: Alias can be chained.
+    Alias(ScopeIndex),
 
     Global(GlobalScopeData),
     Var(VarScopeData),
@@ -515,7 +516,7 @@ impl ScopeDataMap {
 
     pub fn is_alias(&mut self, index: ScopeIndex) -> bool {
         match self.scopes.get(index) {
-            ScopeData::AliasPrevious => true,
+            ScopeData::Alias(_) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
To support the case that `ScopeIndex` isn't allocated contiguously, changed `AliasPrevious` to `Alias(ScopeIndex)`
this will be necessary when there is another scope inside parameter, and function body tries to refer parameter scope.