### PR TITLE
Replace Term enum by a simple number.

### DIFF
--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -4,7 +4,7 @@ use ast::arena;
 use ast::SourceLocation;
 use generated_parser::{
     full_actions, AstBuilder, AstBuilderDelegate, ErrorCode, ParseError, ParserTrait, Result,
-    StackValue, Term, TermValue, TerminalId, Token, TABLES,
+    StackValue, TermValue, TerminalId, Token, TABLES,
 };
 use json_log::json_trace;
 
@@ -127,7 +127,7 @@ impl<'alloc> Parser<'alloc> {
             "end": token.loc.end,
         });
         // Shift the token with the associated StackValue.
-        let term = Term::Terminal(token.terminal_id);
+        let term = token.terminal_id.into();
         let accept = self.shift(TermValue {
             term,
             value: StackValue::Token(token),
@@ -147,7 +147,7 @@ impl<'alloc> Parser<'alloc> {
         let loc = SourceLocation::new(position, position);
         let token = Token::basic_token(TerminalId::End, loc);
         let accept = self.shift(TermValue {
-            term: Term::Terminal(TerminalId::End),
+            term: TerminalId::End.into(),
             value: StackValue::Token(self.handler.alloc(token)),
         })?;
         // Adding a TerminalId::End would either lead to a parse error, or to
@@ -186,7 +186,7 @@ impl<'alloc> Parser<'alloc> {
             // and while the ErrorToken might be in the lookahead rules, it
             // might not be in the shifted terms coming after the reduced
             // nonterminal.
-            if t.term == Term::Terminal(TerminalId::ErrorToken) {
+            if t.term == TerminalId::ErrorToken.into() {
                 return Err(Self::parse_error(token).into());
             }
 
@@ -201,7 +201,7 @@ impl<'alloc> Parser<'alloc> {
                 self.replay(t);
                 let err_token = self.handler.alloc(err_token);
                 self.replay(TermValue {
-                    term: Term::Terminal(TerminalId::ErrorToken),
+                    term: TerminalId::ErrorToken.into(),
                     value: StackValue::Token(err_token),
                 });
                 return Ok(false);


### PR DESCRIPTION
This change replace the Term enum which was wrapping the enumerated type of
TerminalId and NonterminalId values. Despite the non-overlapping ranges of
numbers, Rust kept a single bit to distinguish between a Terminal and a
Nonterminal.

This change encode a Term as a single integer, as it was expected to be compiled
to. Note, this is using u32 instead of the minimal u16 representation as u32 is
faster to load and write to memory.

This change optimize the execution by reducing the Smoosh/Spider ratio from ~1.47 to ~1.44, when added on top of other optimizations.
