### PR TITLE
Move labels into their own vec; fixes #503

### DIFF
--- a/crates/generated_parser/src/context_stack.rs
+++ b/crates/generated_parser/src/context_stack.rs
@@ -394,6 +394,11 @@ impl ContextMetadata {
         self.breaks_and_continues.get(index.index)
     }
 
+    pub fn find_label_index_at_offset(&self, offset: usize) -> Option<LabelIndex> {
+        let index = self.labels.iter().position(|info| info.offset == offset);
+        index.map(|index| LabelIndex { index })
+    }
+
     pub fn find_label_at_offset(&mut self, offset: usize) -> Option<&mut LabelInfo> {
         self.labels.iter_mut().find(|info| info.offset == offset)
     }

--- a/crates/generated_parser/src/early_errors.rs
+++ b/crates/generated_parser/src/early_errors.rs
@@ -1,4 +1,4 @@
-use crate::context_stack::{ControlInfo, ControlKind};
+use crate::context_stack::{ControlInfo, ControlKind, LabelKind};
 use crate::parser_tables_generated::TerminalId;
 use crate::DeclarationKind;
 use crate::Token;
@@ -905,12 +905,12 @@ impl VarEarlyErrorsContext for LexicalForBodyEarlyErrorsContext {
 
 pub struct LabelledStatementEarlyErrorsContext {
     name: SourceAtomSetIndex,
-    is_loop: bool,
+    kind: LabelKind,
 }
 
 impl LabelledStatementEarlyErrorsContext {
-    pub fn new(name: SourceAtomSetIndex, is_loop: bool) -> Self {
-        Self { name, is_loop }
+    pub fn new(name: SourceAtomSetIndex, kind: LabelKind) -> Self {
+        Self { name, kind }
     }
 
     pub fn check_duplicate_label<'alloc>(
@@ -966,7 +966,10 @@ impl LabelledStatementEarlyErrorsContext {
         //    indirectly (but not crossing function boundaries), within an
         //    IterationStatement.
         if let Some(name) = info.label {
-            if !self.is_loop && info.kind == ControlKind::Continue && name == self.name {
+            if self.kind != LabelKind::Loop
+                && info.kind == ControlKind::Continue
+                && name == self.name
+            {
                 return Err(ParseError::BadContinue.into());
             }
         }


### PR DESCRIPTION
This splits labels out of the bindings vec, and also updates the label checking helper methods to not use the AST. The last commit is not critical, and can be removed (we can continue to rely on the statements). 