### PR TITLE
Pop values pushed by init/update in c-style-for in the caller for consistency with declaration (fixes #493)

### DIFF
--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -179,11 +179,17 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
                             emitter.emit_variable_declaration_statement(ast)
                         }
                         VariableDeclarationOrExpression::Expression(expr) => {
-                            emitter.emit_expression(expr)
+                            emitter.emit_expression(expr)?;
+                            emitter.emit.pop();
+                            Ok(())
                         }
                     },
                     test: |emitter, expr| emitter.emit_expression(expr),
-                    update: |emitter, expr| emitter.emit_expression(expr),
+                    update: |emitter, expr| {
+                        emitter.emit_expression(expr)?;
+                        emitter.emit.pop();
+                        Ok(())
+                    },
                     block: |emitter| emitter.emit_statement(block),
                 }
                 .emit(self)?;

--- a/crates/emitter/src/control_structures.rs
+++ b/crates/emitter/src/control_structures.rs
@@ -522,7 +522,6 @@ where
         // ie) for(foo(); <test>; <update>) or for(var x = 0; <test>; <update)
         if let Some(init) = self.maybe_init {
             (self.init)(emitter, init)?;
-            emitter.emit.pop();
         }
 
         // Emit loop head
@@ -549,7 +548,6 @@ where
 
         if let Some(update) = self.maybe_update {
             (self.update)(emitter, &update)?;
-            emitter.emit.pop();
         }
 
         // Merge point after test fails (or there is a break statement)


### PR DESCRIPTION
`emit_variable_declaration_statement` doesn't push any value, given it's statement.
so `VariableDeclarationOrExpression::Expression` branch should also pop the value pushed by `emit_expression`.

for consistency, changed `update` part also to pop the value.

`test` closure should still leave the value, given the value is used for condition.