### PR TITLE
Fix labels and add more information to disassembly

### DIFF
--- a/crates/emitter/src/control_structures.rs
+++ b/crates/emitter/src/control_structures.rs
@@ -199,7 +199,9 @@ impl Breakable for LabelControl {
     }
 
     fn emit_break_target_and_patch(&mut self, emit: &mut InstructionWriter) {
-        emit.emit_jump_target_and_patch(&self.breaks);
+        if !self.breaks.is_empty() {
+            emit.emit_jump_target_and_patch(&self.breaks);
+        }
     }
 }
 
@@ -265,12 +267,9 @@ impl ControlStructureStack {
     }
 
     pub fn register_labelled_break(&mut self, label: SourceAtomSetIndex, offset: BytecodeOffset) {
-        if let Some(control) = self.find_labelled_loop(label) {
-            control.register_break(offset);
-        } else {
-            panic!(
-                "A labelled break was passed, but no label was found. This should be caught by early errors"
-            )
+        match self.find_labelled_control(label) {
+            Control::Label(control) => control.register_break(offset),
+            Control::Loop(control) => control.register_break(offset),
         }
     }
 
@@ -289,7 +288,7 @@ impl ControlStructureStack {
     }
 
     pub fn find_labelled_loop(&mut self, label: SourceAtomSetIndex) -> Option<&mut LoopControl> {
-        let label_index = self.find_labelled_index(label)?;
+        let label_index = self.find_labelled_index(label);
         // To find the associated loop for a label, we can take the label's index + 1, as the
         // associated loop should always be in the position after the label.
         let control = self.control_stack.get_mut(label_index + 1);
@@ -299,16 +298,34 @@ impl ControlStructureStack {
         }
     }
 
-    pub fn find_labelled_index(&mut self, label: SourceAtomSetIndex) -> Option<usize> {
-        self.control_stack.iter().position(|control| match control {
-            Control::Label(control) => {
-                if control.name == label {
-                    return true;
+    pub fn find_labelled_control(&mut self, label: SourceAtomSetIndex) -> &mut Control {
+        self.control_stack
+            .iter_mut()
+            .find(|control| match control {
+                Control::Label(control) => {
+                    if control.name == label {
+                        return true;
+                    }
+                    false
                 }
-                false
-            }
-            _ => false,
-        })
+                _ => false,
+            })
+            .expect("there should be a control with this label")
+    }
+
+    pub fn find_labelled_index(&mut self, label: SourceAtomSetIndex) -> usize {
+        self.control_stack
+            .iter()
+            .position(|control| match control {
+                Control::Label(control) => {
+                    if control.name == label {
+                        return true;
+                    }
+                    false
+                }
+                _ => false,
+            })
+            .expect("there should be a control with this label")
     }
 
     pub fn emit_continue_target_and_patch(&mut self, emit: &mut InstructionWriter) {

--- a/crates/emitter/src/dis.rs
+++ b/crates/emitter/src/dis.rs
@@ -6,11 +6,13 @@ use std::fmt::Write;
 pub fn dis(bc: &[u8]) -> String {
     let mut result = String::new();
     let mut iter = bc.iter();
+    let mut offset = 0;
     loop {
         let len = match iter.next() {
             Some(byte) => match Opcode::try_from(*byte) {
                 Ok(op) => {
-                    write!(&mut result, "{:?}", op).unwrap();
+                    write!(&mut result, "{}", format!("{:05}: {:?}", offset, op)).unwrap();
+                    offset = offset + op.instruction_length();
                     op.instruction_length()
                 }
                 Err(()) => {

--- a/crates/generated_parser/src/early_error_checker.rs
+++ b/crates/generated_parser/src/early_error_checker.rs
@@ -565,8 +565,12 @@ pub trait EarlyErrorChecker<'alloc> {
             CatchParameterEarlyErrorsContext::new_with_binding_pattern()
         };
 
-        let param_index = self.context_metadata_mut().find_first_binding(start_of_bindings_offset);
-        let body_index = self.context_metadata_mut().find_first_binding(end_of_bindings_offset);
+        let param_index = self
+            .context_metadata_mut()
+            .find_first_binding(start_of_bindings_offset);
+        let body_index = self
+            .context_metadata_mut()
+            .find_first_binding(end_of_bindings_offset);
         declare_param(
             self.context_metadata(),
             self.atoms(),
@@ -589,8 +593,13 @@ pub trait EarlyErrorChecker<'alloc> {
     }
 
     // Check bindings in Catch with no parameter and Block.
-    fn check_catch_no_param_bindings(&mut self, start_of_catch_offset: usize) -> Result<'alloc, ()> {
-        let body_index = self.context_metadata_mut().find_first_binding(start_of_catch_offset);
+    fn check_catch_no_param_bindings(
+        &mut self,
+        start_of_catch_offset: usize,
+    ) -> Result<'alloc, ()> {
+        let body_index = self
+            .context_metadata_mut()
+            .find_first_binding(start_of_catch_offset);
 
         let param_context = CatchParameterEarlyErrorsContext::new_with_binding_identifier();
         let mut block_context = CatchBlockEarlyErrorsContext::new(param_context);
@@ -614,8 +623,12 @@ pub trait EarlyErrorChecker<'alloc> {
     ) -> Result<'alloc, ()> {
         let mut head_context = LexicalForHeadEarlyErrorsContext::new();
 
-        let head_index = self.context_metadata_mut().find_first_binding(start_of_bindings_offset);
-        let body_index = self.context_metadata_mut().find_first_binding(end_of_bindings_offset);
+        let head_index = self
+            .context_metadata_mut()
+            .find_first_binding(start_of_bindings_offset);
+        let body_index = self
+            .context_metadata_mut()
+            .find_first_binding(end_of_bindings_offset);
         declare_lexical_for_head(
             self.context_metadata(),
             self.atoms(),


### PR DESCRIPTION
While working on #515 i noted that there were a few problems with my label implementation. Labels were not breaking correctly. This fixes that, and also cleans up some formatting in error stacks, and adds more debug information. 