### PR TITLE
Lexer returns allocated token

### DIFF
--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -2,6 +2,7 @@
 
 use crate::numeric_value::{parse_float, parse_int, NumericLiteralBase};
 use crate::parser::Parser;
+use ast::arena;
 use ast::source_atom_set::{CommonSourceAtomSetIndices, SourceAtomSet};
 use ast::source_slice_list::SourceSliceList;
 use ast::SourceLocation;
@@ -91,16 +92,20 @@ impl<'alloc> Lexer<'alloc> {
         chars.next()
     }
 
-    pub fn next<'parser>(&mut self, parser: &Parser<'parser>) -> Result<'alloc, Token> {
+    #[inline]
+    pub fn next<'parser>(
+        &mut self,
+        parser: &Parser<'parser>,
+    ) -> Result<'alloc, arena::Box<'alloc, Token>> {
         let result = self.advance_impl(parser)?;
         let is_on_new_line = self.is_on_new_line;
         self.is_on_new_line = false;
-        Ok(Token {
+        Ok(arena::alloc_with(self.allocator, || Token {
             terminal_id: result.terminal_id,
             loc: result.loc,
             is_on_new_line,
             value: result.value,
-        })
+        }))
     }
 
     fn unexpected_err(&mut self) -> ParseError<'alloc> {

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -81,7 +81,7 @@ fn parse<'alloc>(
         if t.terminal_id == TerminalId::End {
             break;
         }
-        parser.write_token(&t)?;
+        parser.write_token(t)?;
     }
     parser.close(tokens.offset())
 }
@@ -102,7 +102,7 @@ pub fn is_partial_script<'alloc>(
         if t.terminal_id == TerminalId::End {
             break;
         }
-        parser.write_token(&t)?;
+        parser.write_token(t)?;
     }
     Ok(!parser.can_close())
 }

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -1,5 +1,6 @@
 use crate::queue_stack::QueueStack;
 use crate::simulator::Simulator;
+use ast::arena;
 use ast::SourceLocation;
 use generated_parser::{
     full_actions, AstBuilder, AstBuilderDelegate, ErrorCode, ParseError, ParserTrait, Result,
@@ -118,7 +119,7 @@ impl<'alloc> Parser<'alloc> {
         *self.state_stack.last().unwrap()
     }
 
-    pub fn write_token(&mut self, token: &Token) -> Result<'alloc, ()> {
+    pub fn write_token(&mut self, token: arena::Box<'alloc, Token>) -> Result<'alloc, ()> {
         json_trace!({
             "method": "write_token",
             "is_on_new_line": token.is_on_new_line,
@@ -126,9 +127,10 @@ impl<'alloc> Parser<'alloc> {
             "end": token.loc.end,
         });
         // Shift the token with the associated StackValue.
+        let term = Term::Terminal(token.terminal_id);
         let accept = self.shift(TermValue {
-            term: Term::Terminal(token.terminal_id),
-            value: StackValue::Token(self.handler.alloc(token.clone())),
+            term,
+            value: StackValue::Token(token),
         })?;
         // JavaScript grammar accepts empty inputs, therefore we can never
         // accept any program before receiving a TerminalId::End.
@@ -146,7 +148,7 @@ impl<'alloc> Parser<'alloc> {
         let token = Token::basic_token(TerminalId::End, loc);
         let accept = self.shift(TermValue {
             term: Term::Terminal(TerminalId::End),
-            value: StackValue::Token(self.handler.alloc(token.clone())),
+            value: StackValue::Token(self.handler.alloc(token)),
         })?;
         // Adding a TerminalId::End would either lead to a parse error, or to
         // accepting the current input. In which case we return matching node
@@ -232,11 +234,7 @@ impl<'alloc> Parser<'alloc> {
     }
 
     pub fn can_accept_terminal(&self, t: TerminalId) -> bool {
-        let bogus_loc = SourceLocation::new(0, 0);
-        let result = self
-            .simulator()
-            .write_token(&Token::basic_token(t, bogus_loc))
-            .is_ok();
+        let result = self.simulator().write_token(t).is_ok();
         json_trace!({
             "can_accept": result,
             "terminal": format!("{:?}", t),

--- a/crates/parser/src/simulator.rs
+++ b/crates/parser/src/simulator.rs
@@ -126,10 +126,10 @@ impl<'alloc, 'parser> Simulator<'alloc, 'parser> {
         }
     }
 
-    pub fn write_token(&mut self, token: &Token) -> Result<'alloc, ()> {
+    pub fn write_token(&mut self, t: TerminalId) -> Result<'alloc, ()> {
         // Shift the token with the associated StackValue.
         let accept = self.shift(TermValue {
-            term: Term::Terminal(token.terminal_id),
+            term: Term::Terminal(t),
             value: (),
         })?;
         // JavaScript grammar accepts empty inputs, therefore we can never

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -181,8 +181,8 @@ fn assert_same_tokens<'alloc>(left: &str, right: &str) {
         if left_token.terminal_id == TerminalId::End {
             break;
         }
-        left_parser.write_token(&left_token).unwrap();
-        right_parser.write_token(&right_token).unwrap();
+        left_parser.write_token(left_token).unwrap();
+        right_parser.write_token(right_token).unwrap();
     }
     left_parser.close(left_lexer.offset()).unwrap();
     right_parser.close(left_lexer.offset()).unwrap();
@@ -203,7 +203,7 @@ fn assert_can_close_after<'alloc, T: IntoChunks<'alloc>>(code: T) {
         if t.terminal_id == TerminalId::End {
             break;
         }
-        parser.write_token(&t).unwrap();
+        parser.write_token(t).unwrap();
     }
     assert!(parser.can_close());
 }


### PR DESCRIPTION
The lexer is currently returning an `AdvanceResult`, which is then converted to a `Token`, and copied by the `Parser` to the bump allocator space. This patch move the allocation made by the parser as soon as possible, into the Lexer, and the lexer only write this data once straight to memory, where it is expected to be found by the parser.

This modifications is aimed at the top-level loop which was representing 8% of SmooshMonkey profile.
https://perfht.ml/2xHcY0r , this change, in addition to #505 , divide by 3 the time spent in this function.
