### PR TITLE
Remove extra braces produced by not having any escaped sequence anymore.

### DIFF
--- a/jsparagus/emit/rust.py
+++ b/jsparagus/emit/rust.py
@@ -445,7 +445,7 @@ class RustParserWriter:
         self.write(1, "}")
         self.write(1, "pub fn to_terminal(&self) -> TerminalId {")
         self.write(2, "assert!(self.is_terminal());")
-        self.write(2, "unsafe {{ std::mem::transmute(self.0) }}")
+        self.write(2, "unsafe { std::mem::transmute(self.0) }")
         self.write(1, "}")
         self.write(0, "}")
         self.write(0, "")


### PR DESCRIPTION
This caused the test suite to fail because of rust complaining about it.

```
error: unnecessary braces around block return value
   --> crates/generated_parser/src/parser_tables_generated.rs:353:17
    |
353 |         unsafe {{ std::mem::transmute(self.0) }}
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these braces
    |
    = note: `-D unused-braces` implied by `-D warnings`

```