### PR TITLE
Box the ParseError to reduce the size of Result type.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ version = "0.1.0"
 dependencies = [
  "bumpalo 2.6.0",
  "jsparagus-ast",
+ "static_assertions",
 ]
 
 [[package]]
@@ -809,6 +810,12 @@ name = "sourcefile"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/crates/generated_parser/Cargo.toml
+++ b/crates/generated_parser/Cargo.toml
@@ -8,3 +8,4 @@ license = "MIT/Apache-2.0"
 [dependencies]
 bumpalo = "2.6.0"
 jsparagus-ast = { path = "../ast" }
+static_assertions = "1.1.0"

--- a/crates/generated_parser/src/error.rs
+++ b/crates/generated_parser/src/error.rs
@@ -152,6 +152,22 @@ impl<'alloc> From<AstError> for ParseError<'alloc> {
     }
 }
 
-impl<'alloc> Error for ParseError<'alloc> {}
+impl<'alloc> From<Infallible> for std::boxed::Box<ParseError<'alloc>> {
+    fn from(err: Infallible) -> std::boxed::Box<ParseError<'alloc>> {
+        match err {}
+    }
+}
 
-pub type Result<'alloc, T> = std::result::Result<T, ParseError<'alloc>>;
+impl<'alloc> From<AstError> for std::boxed::Box<ParseError<'alloc>> {
+    fn from(err: AstError) -> std::boxed::Box<ParseError<'alloc>> {
+        ParseError::AstError(err).into()
+    }
+}
+
+impl<'a, 'alloc: 'a> Error for &'a ParseError<'alloc> {}
+
+// NOTE: This is not the Bump allocator, as error are allocated infrequently and
+// this avoid propagating the bump allocator to all places, while keeping these
+// implementation possible.
+pub type BoxedParseError<'alloc> = std::boxed::Box<ParseError<'alloc>>;
+pub type Result<'alloc, T> = std::result::Result<T, BoxedParseError<'alloc>>;

--- a/crates/generated_parser/src/error.rs
+++ b/crates/generated_parser/src/error.rs
@@ -1,6 +1,7 @@
 use crate::stack_value_generated::AstError;
 use crate::DeclarationKind;
 use crate::Token;
+use static_assertions::assert_eq_size;
 use std::{convert::Infallible, error::Error, fmt};
 
 #[derive(Debug)]
@@ -171,3 +172,6 @@ impl<'a, 'alloc: 'a> Error for &'a ParseError<'alloc> {}
 // implementation possible.
 pub type BoxedParseError<'alloc> = std::boxed::Box<ParseError<'alloc>>;
 pub type Result<'alloc, T> = std::result::Result<T, BoxedParseError<'alloc>>;
+
+assert_eq_size!(BoxedParseError<'static>, usize);
+assert_eq_size!(Result<'static, ()>, usize);

--- a/crates/generated_parser/src/lib.rs
+++ b/crates/generated_parser/src/lib.rs
@@ -11,6 +11,7 @@ mod token;
 pub mod traits;
 
 extern crate jsparagus_ast as ast;
+extern crate static_assertions;
 
 pub use ast_builder::{AstBuilder, AstBuilderDelegate};
 pub use declaration_kind::DeclarationKind;

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -96,7 +96,7 @@ impl<'alloc> ParserTrait<'alloc, StackValue<'alloc>> for Parser<'alloc> {
             self.try_error_handling(tv)?;
             return Ok(false);
         }
-        Err(ParseError::NoLineTerminatorHereExpectedToken)
+        Err(ParseError::NoLineTerminatorHereExpectedToken.into())
     }
 }
 
@@ -185,7 +185,7 @@ impl<'alloc> Parser<'alloc> {
             // might not be in the shifted terms coming after the reduced
             // nonterminal.
             if t.term == Term::Terminal(TerminalId::ErrorToken) {
-                return Err(Self::parse_error(token));
+                return Err(Self::parse_error(token).into());
             }
 
             // Otherwise, check if the current rule accept an Automatic
@@ -205,9 +205,9 @@ impl<'alloc> Parser<'alloc> {
                 return Ok(false);
             }
             // On error, don't attempt error handling again.
-            return Err(Self::parse_error(token));
+            return Err(Self::parse_error(token).into());
         }
-        Err(ParseError::ParserCannotUnpackToken)
+        Err(ParseError::ParserCannotUnpackToken.into())
     }
 
     pub(crate) fn recover(t: &Token, error_code: ErrorCode) -> Result<'alloc, ()> {
@@ -219,7 +219,7 @@ impl<'alloc> Parser<'alloc> {
                 {
                     Ok(())
                 } else {
-                    Err(Self::parse_error(t))
+                    Err(Self::parse_error(t).into())
                 }
             }
             ErrorCode::DoWhileAsi => Ok(()),

