### PR TITLE
Add FilterState action.

### DIFF
--- a/crates/generated_parser/src/traits/mod.rs
+++ b/crates/generated_parser/src/traits/mod.rs
@@ -30,5 +30,6 @@ pub trait ParserTrait<'alloc, Value> {
     fn pop(&mut self) -> TermValue<Value>;
     fn replay(&mut self, tv: TermValue<Value>);
     fn epsilon(&mut self, state: usize);
+    fn top_state(&self) -> usize;
     fn check_not_on_new_line(&mut self, peek: usize) -> Result<'alloc, bool>;
 }

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -83,6 +83,9 @@ impl<'alloc> ParserTrait<'alloc, StackValue<'alloc>> for Parser<'alloc> {
     fn epsilon(&mut self, state: usize) {
         *self.state_stack.last_mut().unwrap() = state;
     }
+    fn top_state(&self) -> usize {
+        self.state()
+    }
     fn check_not_on_new_line(&mut self, peek: usize) -> Result<'alloc, bool> {
         let sv = {
             let stack = self.node_stack.stack_slice();

--- a/crates/parser/src/simulator.rs
+++ b/crates/parser/src/simulator.rs
@@ -95,6 +95,9 @@ impl<'alloc, 'parser> ParserTrait<'alloc, ()> for Simulator<'alloc, 'parser> {
         }
         *self.sim_state_stack.last_mut().unwrap() = state;
     }
+    fn top_state(&self) -> usize {
+        self.state()
+    }
     fn check_not_on_new_line(&mut self, _peek: usize) -> Result<'alloc, bool> {
         Ok(true)
     }

--- a/jsparagus/actions.py
+++ b/jsparagus/actions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import typing
 import dataclasses
 
+from .ordered import OrderedFrozenSet
 from .grammar import Element, ErrorSymbol, InitNt, Nt
 from . import types, grammar
 
@@ -64,6 +65,16 @@ class Action:
         "Return the conditional action."
         raise TypeError("Action.condition not implemented")
 
+    def check_same_variable(self, other: Action) -> bool:
+        "Return whether both conditionals are checking the same variable."
+        assert self.is_condition()
+        raise TypeError("Action.check_same_variable not implemented")
+
+    def check_different_values(self, other: Action) -> bool:
+        "Return whether these 2 conditions are mutually exclusive."
+        assert self.is_condition()
+        raise TypeError("Action.check_different_values not implemented")
+
     def follow_edge(self) -> bool:
         """Whether the execution of this action resume following the epsilon transition
         (True) or if it breaks the graph epsilon transition (False) and returns
@@ -78,7 +89,7 @@ class Action:
         """Returns a StackDiff which represents the mutation to be applied to the
         parser stack."""
         assert self.update_stack()
-        raise TypeError("Action::update_stack_with not implemented")
+        raise TypeError("Action.update_stack_with not implemented")
 
     def shifted_action(self, shifted_term: Element) -> ShiftedAction:
         """Transpose this action with shifting the given terminal or Nt.
@@ -235,7 +246,8 @@ class Lookahead(Action):
 
     def is_inconsistent(self) -> bool:
         # A lookahead restriction cannot be encoded in code, it has to be
-        # solved using fix_with_lookahead.
+        # solved using fix_with_lookahead, which encodes the lookahead
+        # resolution in the generated parse table.
         return True
 
     def is_condition(self) -> bool:
@@ -243,6 +255,12 @@ class Lookahead(Action):
 
     def condition(self) -> Lookahead:
         return self
+
+    def check_same_variable(self, other: Action) -> bool:
+        raise TypeError("Lookahead.check_same_variables: Lookahead are always inconsistent")
+
+    def check_different_values(self, other: Action) -> bool:
+        raise TypeError("Lookahead.check_different_values: Lookahead are always inconsistent")
 
     def __str__(self) -> str:
         return "Lookahead({}, {})".format(self.terms, self.accept)
@@ -281,6 +299,12 @@ class CheckNotOnNewLine(Action):
     def condition(self) -> CheckNotOnNewLine:
         return self
 
+    def check_same_variable(self, other: Action) -> bool:
+        return isinstance(other, CheckNotOnNewLine) and self.offset == other.offset
+
+    def check_different_values(self, other: Action) -> bool:
+        return False
+
     def shifted_action(self, shifted_term: Element) -> ShiftedAction:
         if isinstance(shifted_term, Nt):
             return True
