### PR TITLE
Add SmooshMonkey build/test status badge (fixes #569)

### DIFF
--- a/.github/workflows/smoosh-status.yml
+++ b/.github/workflows/smoosh-status.yml
@@ -1,0 +1,87 @@
+name: SmooshMonkey status
+
+on:
+  schedule:
+    # Every hour
+    - cron:  '0 * * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: "3.7"
+    - name: Initialize venv
+      run: make init-venv
+    - name: Setup Git Profile
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+    - name: Check SmooshMonkey status
+      run: make smoosh-status-ci
+      id: status
+    - name: Checkout ci_smoosh_status
+      run: |
+        if git ls-remote origin | grep refs/heads/ci_smoosh_status; then
+          # If the remote branch exists.
+          git fetch origin ci_smoosh_status
+          git checkout -b ci_smoosh_status origin/ci_smoosh_status
+        else
+          # Otherwise, create a branch.
+          git checkout -b ci_smoosh_status-master
+          # And reset all history
+          git reset --hard deb48a2460abf091705d9972318bbb6e7349de9c
+          # And also remove remaining files
+          rm README.md gen.py
+          echo jsparagus_build_venv > .gitignore
+        fi
+    - name: Update files
+      run: |
+        echo ${{steps.status.outputs.mc}} > latest_mc
+        echo ${{steps.status.outputs.jsparagus}} > latest_jsparagus
+        echo ${{steps.status.outputs.build}} > latest_build
+        echo ${{steps.status.outputs.test}} > latest_test
+
+        if [ ${{steps.status.outputs.build}} == "OK" ]; then
+            BUILD_COLOR="green"
+        elif [ ${{steps.status.outputs.build}} == "NG" ]; then
+            BUILD_COLOR="red"
+        else
+            BUILD_COLOR="yellow"
+        fi
+
+        if [ ${{steps.status.outputs.test}} == "OK" ]; then
+            echo ${{steps.status.outputs.mc}} > known_good_mc
+            echo ${{steps.status.outputs.jsparagus}} > known_good_jsparagus
+            TEST_COLOR="green"
+        elif [ ${{steps.status.outputs.test}} == "NG" ]; then
+            TEST_COLOR="red"
+        else
+            TEST_COLOR="yellow"
+        fi
+
+        echo "{ \"schemaVersion\": 1, \"label\": \"SmooshMonkey Build\", \"message\": \"${{steps.status.outputs.build}}\", \"color\": \"$BUILD_COLOR\" }" > smoosh_build.json
+        echo "{ \"schemaVersion\": 1, \"label\": \"SmooshMonkey Test\", \"message\": \"${{steps.status.outputs.test}}\", \"color\": \"$TEST_COLOR\" }" > smoosh_test.json
+    - name: Add files
+      run: |
+        git add .
+        set +e
+        git diff --cached --quiet
+        echo "##[set-output name=modified;]$?"
+        set -e
+      id: status_add
+    - name: Commit files
+      if: steps.status_add.outputs.modified == '1'
+      run: |
+        git commit -m "Update Smoosh Status" -a
+    - name: Push changes
+      if: steps.status_add.outputs.modified == '1'
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ci_smoosh_status

--- a/Makefile
+++ b/Makefile
@@ -102,4 +102,10 @@ update-stencil:
 update-unicode:
 	$(PYTHON) update_unicode.py UNIDATA ./
 
-.PHONY: all check static-check dyn-check jsdemo rust update-opcodes-m-u
+smoosh-status:
+	$(PYTHON) smoosh_status.py
+
+smoosh-status-ci:
+	$(PYTHON) smoosh_status.py ci
+
+.PHONY: all check static-check dyn-check jsdemo rust update-opcodes-m-u smoosh-status smoosh-status-ci

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [![NotImplemented Counter][NotImplemented Badge]][NotImplemented Search]
 [![Fuzzbug days since][Fuzzbug Days Badge]][Fuzzbugs]
 [![Fuzzbug open][Fuzzbug Open Badge]][Open Fuzzbugs]
-
+[![SmooshMonkey Build Result][SmooshMonkey Build Badge]][SmooshMonkey Build TreeHerder]
+[![SmooshMonkey Test Result][SmooshMonkey Test Badge]][SmooshMonkey Test TreeHerder]
 
 # jsparagus - A JavaScript parser written in Rust
 
@@ -152,3 +153,7 @@ as the bytecode emitter and further integration with SpiderMonkey.
 [Fuzzbug Open Badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmozilla-spidermonkey%2Fjsparagus%2Fci_results%2F.metrics%2Fbadges%2Fopen-fuzzbug.json
 [Fuzzbugs]: https://github.com/mozilla-spidermonkey/jsparagus/issues?utf8=%E2%9C%93&q=label%3AlibFuzzer+
 [Open Fuzzbugs]: https://github.com/mozilla-spidermonkey/jsparagus/labels/libFuzzer
+[SmooshMonkey Build Badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Farai-a%2Fjsparagus%2Fci_smoosh_status%2Fsmoosh_build.json
+[SmooshMonkey Build TreeHerder]: https://treeherder.mozilla.org/#/jobs?repo=mozilla-central&tier=1%2C2%2C3&searchStr=sm-nonunified
+[SmooshMonkey Test Badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Farai-a%2Fjsparagus%2Fci_smoosh_status%2Fsmoosh_test.json
+[SmooshMonkey Test TreeHerder]: https://treeherder.mozilla.org/#/jobs?repo=mozilla-central&tier=1%2C2%2C3&searchStr=sm-smoosh

--- a/smoosh_status.py
+++ b/smoosh_status.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pathlib
+import json
+import urllib.request
+import re
+import subprocess
+import sys
+
+
+class Logger:
+    @classmethod
+    def info(cls, s):
+        print('[INFO]', s)
+
+        # Flush to make it apeear immediately in automation log.
+        sys.stdout.flush()
+
+    @classmethod
+    def fetch(cls, url):
+        cls.info(f'Fetching {url}')
+
+    @classmethod
+    def cmd(cls, cmd):
+        def format_cmd(s):
+            if ' ' in s:
+                escaped = s.replace('"', '\"')
+                return f'"{escaped}"'
+            return s
+
+        formatted_command = ' '.join(list(map(format_cmd, cmd)))
+        cls.info(f'$ {formatted_command}')
+
+
+class GitRepository:
+    def __init__(self, path):
+        self.path = path
+
+        self.git_dir = self.path / '.git'
+        if not self.git_dir.exists():
+            print(f'{self.path} is not a Git repository.', file=sys.stderr)
+            sys.exit(1)
+
+    def get_output(self, *args):
+        cmd = ['git'] + list(args)
+        Logger.cmd(cmd)
+        output = subprocess.run(cmd,
+                                capture_output=True,
+                                cwd=self.path)
+
+        return output.stdout.decode()
+
+    def run(self, *args):
+        cmd = ['git'] + list(args)
+        Logger.cmd(cmd)
+        subprocess.run(cmd,
+                       check=True,
+                       cwd=self.path)
+
+    def commit_message(self, rev):
+        return self.get_output('log', '-1', '--pretty=format:%s%n', rev)
+
+
+class MCRemoteRepository:
+    HG_API_URL = 'https://hg.mozilla.org/mozilla-central/'
+
+    @classmethod
+    def call(cls, name, path):
+        url = f'{cls.HG_API_URL}{name}{path}'
+        Logger.fetch(url)
+        req = urllib.request.Request(url, None, {})
+        response = urllib.request.urlopen(req)
+        return response.read()
+
+    @classmethod
+    def call_json(cls, name, path):
+        return json.loads(cls.call(name, path))
+
+    @classmethod
+    def file(cls, rev, path):
+        return cls.call('raw-file', f'/{rev}{path}')
+
+
+class TreeHerder:
+    API_URL = 'https://treeherder.mozilla.org/api/'
+
+    @classmethod
+    def call(cls, name):
+        url = f'{cls.API_URL}{name}'
+        Logger.fetch(url)
+        req = urllib.request.Request(url, None, {
+            'User-Agent': 'smoosh-tools',
+        })
+        response = urllib.request.urlopen(req)
+        return response.read()
+
+    @classmethod
+    def call_json(cls, name):
+        return json.loads(cls.call(name))
+
+    @classmethod
+    def push_id(cls, rev):
+        push = cls.call_json(f'project/mozilla-central/push/?full=true&format=json&count=1&revision={rev}')
+        return push['results'][0]['id']
+
+    @classmethod
+    def jobs(cls, push_id):
+        push = cls.call_json(f'jobs/?push_id={push_id}&format=json')
+        count = push['count']
+        results = []
+        results += push['results']
+
+        page = 2
+        while len(results) < count:
+            push = cls.call_json(f'jobs/?push_id={push_id}&format=json&page={page}')
+            results += push['results']
+            page += 1
+
+        return results
+
+
+class Status:
+    def run(is_ci):
+        Logger.info('Fetching ci_generated branch')
+
+        jsparagus = GitRepository(pathlib.Path('./'))
+        jsparagus.run('fetch', 'origin', 'ci_generated')
+
+        Logger.info('Checking mozilla-central tip revision')
+
+        m_c_rev = MCRemoteRepository.call_json('json-log', '/tip/')['node']
+        cargo_file = MCRemoteRepository.file(
+            m_c_rev,
+            '/js/src/frontend/smoosh/Cargo.toml'
+        ).decode()
+        m = re.search('rev = "(.+)"', cargo_file)
+        ci_generated_rev = m.group(1)
+
+        Logger.info('Checking jsparagus referred by mozilla-central')
+
+        message = jsparagus.commit_message(ci_generated_rev)
+        m = re.search('for ([A-Fa-f0-9]+)', message)
+        master_rev = m.group(1)
+
+        Logger.info('Checking build status')
+
+        push_id = TreeHerder.push_id(m_c_rev)
+        jobs = TreeHerder.jobs(push_id)
+        nonunified_job = None
+        smoosh_job = None
+        for job in jobs:
+            if 'spidermonkey-sm-nonunified-linux64/debug' in job:
+                nonunified_job = job
+            if 'spidermonkey-sm-smoosh-linux64/debug' in job:
+                smoosh_job = job
+
+        def get_result(job):
+            if job:
+                if 'completed' in job:
+                    if 'success' in job:
+                        return 'OK'
+                    else:
+                        return 'NG'
+                else:
+                    return 'not yet finished'
+            else:
+                return 'unknown'
+
+        nonunified_result = get_result(nonunified_job)
+        smoosh_result = get_result(smoosh_job)
+
+        if is_ci:
+            print(f'##[set-output name=mc;]{m_c_rev}')
+            print(f'##[set-output name=jsparagus;]{master_rev}')
+            print(f'##[set-output name=build;]{nonunified_result}')
+            print(f'##[set-output name=test;]{smoosh_result}')
+        else:
+            print(f'mozilla-central tip: {m_c_rev}')
+            print(f'referred jsparagus revision: {master_rev}')
+            print(f'Build status:')
+            print(f'  Build with --enable-smoosh: {nonunified_result}')
+            print(f'  Test with --smoosh: {smoosh_result}')
+
+
+is_ci = False
+if len(sys.argv) > 1:
+    if sys.argv[1] == 'ci':
+        is_ci = True
+
+Status.run(is_ci)


### PR DESCRIPTION
This adds an automation that does:
  * checks the latest SmooshMonkey build (SM(nu) job) result and test (debug SM(smoosh) job) result
  * write the result into files in ci_smoosh_status branch (see https://github.com/arai-a/jsparagus/tree/ci_smoosh_status for example)
currently the automation runs every hour (maybe we can reduce the frequency tho)

and also this patch adds badges that uses the result (see https://github.com/arai-a/jsparagus)

the result is written into multiple files.
this is to make it easier to use it from smoosh_tools eventually
(so that it can checkout known good revisions)
