### PR TITLE
Rewrite states within Actions.

### DIFF
--- a/jsparagus/actions.py
+++ b/jsparagus/actions.py
@@ -6,7 +6,9 @@ import typing
 from .grammar import Element, InitNt, Nt
 from . import types, grammar
 
-StateId = int
+# Avoid circular reference between this module and parse_table.py
+if typing.TYPE_CHECKING:
+    from .parse_table import StateId
 
 
 class Action:

--- a/jsparagus/actions.py
+++ b/jsparagus/actions.py
@@ -6,6 +6,8 @@ import typing
 from .grammar import Element, InitNt, Nt
 from . import types, grammar
 
+StateId = int
+
 
 class Action:
     __slots__ = ["read", "write", "_hash"]
@@ -69,6 +71,11 @@ class Action:
     def contains_accept(self) -> bool:
         "Returns whether the current action stops the parser."
         return False
+
+    def rewrite_state_indexes(self, state_map: typing.Dict[StateId, StateId]) -> Action:
+        """If the action contains any state index, use the map to map the old index to
+        the new indexes"""
+        return self
 
     def __eq__(self, other: object) -> bool:
         if self.__class__ != other.__class__:
@@ -166,6 +173,7 @@ class Accept(Action):
 
     def shifted_action(self, shifted_term: Element) -> Accept:
         return Accept()
+
 
 class Lookahead(Action):
     """Define a Lookahead assertion which is meant to either accept or reject
@@ -409,3 +417,7 @@ class Seq(Action):
 
     def contains_accept(self) -> bool:
         return any(a.contains_accept() for a in self.actions)
+
+    def rewrite_state_indexes(self, state_map: typing.Dict[StateId, StateId]) -> Seq:
+        actions = list(map(lambda a: a.rewrite_state_indexes(state_map), self.actions))
+        return Seq(actions)

--- a/jsparagus/aps.py
+++ b/jsparagus/aps.py
@@ -7,12 +7,9 @@ from .grammar import Nt
 from .lr0 import ShiftedTerm, Term
 from .actions import Action, Reduce
 
-
-StateId = int
-
-# Hack to avoid circular reference between this module and parse_table.py
-StateAndTransition = typing.Any
-ParseTable = typing.Any
+# Avoid circular reference between this module and parse_table.py
+if typing.TYPE_CHECKING:
+    from .parse_table import StateId, StateAndTransitions, ParseTable
 
 
 def shifted_path_to(pt: ParseTable, n: int, right_of: Path) -> typing.Iterator[Path]:
@@ -99,7 +96,7 @@ class Edge:
     src: StateId
     term: typing.Optional[Term]
 
-    def stable_str(self, states: typing.List[StateAndTransition]) -> str:
+    def stable_str(self, states: typing.List[StateAndTransitions]) -> str:
         return "{} -- {} -->".format(states[self.src].stable_hash, str(self.term))
 
     def __str__(self) -> str:
@@ -153,7 +150,7 @@ class APS:
     # to be shifted. This list corresponds to terminals and non-terminals which
     # were necessary for removing inconsistencies, but have to be replayed
     # after shifting the reduced non-terminals.
-    replay: typing.List[typing.Union[str, Nt]]
+    replay: typing.List[ShiftedTerm]
 
     # This is the list of edges visited since the starting state.
     history: Path
@@ -199,8 +196,8 @@ class APS:
             for term, to in state.shifted_edges():
                 edge = Edge(last_edge.src, term)
                 new_sh = self.shift[:-1] + [edge]
-                to = Edge(to, None)
-                yield APS(st, new_sh + [to], la + [term], rp, hs + [edge], False)
+                edge_to = Edge(to, None)
+                yield APS(st, new_sh + [edge_to], la + [term], rp, hs + [edge], False)
         else:
             term = self.replay[0]
             rp = self.replay[1:]
@@ -208,10 +205,9 @@ class APS:
                 edge = Edge(last_edge.src, term)
                 new_sh = self.shift[:-1] + [edge]
                 to = state[term]
-                to = Edge(to, None)
-                yield APS(st, new_sh + [to], la, rp, hs + [edge], False)
+                edge_to = Edge(to, None)
+                yield APS(st, new_sh + [edge_to], la, rp, hs + [edge], False)
 
-        term = None
         rp = self.replay
         for a, to in state.epsilon:
             edge = Edge(last_edge.src, a)
@@ -276,18 +272,21 @@ class APS:
                     # computed here such that we can traverse the graph from
                     # `to` state, using the replayed terms.
                     replay = reducer.replay
-                    new_rp = [reducer.nt]
+                    new_rp: typing.List[ShiftedTerm] = [reducer.nt]
                     if replay > 0:
-                        stacked_terms = [edge.term for edge in path if pt.term_is_stacked(edge.term)]
+                        stacked_terms = [
+                            typing.cast(ShiftedTerm, edge.term)
+                            for edge in path if pt.term_is_stacked(edge.term)
+                        ]
                         new_rp = new_rp + stacked_terms[-replay:]
                     new_rp = new_rp + rp
                     new_la = la[:max(len(la) - replay, 0)]
                     yield APS(new_st, new_sh, new_la, new_rp, hs + [edge], True)
             else:
-                to = Edge(to, None)
-                yield APS(st, prev_sh + [to], la, rp, hs + [edge], self.reducing)
+                edge_to = Edge(to, None)
+                yield APS(st, prev_sh + [edge_to], la, rp, hs + [edge], self.reducing)
 
-    def stable_str(self, states: typing.List[StateAndTransition], name: str = "aps") -> str:
+    def stable_str(self, states: typing.List[StateAndTransitions], name: str = "aps") -> str:
         return """{}.stack = [{}]
 {}.shift = [{}]
 {}.lookahead = [{}]
