### PR TITLE
Disable break/continue until scope handling gets ready

### DIFF
--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -132,6 +132,9 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
                     label: label.as_ref().map(|x| x.value),
                 }
                 .emit(self);
+                return Err(EmitError::NotImplemented(
+                    "TODO: scope handling for BreakStatement",
+                ));
             }
             Statement::ContinueStatement { label, .. } => {
                 ContinueEmitter {
@@ -139,6 +142,9 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
                     label: label.as_ref().map(|x| x.value),
                 }
                 .emit(self);
+                return Err(EmitError::NotImplemented(
+                    "TODO: scope handling for ContinueStatement",
+                ));
             }
             Statement::DebuggerStatement { .. } => {
                 return Err(EmitError::NotImplemented("TODO: DebuggerStatement"));


### PR DESCRIPTION
non-local jumps needs scope handling (https://github.com/mozilla-spidermonkey/jsparagus/issues/495)
so disabling break/continue support until that part gets ready.

now running try with this, to check remaining failure
https://treeherder.mozilla.org/#/jobs?repo=try&tier=1%2C2%2C3&revision=328faf2231440985821bdf8d456e5c74ab732606