@@ -288,6 +312,39 @@ class CheckNotOnNewLine(Action):
 
     def __str__(self) -> str:
         return "CheckNotOnNewLine({})".format(self.offset)
+
+
+class FilterStates(Action):
+    """Check whether the stack at a given depth match the state value, if so
+    transition to the destination, otherwise check other states."""
+    __slots__ = ['states']
+
+    states: OrderedFrozenSet[StateId]
+
+    def __init__(self, states: typing.Iterable[StateId]):
+        super().__init__()
+        # Set of states which can follow this transition.
+        self.states = OrderedFrozenSet(sorted(states))
+
+    def is_condition(self) -> bool:
+        return True
+
+    def condition(self) -> FilterStates:
+        return self
+
+    def check_same_variable(self, other: Action) -> bool:
+        return isinstance(other, FilterStates)
+
+    def check_different_values(self, other: Action) -> bool:
+        assert isinstance(other, FilterStates)
+        return self.states.is_disjoint(other.states)
+
+    def rewrite_state_indexes(self, state_map: typing.Dict[StateId, StateId]) -> FilterStates:
+        states = list(state_map[s] for s in self.states)
+        return FilterStates(states)
+
+    def __str__(self) -> str:
+        return "FilterStates({})".format(self.states)
 
 
 class FilterFlag(Action):
@@ -308,6 +365,13 @@ class FilterFlag(Action):
 
     def condition(self) -> FilterFlag:
         return self
+
+    def check_same_variable(self, other: Action) -> bool:
+        return isinstance(other, FilterFlag) and self.flag == other.flag
+
+    def check_different_values(self, other: Action) -> bool:
+        assert isinstance(other, FilterFlag)
+        return self.value != other.value
 
     def __str__(self) -> str:
         return "FilterFlag({}, {})".format(self.flag, self.value)

--- a/jsparagus/parse_table.py
+++ b/jsparagus/parse_table.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import pickle
 import typing
+import itertools
 
 from . import types
 from .utils import consume, keep_until, split
@@ -115,18 +116,20 @@ class StateAndTransitions:
         elif len(self.epsilon) > 1:
             if any(k.is_inconsistent() for k, s in self.epsilon):
                 return True
-            # If all the out-going edges are FilterFlags, with the same flag
-            # and different values, then this state remains consistent, as this
-            # can be implemented as a deterministic switch statement.
+            # NOTE: We can accept multiple conditions as epsilon transitions
+            # iff they are checking the same variable with non-overlapping
+            # values. This implies that we can implement these conditions as a
+            # deterministic switch statement in the code emitter.
             if any(not k.is_condition() for k, s in self.epsilon):
                 return True
-            if any(not isinstance(k.condition(), FilterFlag) for k, s in self.epsilon):
+            iterator = iter(self.epsilon)
+            first, _ = next(iterator)
+            if any(not first.check_same_variable(k) for k, s in iterator):
                 return True
             # "type: ignore" because mypy does not see that the preceding if-statement
             # means all k.condition() actions are FilterFlags.
-            if len(set(k.condition().flag for k, s in self.epsilon)) > 1:  # type: ignore
-                return True
-            if len(self.epsilon) != len(set(k.condition().value for k, s in self.epsilon)):  # type: ignore
+            pairs = itertools.combinations((k for k, s in self.epsilon), 2)
+            if any(not k1.check_different_values(k2) for k1, k2 in pairs):
                 return True
         else:
             try:

--- a/jsparagus/runtime.py
+++ b/jsparagus/runtime.py
@@ -209,6 +209,9 @@ class Parser:
             assert isinstance(self.stack[1].term, Nt)
             return self.stack[1].value
 
+    def top_state(self):
+        return self.stack[-1].state
+
     def check_not_on_new_line(self, lexer, peek):
         if peek <= 0:
             raise ValueError("check_not_on_new_line got an impossible peek offset")


### PR DESCRIPTION
This work is part of #430 and add the `FilterStates` action as well as the code it produces in both the Python and Rust backend.

At the moment no phase of the parse table is making use of this code, but this would be part of the upcoming PR.

@jorendorff I think you might want to give a look at these changes as it is a corner stone from moving away from the default style of parse tables.