--- a/crates/parser/src/simulator.rs
+++ b/crates/parser/src/simulator.rs
@@ -167,7 +167,7 @@ impl<'alloc, 'parser> Simulator<'alloc, 'parser> {
             // might not be in the shifted terms coming after the reduced
             // nonterminal.
             if t.term == Term::Terminal(TerminalId::ErrorToken) {
-                return Err(Parser::parse_error(token));
+                return Err(Parser::parse_error(token).into());
             }
 
             // Otherwise, check if the current rule accept an Automatic
@@ -184,9 +184,9 @@ impl<'alloc, 'parser> Simulator<'alloc, 'parser> {
                 });
                 return Ok(false);
             }
-            return Err(Parser::parse_error(token));
+            return Err(Parser::parse_error(token).into());
         }
         // On error, don't attempt error handling again.
-        Err(ParseError::ParserCannotUnpackToken)
+        Err(ParseError::ParserCannotUnpackToken.into())
     }
 }

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -82,7 +82,7 @@ fn assert_parses<'alloc, T: IntoChunks<'alloc>>(code: T) {
 
 fn assert_error<'alloc, T: IntoChunks<'alloc>>(code: T) {
     let allocator = &Bump::new();
-    assert!(match try_parse(allocator, code) {
+    assert!(match try_parse(allocator, code).map_err(|e| *e) {
         Err(ParseError::NotImplemented(_)) => panic!("expected error, got NotImplemented"),
         Err(_) => true,
         Ok(ast) => panic!("assertion failed: SUCCESS error: {:?}", ast),
@@ -91,7 +91,7 @@ fn assert_error<'alloc, T: IntoChunks<'alloc>>(code: T) {
 
 fn assert_syntax_error<'alloc, T: IntoChunks<'alloc>>(code: T) {
     let allocator = &Bump::new();
-    assert!(match try_parse(allocator, code) {
+    assert!(match try_parse(allocator, code).map_err(|e| *e) {
         Err(ParseError::SyntaxError(_)) => true,
         Err(other) => panic!("unexpected error: {:?}", other),
         Ok(ast) => panic!("assertion failed: SUCCESS error: {:?}", ast),
@@ -100,7 +100,7 @@ fn assert_syntax_error<'alloc, T: IntoChunks<'alloc>>(code: T) {
 
 fn assert_not_implemented<'alloc, T: IntoChunks<'alloc>>(code: T) {
     let allocator = &Bump::new();
-    assert!(match try_parse(allocator, code) {
+    assert!(match try_parse(allocator, code).map_err(|e| *e) {
         Err(ParseError::NotImplemented(_)) => true,
         Err(other) => panic!("unexpected error: {:?}", other),
         Ok(ast) => panic!("assertion failed: SUCCESS error: {:?}", ast),
@@ -109,7 +109,7 @@ fn assert_not_implemented<'alloc, T: IntoChunks<'alloc>>(code: T) {
 
 fn assert_illegal_character<'alloc, T: IntoChunks<'alloc>>(code: T) {
     let allocator = &Bump::new();
-    assert!(match try_parse(allocator, code) {
+    assert!(match try_parse(allocator, code).map_err(|e| *e) {
         Err(ParseError::IllegalCharacter(_)) => true,
         Err(other) => panic!("unexpected error: {:?}", other),
         Ok(ast) => panic!("assertion failed: SUCCESS error: {:?}", ast),
@@ -120,14 +120,14 @@ fn assert_error_eq<'alloc, T: IntoChunks<'alloc>>(code: T, expected: ParseError)
     let allocator = &Bump::new();
     let result = try_parse(allocator, code);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), expected);
+    assert_eq!(*result.unwrap_err(), expected);
 }
 
 fn assert_incomplete<'alloc, T: IntoChunks<'alloc>>(code: T) {
     let allocator = &Bump::new();
     let result = try_parse(allocator, code);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), ParseError::UnexpectedEnd);
+    assert_eq!(*result.unwrap_err(), ParseError::UnexpectedEnd);
 }
 
 // Assert that `left` and `right`, when parsed as ES Modules, consist of the


### PR DESCRIPTION
This work is divided in 2 patches, the first one add the `std::boxed::Box` type as well as `.into()` calls where necessary, and the second one adds assertions to avoid accidental regressions.

Note `std::boxed::Box` is explicitly used to avoid confusing it with `arena::Box`, and `.into()` is used instead of `Box::new(…)` to avoid name clashes with `arena::Box`.

This changes need some changes in smoosh monkey. I will link the bugzilla issue here later.