### PR TITLE
Remove unused alias set fields from actions.

### DIFF
--- a/jsparagus/lr0.py
+++ b/jsparagus/lr0.py
@@ -180,14 +180,11 @@ def callmethods_to_funcalls(
     in this way are appended to `funcalls`.
     """
 
-    # TODO: find a way to carry alias sets to here.
-    alias_set = ["parser"]
     if isinstance(expr, int):
         stack_index = pop - expr
         if depth == 0:
             call = FunCall("id", (stack_index,), fallible=False,
-                           trait=types.Type("AstBuilder"), set_to=ret,
-                           alias_read=alias_set, alias_write=alias_set)
+                           trait=types.Type("AstBuilder"), set_to=ret)
             funcalls.append(call)
             return ret
         else:
@@ -206,9 +203,7 @@ def callmethods_to_funcalls(
         call = FunCall(expr.method, args,
                        trait=expr.trait,
                        fallible=expr.fallible,
-                       set_to=ret,
-                       alias_read=alias_set,
-                       alias_write=alias_set)
+                       set_to=ret)
         funcalls.append(call)
         return ret
     elif expr == "accept":


### PR DESCRIPTION
This is a simple clean-up, which removes unused code.