@@ -325,7 +324,7 @@ class APS:
 
 def stable_aps_lanes_str(
         aps_lanes: typing.List[APS],
-        states: typing.List[StateAndTransition],
+        states: typing.List[StateAndTransitions],
         header: str = "lanes:",
         name: str = "\taps"
 ) -> str:

--- a/jsparagus/emit/python.py
+++ b/jsparagus/emit/python.py
@@ -11,8 +11,7 @@ from ..actions import (Accept, Action, CheckNotOnNewLine, FilterFlag, FunCall,
 from ..runtime import ErrorToken, ErrorTokenClass
 from ..ordered import OrderedSet
 from ..lr0 import Term
-from ..aps import StateId
-from ..parse_table import ParseTable
+from ..parse_table import StateId, ParseTable
 
 
 def method_name_to_python(name: str) -> str:

--- a/jsparagus/parse_table.py
+++ b/jsparagus/parse_table.py
@@ -160,6 +160,12 @@ class StateAndTransitions:
             self,
             state_map: typing.Dict[StateId, StateId]
     ) -> None:
+        def apply_on_term(term: typing.Union[Term, None]) -> Term:
+            assert term is not None
+            if isinstance(term, Action):
+                return term.rewrite_state_indexes(state_map)
+            return term
+
         self.index = state_map[self.index]
         self.terminals = {
             k: state_map[s] for k, s in self.terminals.items()
@@ -171,10 +177,11 @@ class StateAndTransitions:
             k: state_map[s] for k, s in self.errors.items()
         }
         self.epsilon = [
-            (k, state_map[s]) for k, s in self.epsilon
+            (k.rewrite_state_indexes(state_map), state_map[s]) for k, s in self.epsilon
         ]
         self.backedges = OrderedSet(
-            Edge(state_map[edge.src], edge.term) for edge in self.backedges
+            Edge(state_map[edge.src], apply_on_term(edge.term))
+            for edge in self.backedges
         )
 
     def get_error_symbol(self) -> typing.Optional[ErrorSymbol]:

--- a/jsparagus/parse_table.py
+++ b/jsparagus/parse_table.py
@@ -14,7 +14,10 @@ from .actions import Action, FilterFlag
 from .grammar import End, ErrorSymbol, InitNt, Nt
 from .rewrites import CanonicalGrammar
 from .lr0 import LR0Generator, Term
-from .aps import APS, Edge, Path, StateId
+from .aps import APS, Edge, Path
+
+# StateAndTransitions objects are indexed using a StateId which is an integer.
+StateId = int
 
 
 class StateAndTransitions:


### PR DESCRIPTION
This change is needed as part of the work on #430, as `FilterState` action is introduced, an `Action` can hold a state index. When making changes to the parse table, we should keep these state indexes up-to-date.
