### PR TITLE
Implement `debugger` statement

### DIFF
--- a/crates/emitter/src/ast_emitter.rs
+++ b/crates/emitter/src/ast_emitter.rs
@@ -200,7 +200,7 @@ impl<'alloc, 'opt> AstEmitter<'alloc, 'opt> {
                 .emit(self);
             }
             Statement::DebuggerStatement { .. } => {
-                return Err(EmitError::NotImplemented("TODO: DebuggerStatement"));
+                self.emit.debugger();
             }
             Statement::DoWhileStatement { block, test, .. } => {
                 DoWhileEmitter {

--- a/crates/interpreter/src/evaluate.rs
+++ b/crates/interpreter/src/evaluate.rs
@@ -389,6 +389,8 @@ pub fn evaluate(result: &EmitResult, global: Rc<RefCell<Object>>) -> Result<JSVa
 
             Opcode::JumpTarget => {}
 
+            Opcode::Debugger => {}
+
             Opcode::LoopHead => {}
 
             Opcode::Dup => {


### PR DESCRIPTION
Finally was able to test this in SM - running `debugger` without this patch throws that `TODO` error, and it's just a no-op with this patch.

Closes #225