### PR TITLE
Scope notes for breaks and continues

### DIFF
--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -128,7 +128,6 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             }
             Statement::BreakStatement { label, .. } => {
                 BreakEmitter {
-                    jump: JumpKind::Goto,
                     label: label.as_ref().map(|x| x.value),
                 }
                 .emit(self);
@@ -138,7 +137,6 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             }
             Statement::ContinueStatement { label, .. } => {
                 ContinueEmitter {
-                    jump: JumpKind::Goto,
                     label: label.as_ref().map(|x| x.value),
                 }
                 .emit(self);

--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -143,7 +143,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             }
             Statement::DoWhileStatement { block, test, .. } => {
                 DoWhileEmitter {
-                    scope_note_index: self.emit.get_scope_note_index(),
+                    enclosing_emitter_scope_index: self.scope_stack.current_index(),
                     block: |emitter| emitter.emit_statement(block),
                     test: |emitter| emitter.emit_expression(test),
                 }
@@ -170,7 +170,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
                 ..
             } => {
                 CForEmitter {
-                    scope_note_index: self.emit.get_scope_note_index(),
+                    enclosing_emitter_scope_index: self.scope_stack.current_index(),
                     maybe_init: init,
                     maybe_test: test,
                     maybe_update: update,
@@ -199,7 +199,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             }
             Statement::LabelledStatement { label, body, .. } => {
                 LabelEmitter {
-                    scope_note_index: self.emit.get_scope_note_index(),
+                    enclosing_emitter_scope_index: self.scope_stack.current_index(),
                     name: label.value,
                     body: |emitter| emitter.emit_statement(body),
                 }
@@ -231,7 +231,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             }
             Statement::WhileStatement { test, block, .. } => {
                 WhileEmitter {
-                    scope_note_index: self.emit.get_scope_note_index(),
+                    enclosing_emitter_scope_index: self.scope_stack.current_index(),
                     test: |emitter| emitter.emit_expression(test),
                     block: |emitter| emitter.emit_statement(block),
                 }

--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -149,6 +149,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             }
             Statement::DoWhileStatement { block, test, .. } => {
                 DoWhileEmitter {
+                    scope_note_index: self.emit.get_scope_note_index(),
                     block: |emitter| emitter.emit_statement(block),
                     test: |emitter| emitter.emit_expression(test),
                 }
@@ -175,6 +176,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
                 ..
             } => {
                 CForEmitter {
+                    scope_note_index: self.emit.get_scope_note_index(),
                     maybe_init: init,
                     maybe_test: test,
                     maybe_update: update,
@@ -203,6 +205,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             }
             Statement::LabelledStatement { label, body, .. } => {
                 LabelEmitter {
+                    scope_note_index: self.emit.get_scope_note_index(),
                     name: label.value,
                     body: |emitter| emitter.emit_statement(body),
                 }
@@ -234,6 +237,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             }
             Statement::WhileStatement { test, block, .. } => {
                 WhileEmitter {
+                    scope_note_index: self.emit.get_scope_note_index(),
                     test: |emitter| emitter.emit_expression(test),
                     block: |emitter| emitter.emit_statement(block),
                 }

--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -143,7 +143,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             }
             Statement::DoWhileStatement { block, test, .. } => {
                 DoWhileEmitter {
-                    enclosing_emitter_scope_index: self.scope_stack.current_index(),
+                    enclosing_emitter_scope_depth: self.scope_stack.current_depth(),
                     block: |emitter| emitter.emit_statement(block),
                     test: |emitter| emitter.emit_expression(test),
                 }
@@ -170,7 +170,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
                 ..
             } => {
                 CForEmitter {
-                    enclosing_emitter_scope_index: self.scope_stack.current_index(),
+                    enclosing_emitter_scope_depth: self.scope_stack.current_depth(),
                     maybe_init: init,
                     maybe_test: test,
                     maybe_update: update,
@@ -199,7 +199,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             }
             Statement::LabelledStatement { label, body, .. } => {
                 LabelEmitter {
-                    enclosing_emitter_scope_index: self.scope_stack.current_index(),
+                    enclosing_emitter_scope_depth: self.scope_stack.current_depth(),
                     name: label.value,
                     body: |emitter| emitter.emit_statement(body),
                 }
@@ -231,7 +231,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
             }
             Statement::WhileStatement { test, block, .. } => {
                 WhileEmitter {
-                    enclosing_emitter_scope_index: self.scope_stack.current_index(),
+                    enclosing_emitter_scope_depth: self.scope_stack.current_depth(),
                     test: |emitter| emitter.emit_expression(test),
                     block: |emitter| emitter.emit_statement(block),
                 }

--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -131,18 +131,12 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
                     label: label.as_ref().map(|x| x.value),
                 }
                 .emit(self);
-                return Err(EmitError::NotImplemented(
-                    "TODO: scope handling for BreakStatement",
-                ));
             }
             Statement::ContinueStatement { label, .. } => {
                 ContinueEmitter {
                     label: label.as_ref().map(|x| x.value),
                 }
                 .emit(self);
-                return Err(EmitError::NotImplemented(
-                    "TODO: scope handling for ContinueStatement",
-                ));
             }
             Statement::DebuggerStatement { .. } => {
                 return Err(EmitError::NotImplemented("TODO: DebuggerStatement"));

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -1411,15 +1411,17 @@ impl InstructionWriter {
         self.scope_notes.leave_scope(index, offset);
     }
 
-    pub fn get_scope_note_index(&self) -> ScopeNoteIndex {
-        self.scope_notes.current_index()
-    }
-
-    pub fn enter_scope_hole(&mut self, index: ScopeNoteIndex) -> ScopeNoteIndex {
+    pub fn enter_scope_hole(
+        &mut self,
+        maybe_scope_note_index: &Option<ScopeNoteIndex>,
+    ) -> ScopeNoteIndex {
         self.debug_leave_lexical_env();
         let offset = self.bytecode_offset();
-        let index = self.scope_notes.enter_scope_hole(index, offset);
-        index
+        let body_scope_index = self
+            .body_scope_index
+            .expect("we should have a body scope index");
+        self.scope_notes
+            .enter_scope_hole(maybe_scope_note_index, body_scope_index, offset)
     }
 
     pub fn leave_scope_hole(&mut self, index: ScopeNoteIndex) {

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -1415,6 +1415,17 @@ impl InstructionWriter {
         self.scope_notes.current_index()
     }
 
+    pub fn enter_scope_hole(&mut self, index: ScopeNoteIndex) -> ScopeNoteIndex {
+        self.debug_leave_lexical_env();
+        let offset = self.bytecode_offset();
+        let index = self.scope_notes.enter_scope_hole(index, offset);
+        index
+    }
+
+    pub fn leave_scope_hole(&mut self, index: ScopeNoteIndex) {
+        let offset = self.bytecode_offset();
+        self.scope_notes.leave_scope(index, offset);
+    }
 
     pub fn switch_to_main(&mut self) {
         self.main_offset = self.bytecode_offset();

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -1411,6 +1411,11 @@ impl InstructionWriter {
         self.scope_notes.leave_scope(index, offset);
     }
 
+    pub fn get_scope_note_index(&self) -> ScopeNoteIndex {
+        self.scope_notes.current_index()
+    }
+
+
     pub fn switch_to_main(&mut self) {
         self.main_offset = self.bytecode_offset();
     }

--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -1414,14 +1414,23 @@ impl InstructionWriter {
     pub fn enter_scope_hole(
         &mut self,
         maybe_scope_note_index: &Option<ScopeNoteIndex>,
+        parent_scope_note_index: Option<ScopeNoteIndex>,
     ) -> ScopeNoteIndex {
+        // TODO: the bytecode sequence before leaving scope (entering hole) depends on the kind
+        // of scope (and also controls). This is currently only debug_leave_lexical_env because
+        // there's only simple lexical scope.
         self.debug_leave_lexical_env();
         let offset = self.bytecode_offset();
-        let body_scope_index = self
-            .body_scope_index
-            .expect("we should have a body scope index");
+
+        let gcthing_index = match maybe_scope_note_index {
+            Some(index) => self.scope_notes.get_scope_hole_gcthing_index(index),
+            None => self
+                .body_scope_index
+                .expect("we should have a body scope index"),
+        };
+
         self.scope_notes
-            .enter_scope_hole(maybe_scope_note_index, body_scope_index, offset)
+            .enter_scope(gcthing_index, offset, parent_scope_note_index)
     }
 
     pub fn leave_scope_hole(&mut self, index: ScopeNoteIndex) {

--- a/crates/emitter/src/emitter_scope.rs
+++ b/crates/emitter/src/emitter_scope.rs
@@ -23,7 +23,7 @@ pub enum NameLocation {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct EmitterScopeIndex {
+pub struct EmitterScopeDepth {
     index: usize,
 }
 
@@ -160,23 +160,6 @@ impl EmitterScopeStack {
             .expect("There should be at least one scope")
     }
 
-    pub fn scope_note_indices_from_to(
-        &self,
-        from: &EmitterScopeIndex,
-        to: &EmitterScopeIndex,
-    ) -> Vec<Option<ScopeNoteIndex>> {
-        let mut indices = Vec::new();
-        for scope in self
-            .scope_stack
-            .iter()
-            .skip(from.index)
-            .take(to.index - from.index)
-        {
-            indices.push(scope.scope_note_index());
-        }
-        indices
-    }
-
     /// Enter the global scope. Call this once at the beginning of a top-level
     /// script.
     ///
@@ -308,9 +291,33 @@ impl EmitterScopeStack {
         NameLocation::Dynamic
     }
 
-    pub fn current_index(&mut self) -> EmitterScopeIndex {
-        EmitterScopeIndex {
+    pub fn current_depth(&mut self) -> EmitterScopeDepth {
+        EmitterScopeDepth {
             index: self.scope_stack.len() - 1,
         }
+    }
+
+    pub fn scope_note_indices_from_to(
+        &self,
+        from: &EmitterScopeDepth,
+        to: &EmitterScopeDepth,
+    ) -> Vec<Option<ScopeNoteIndex>> {
+        let mut indices = Vec::new();
+        for scope in self
+            .scope_stack
+            .iter()
+            .skip(from.index)
+            .take(to.index - from.index)
+        {
+            indices.push(scope.scope_note_index());
+        }
+        indices
+    }
+
+    pub fn get_scope_note_index_for(&self, index: EmitterScopeDepth) -> Option<ScopeNoteIndex> {
+        self.scope_stack
+            .get(index.index)
+            .expect("scope should exist")
+            .scope_note_index()
     }
 }

--- a/crates/emitter/src/emitter_scope.rs
+++ b/crates/emitter/src/emitter_scope.rs
@@ -22,6 +22,11 @@ pub enum NameLocation {
     FrameSlot(FrameSlot, BindingKind),
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct EmitterScopeIndex {
+    index: usize,
+}
+
 // --- EmitterScope types
 //
 // These types are the variants of enum EmitterScope.
@@ -155,20 +160,18 @@ impl EmitterScopeStack {
             .expect("There should be at least one scope")
     }
 
-    pub fn scope_indices_from(
+    pub fn scope_note_indices_from_to(
         &self,
-        scope_note_index: &ScopeNoteIndex,
+        from: &EmitterScopeIndex,
+        to: &EmitterScopeIndex,
     ) -> Vec<Option<ScopeNoteIndex>> {
-        let index = self
+        let mut indices = Vec::new();
+        for scope in self
             .scope_stack
             .iter()
-            .position(|scope| match scope.scope_note_index() {
-                Some(index) => &index == scope_note_index,
-                _ => false,
-            })
-            .expect("Index must be available");
-        let mut indices = Vec::new();
-        for scope in self.scope_stack.iter().skip(index) {
+            .skip(from.index)
+            .take(to.index - from.index)
+        {
             indices.push(scope.scope_note_index());
         }
         indices
@@ -303,5 +306,11 @@ impl EmitterScopeStack {
         }
 
         NameLocation::Dynamic
+    }
+
+    pub fn current_index(&mut self) -> EmitterScopeIndex {
+        EmitterScopeIndex {
+            index: self.scope_stack.len() - 1,
+        }
     }
 }

--- a/crates/emitter/src/emitter_scope.rs
+++ b/crates/emitter/src/emitter_scope.rs
@@ -118,7 +118,7 @@ impl EmitterScope {
         }
     }
 
-    fn scope_note_index(&self) -> Option<ScopeNoteIndex> {
+    pub fn scope_note_index(&self) -> Option<ScopeNoteIndex> {
         match self {
             EmitterScope::Global(scope) => scope.scope_note_index(),
             EmitterScope::Lexical(scope) => scope.scope_note_index(),
@@ -153,6 +153,25 @@ impl EmitterScopeStack {
         self.scope_stack
             .last()
             .expect("There should be at least one scope")
+    }
+
+    pub fn scope_indices_from(
+        &self,
+        scope_note_index: &ScopeNoteIndex,
+    ) -> Vec<Option<ScopeNoteIndex>> {
+        let index = self
+            .scope_stack
+            .iter()
+            .position(|scope| match scope.scope_note_index() {
+                Some(index) => &index == scope_note_index,
+                _ => false,
+            })
+            .expect("Index must be available");
+        let mut indices = Vec::new();
+        for scope in self.scope_stack.iter().skip(index) {
+            indices.push(scope.scope_note_index());
+        }
+        indices
     }
 
     /// Enter the global scope. Call this once at the beginning of a top-level

--- a/crates/emitter/src/gcthings.rs
+++ b/crates/emitter/src/gcthings.rs
@@ -18,7 +18,7 @@ pub struct GCThingIndex {
 }
 
 impl GCThingIndex {
-    pub fn new(index: usize) -> Self {
+    fn new(index: usize) -> Self {
         Self { index }
     }
 }

--- a/crates/emitter/src/gcthings.rs
+++ b/crates/emitter/src/gcthings.rs
@@ -18,7 +18,7 @@ pub struct GCThingIndex {
 }
 
 impl GCThingIndex {
-    fn new(index: usize) -> Self {
+    pub fn new(index: usize) -> Self {
         Self { index }
     }
 }

--- a/crates/emitter/src/scope_notes.rs
+++ b/crates/emitter/src/scope_notes.rs
@@ -22,7 +22,7 @@ impl ScopeNote {
 }
 
 /// Index into ScopeNoteList.notes.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy)]
 pub struct ScopeNoteIndex {
     index: usize,
 }
@@ -62,35 +62,29 @@ impl ScopeNoteList {
         ScopeNoteIndex::new(note_index)
     }
 
-    fn get_scope_hole_gcthing_index(&self, reference_scope_index: ScopeNoteIndex) -> GCThingIndex {
-        if reference_scope_index.index >= 1 {
-            return self
-                .notes
-                .get(reference_scope_index.index - 1)
-                .unwrap()
-                .index;
-        }
-        GCThingIndex::new(0)
+    fn get_scope_hole_gcthing_index(&self, scope_note_index: &ScopeNoteIndex) -> GCThingIndex {
+        self.notes
+            .get(scope_note_index.index)
+            .expect("Scope note should exist")
+            .index
     }
 
     pub fn enter_scope_hole(
         &mut self,
-        reference_scope_index: ScopeNoteIndex,
+        maybe_enclosing_scope_note_index: &Option<ScopeNoteIndex>,
+        body_index: GCThingIndex,
         offset: BytecodeOffset,
     ) -> ScopeNoteIndex {
-        let note_index = self.notes.len();
-        let parent_index = ScopeNoteIndex::new(note_index - 1);
-        let reference_gcthing_index = self.get_scope_hole_gcthing_index(reference_scope_index);
-        self.enter_scope(reference_gcthing_index, offset, Some(parent_index))
+        let parent_index = ScopeNoteIndex::new(self.notes.len() - 1);
+        let gcthing_index = match maybe_enclosing_scope_note_index {
+            Some(index) => self.get_scope_hole_gcthing_index(index),
+            None => body_index,
+        };
+        self.enter_scope(gcthing_index, offset, Some(parent_index))
     }
 
     pub fn leave_scope(&mut self, index: ScopeNoteIndex, offset: BytecodeOffset) {
         self.notes[usize::from(index)].end = offset;
-    }
-
-    pub fn current_index(&self) -> ScopeNoteIndex {
-        let note_index = self.notes.len();
-        ScopeNoteIndex::new(note_index)
     }
 }
 

--- a/crates/emitter/src/scope_notes.rs
+++ b/crates/emitter/src/scope_notes.rs
@@ -62,25 +62,11 @@ impl ScopeNoteList {
         ScopeNoteIndex::new(note_index)
     }
 
-    fn get_scope_hole_gcthing_index(&self, scope_note_index: &ScopeNoteIndex) -> GCThingIndex {
+    pub fn get_scope_hole_gcthing_index(&self, scope_note_index: &ScopeNoteIndex) -> GCThingIndex {
         self.notes
             .get(scope_note_index.index)
             .expect("Scope note should exist")
             .index
-    }
-
-    pub fn enter_scope_hole(
-        &mut self,
-        maybe_enclosing_scope_note_index: &Option<ScopeNoteIndex>,
-        body_index: GCThingIndex,
-        offset: BytecodeOffset,
-    ) -> ScopeNoteIndex {
-        let parent_index = ScopeNoteIndex::new(self.notes.len() - 1);
-        let gcthing_index = match maybe_enclosing_scope_note_index {
-            Some(index) => self.get_scope_hole_gcthing_index(index),
-            None => body_index,
-        };
-        self.enter_scope(gcthing_index, offset, Some(parent_index))
     }
 
     pub fn leave_scope(&mut self, index: ScopeNoteIndex, offset: BytecodeOffset) {

--- a/crates/emitter/src/scope_notes.rs
+++ b/crates/emitter/src/scope_notes.rs
@@ -62,6 +62,28 @@ impl ScopeNoteList {
         ScopeNoteIndex::new(note_index)
     }
 
+    fn get_scope_hole_gcthing_index(&self, reference_scope_index: ScopeNoteIndex) -> GCThingIndex {
+        if reference_scope_index.index >= 1 {
+            return self
+                .notes
+                .get(reference_scope_index.index - 1)
+                .unwrap()
+                .index;
+        }
+        GCThingIndex::new(0)
+    }
+
+    pub fn enter_scope_hole(
+        &mut self,
+        reference_scope_index: ScopeNoteIndex,
+        offset: BytecodeOffset,
+    ) -> ScopeNoteIndex {
+        let note_index = self.notes.len();
+        let parent_index = ScopeNoteIndex::new(note_index - 1);
+        let reference_gcthing_index = self.get_scope_hole_gcthing_index(reference_scope_index);
+        self.enter_scope(reference_gcthing_index, offset, Some(parent_index))
+    }
+
     pub fn leave_scope(&mut self, index: ScopeNoteIndex, offset: BytecodeOffset) {
         self.notes[usize::from(index)].end = offset;
     }

--- a/crates/emitter/src/scope_notes.rs
+++ b/crates/emitter/src/scope_notes.rs
@@ -22,7 +22,7 @@ impl ScopeNote {
 }
 
 /// Index into ScopeNoteList.notes.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ScopeNoteIndex {
     index: usize,
 }
@@ -64,6 +64,11 @@ impl ScopeNoteList {
 
     pub fn leave_scope(&mut self, index: ScopeNoteIndex, offset: BytecodeOffset) {
         self.notes[usize::from(index)].end = offset;
+    }
+
+    pub fn current_index(&self) -> ScopeNoteIndex {
+        let note_index = self.notes.len();
+        ScopeNoteIndex::new(note_index)
     }
 }
 


### PR DESCRIPTION
fixes #495, depends on #516

The first commit tries to make working with internal control structure jumps safer: I already made the mistake once of emitting a bytecode between recording the offset and emitting the jump, which lead to hard to trace errors.

The second commit adds scopenotes to loops and labels

The final two commits are where #495 is really resolved. I used a similar approach to forward jumps. A `NonLocalJumpControl`, when it prepares to jump, returns a collection of scope holes that need to be closed. After a jump, those must be called. The rest of the changes are helpers to make this possible. 