### PR TITLE
Distinguish Action.update_stack from Action.follow_edge.

### DIFF
--- a/jsparagus/emit/python.py
+++ b/jsparagus/emit/python.py
@@ -36,11 +36,13 @@ def write_python_parse_table(out: io.TextIOBase, parse_table: ParseTable) -> Non
     def write_action(act: Action, indent: str = "") -> typing.Tuple[str, bool]:
         assert not act.is_inconsistent()
         if isinstance(act, Reduce):
-            out.write("{}replay = [StateTermValue(0, {}, value, False)]\n".format(indent, repr(act.nt)))
-            if act.replay > 0:
-                out.write("{}replay = replay + parser.stack[-{}:]\n".format(indent, act.replay))
-            if act.replay + act.pop > 0:
-                out.write("{}del parser.stack[-{}:]\n".format(indent, act.replay + act.pop))
+            stack_diff = act.update_stack_with()
+            out.write("{}replay = [StateTermValue(0, {}, value, False)]\n"
+                      .format(indent, repr(stack_diff.nt)))
+            if stack_diff.replay > 0:
+                out.write("{}replay = replay + parser.stack[-{}:]\n".format(indent, stack_diff.replay))
+            if stack_diff.replay + stack_diff.pop > 0:
+                out.write("{}del parser.stack[-{}:]\n".format(indent, stack_diff.replay + stack_diff.pop))
             out.write("{}parser.shift_list(replay, lexer)\n".format(indent))
             return indent, False
         if isinstance(act, Accept):

--- a/jsparagus/emit/rust.py
+++ b/jsparagus/emit/rust.py
@@ -189,25 +189,25 @@ class RustActionWriter:
         assert isinstance(act, Action)
         assert not act.is_condition()
         is_packed = {}
-        if isinstance(act, Seq):
-            # Do not pop any of the stack elements if the reduce action has
-            # an accept function call. Ideally we should be returning the
-            # result instead of keeping it on the parser stack.
-            if act.update_stack() and not act.contains_accept():
-                assert not act.contains_accept()
-                reducer = act.reduce_with()
-                start = 0
-                depth = reducer.pop
-                if reducer.replay > 0:
-                    self.write("parser.rewind({});", reducer.replay)
-                    start = reducer.replay
-                    depth += start
-                for i in range(start, depth):
-                    name = 's'
-                    if i + 1 not in self.used_variables:
-                        name = '_s'
-                    self.write("let {}{} = parser.pop();", name, i + 1)
 
+        # Do not pop any of the stack elements if the reduce action has an
+        # accept function call. Ideally we should be returning the result
+        # instead of keeping it on the parser stack.
+        if act.update_stack() and not act.contains_accept():
+            stack_diff = act.update_stack_with()
+            start = 0
+            depth = stack_diff.pop
+            if stack_diff.replay > 0:
+                self.write("parser.rewind({});", stack_diff.replay)
+                start = stack_diff.replay
+                depth += start
+            for i in range(start, depth):
+                name = 's'
+                if i + 1 not in self.used_variables:
+                    name = '_s'
+                self.write("let {}{} = parser.pop();", name, i + 1)
+
+        if isinstance(act, Seq):
             for a in act.actions:
                 self.write_single_action(a, is_packed)
                 if a.contains_accept():
@@ -217,7 +217,7 @@ class RustActionWriter:
 
         # If we fallthrough the execution of the action, then generate an
         # epsilon transition.
-        if not act.update_stack() and not act.contains_accept():
+        if act.follow_edge() and not act.contains_accept():
             assert 0 <= dest < self.writer.shift_count + self.writer.action_count
             self.write_epsilon_transition(dest)
 
@@ -254,8 +254,9 @@ class RustActionWriter:
             # Convert into a StackValue (when no ast-builder)
             value = "value"
 
+        stack_diff = act.update_stack_with()
         self.write("let term = NonterminalId::{}.into();",
-                   self.writer.nonterminal_to_camel(act.nt))
+                   self.writer.nonterminal_to_camel(stack_diff.nt))
         if value != "value":
             self.write("let value = {};", value)
         self.write("parser.replay(TermValue { term, value });")

--- a/jsparagus/lr0.py
+++ b/jsparagus/lr0.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 import typing
 
 from .actions import (Accept, Action, CheckNotOnNewLine, FunCall, Lookahead,
-                      OutputExpr, Reduce, Seq)
+                      OutputExpr, Unwind, Reduce, Seq)
 from .ordered import OrderedFrozenSet
 from .grammar import (CallMethod, Element, End, ErrorSymbol, Grammar,
                       LookaheadRule, NoLineTerminatorHere, Nt, ReduceExpr,
@@ -348,7 +348,7 @@ class LR0Generator:
             # parse table. (TODO: this supposed that the canonical form did not
             # move the reduce action to be part of the production)
             pop = sum(1 for e in prod.rhs if on_stack(self.grammar.grammar, e))
-            term = Reduce(prod.nt, pop)
+            term = Reduce(Unwind(prod.nt, pop))
             expr = prod.reducer
             if expr is not None:
                 funcalls = []


### PR DESCRIPTION
The 2 actions used to be joined but will no longer remain joined. Thus, `update_stack` is used to express how the parser stack should be mutated, and `follow_edge` expresses whether the epsilon edge on which the action is attached should be followed or not. Reduce actions are not following the epsilon edges, as they follow the parser stack head, whereas Unwind action would follow the epsilon edge and manage the parser stack with actions, resulting in a split of concepts between the ordinary stack automaton and a regular automaton managing the parser stack.

 - Add Unwind action. (not yet used to generate code)
 - Change Reduce action to wrap the Unwind action with no follow_edge.
 - Add StackDiff to express parser stack mutations.
 - Add Action.update_stack_with to return a StackDiff.

This pull request is the beginning of being able to reason on the manipulation of the parser stack while being able to fallback on the ordinary parser stack. Being able to manipulate the automaton instead of making a separate optimization phase gives extra security as we still have to maintain the parser state consistent, and this can be checked.