### PR TITLE
Add replay action

### DIFF
--- a/crates/generated_parser/src/traits/mod.rs
+++ b/crates/generated_parser/src/traits/mod.rs
@@ -21,6 +21,7 @@ pub struct TermValue<Value> {
 /// with variable lookahead which can be replayed.
 pub trait ParserTrait<'alloc, Value> {
     fn shift(&mut self, tv: TermValue<Value>) -> Result<'alloc, bool>;
+    fn shift_replayed(&mut self, state: usize);
     fn unshift(&mut self);
     fn rewind(&mut self, n: usize) {
         for _ in 0..n {

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -54,8 +54,7 @@ impl<'alloc> ParserTrait<'alloc, StackValue<'alloc>> for Parser<'alloc> {
                 continue;
             }
             state = goto as usize;
-            self.state_stack.push(state);
-            self.node_stack.shift();
+            self.shift_replayed(state);
             // Execute any actions, such as reduce actions ast builder actions.
             if state >= TABLES.shift_count {
                 assert!(state < TABLES.action_count + TABLES.shift_count);
@@ -68,6 +67,17 @@ impl<'alloc> ParserTrait<'alloc, StackValue<'alloc>> for Parser<'alloc> {
             debug_assert!(state < TABLES.shift_count);
         }
         Ok(false)
+    }
+    #[inline(always)]
+    fn shift_replayed(&mut self, state: usize) {
+        // let term_index: usize = self.node_stack.next().unwrap().term.into();
+        // assert!(term_index < TABLES.shift_width);
+        // let from_state = self.state();
+        // let index = from_state * TABLES.shift_width + term_index;
+        // let goto = TABLES.shift_table[index];
+        // assert!((goto as usize) == state);
+        self.state_stack.push(state);
+        self.node_stack.shift();
     }
     fn unshift(&mut self) {
         self.state_stack.pop().unwrap();

--- a/crates/parser/src/queue_stack.rs
+++ b/crates/parser/src/queue_stack.rs
@@ -129,6 +129,7 @@ impl<T> QueueStack<T> {
     ///
     /// # Panics
     /// If the queue is empty or there is a gap.
+    #[inline(always)]
     pub fn shift(&mut self) {
         assert!(self.can_shift());
         self.top += 1;

--- a/crates/parser/src/simulator.rs
+++ b/crates/parser/src/simulator.rs
@@ -68,6 +68,11 @@ impl<'alloc, 'parser> ParserTrait<'alloc, ()> for Simulator<'alloc, 'parser> {
         }
         Ok(false)
     }
+    fn shift_replayed(&mut self, state: usize) {
+        let tv = self.replay_stack.pop().unwrap();
+        self.sim_state_stack.push(state);
+        self.sim_node_stack.push(tv);
+    }
     fn unshift(&mut self) {
         let tv = self.pop();
         self.replay(tv)

--- a/jsparagus/aps.py
+++ b/jsparagus/aps.py
@@ -19,10 +19,13 @@ def shifted_path_to(pt: ParseTable, n: int, right_of: Path) -> typing.Iterator[P
     state = right_of[0].src
     assert isinstance(state, int)
     for edge in pt.states[state].backedges:
-        if not pt.term_is_shifted(edge.term):
-            print(repr(edge))
-            print(pt.states[edge.src])
         assert pt.term_is_shifted(edge.term)
+        if isinstance(edge.term, Action) and edge.term.update_stack():
+            # Some Action such as Unwind and Replay are actions which are
+            # forking the execution state from the parse stable state.
+            # While computing the shifted_path_to, we only iterate over the
+            # parse table states.
+            continue
         if pt.term_is_stacked(edge.term):
             s_n = n - 1
             if n == 0:
@@ -44,6 +47,7 @@ def reduce_path(pt: ParseTable, shifted: Path) -> typing.Iterator[Path]:
     assert action.update_stack()
     stack_diff = action.update_stack_with()
     nt = stack_diff.nt
+    assert nt is not None
     depth = stack_diff.pop + stack_diff.replay
     if depth > 0:
         # We are reducing at least one element from the stack.
@@ -128,7 +132,22 @@ class APS:
     # As the parse table is explored, new APS are produced by
     # `aps.shift_next(parse_table)`, which are containing the new state of the
     # parser and the history which has been seen by the APS since it started.
-    __slots__ = ['stack', 'shift', 'lookahead', 'replay', 'history', 'reducing']
+    slots = [
+        'state',
+        'stack',
+        'shift',
+        'lookahead',
+        'replay',
+        'history',
+        'reducing'
+    ]
+
+    # This the state at which we are at, and from which edges would be listed.
+    # In most cases, this corresponds to the source of last edge of the shift
+    # list. However, it differs only after executing actions which are mutating
+    # the parser state while following the out-going edge such as Unwind and
+    # Replay.
+    state: StateId
 
     # This is the known stack at the location where we started investigating.
     # As more history is discovered by resolving unwind actions, this stack
@@ -163,7 +182,7 @@ class APS:
     def start(state: StateId) -> APS:
         "Return an Abstract Parser State starting at a given state of a parse table"
         edge = Edge(state, None)
-        return APS([edge], [edge], [], [], [], False)
+        return APS(state, [edge], [edge], [], [], [], False)
 
     def shift_next(self, pt: ParseTable) -> typing.Iterator[APS]:
         """Yield an APS for each state reachable from this APS in a single step,
@@ -190,44 +209,62 @@ class APS:
         st, sh, la, rp, hs = self.stack, self.shift, self.lookahead, self.replay, self.history
         last_edge = sh[-1]
         state = pt.states[last_edge.src]
-        state_match_shift_end = True
+        state_match_shift_end = self.state == self.shift[-1].src
         if self.replay == []:
+            assert state_match_shift_end
             for term, to in state.shifted_edges():
-                edge = Edge(last_edge.src, term)
+                edge = Edge(self.state, term)
                 new_sh = self.shift[:-1] + [edge]
                 edge_to = Edge(to, None)
-                yield APS(st, new_sh + [edge_to], la + [term], rp, hs + [edge], False)
-        else:
+                yield APS(to, st, new_sh + [edge_to], la + [term], rp, hs + [edge], False)
+        elif state_match_shift_end:
             term = self.replay[0]
             rp = self.replay[1:]
             if term in state:
-                edge = Edge(last_edge.src, term)
+                edge = Edge(self.state, term)
                 new_sh = self.shift[:-1] + [edge]
                 to = state[term]
                 edge_to = Edge(to, None)
-                yield APS(st, new_sh + [edge_to], la, rp, hs + [edge], False)
+                yield APS(to, st, new_sh + [edge_to], la, rp, hs + [edge], False)
 
         rp = self.replay
         for a, to in state.epsilon:
-            edge = Edge(last_edge.src, a)
+            edge = Edge(self.state, a)
             prev_sh = self.shift[:-1] + [edge]
             # TODO: Add support for Lookahead and flag manipulation rules, as
             # both of these would invalide potential reduce paths.
             if a.update_stack():
+                stack_diff = a.update_stack_with()
+                if stack_diff.replay < 0:
+                    assert stack_diff.pop == 0
+                    assert stack_diff.nt is None
+                    num_replay = -stack_diff.replay
+                    assert len(self.replay) >= num_replay
+                    new_rp = self.replay[:]
+                    new_sh = self.shift[:]
+                    while num_replay > 0:
+                        num_replay -= 1
+                        term = new_rp[0]
+                        del new_rp[0]
+                        sh_state = new_sh[-1].src
+                        sh_edge = Edge(sh_state, term)
+                        sh_to = pt.states[sh_state][term]
+                        sh_edge_to = Edge(sh_to, None)
+                        del new_sh[-1]
+                        new_sh = new_sh + [sh_edge, sh_edge_to]
+                    yield APS(to, st, new_sh, la, new_rp, hs + [edge], False)
+                    continue
+
                 if self.reducing:
                     # When reducing, do not attempt to execute any actions
                     # which might update the stack. Without this restriction,
                     # we might loop on Optional rules. Which would not match
                     # the expected behaviour of the parser.
                     continue
-                # TODO: When unwinding, do not add the reduced_path back to the
-                # shifted state, but add the non-terminal to the list of terms
-                # to be replayed. This is more accruate with the actual inner
-                # working of the parser and allow to extract the Unwind part of
-                # the Reduce action. This also imply that we might have an
-                # action state which is independent of the stack top.
-                assert not a.follow_edge()  # Not supported yet.
-                stack_diff = a.update_stack_with()
+                reducing = not a.follow_edge()
+                assert stack_diff.pop >= 0
+                assert stack_diff.nt is not None
+                assert stack_diff.replay >= 0
                 for path in reduce_path(pt, prev_sh):
                     # path contains the chains of state shifted, including
                     # epsilon transitions. The head of the path should be able
@@ -278,7 +315,7 @@ class APS:
                     replay = stack_diff.replay
                     nt = stack_diff.nt
                     assert nt is not None
-                    new_rp: typing.List[ShiftedTerm] = [nt]
+                    new_rp = [nt]
                     if replay > 0:
                         stacked_terms = [
                             typing.cast(ShiftedTerm, edge.term)
@@ -287,7 +324,18 @@ class APS:
                         new_rp = new_rp + stacked_terms[-replay:]
                     new_rp = new_rp + rp
                     new_la = la[:max(len(la) - replay, 0)]
-                    yield APS(new_st, new_sh, new_la, new_rp, hs + [edge], True)
+
+                    # If we are reducing, this implies that we are not
+                    # following the edge of the reducing action, and resume the
+                    # execution at the last edge of the shift action. At this
+                    # point the execution and the stack diverge from standard
+                    # LR parser. However, the stack is still manipulated
+                    # through Unwind and Replay actions but the state which is
+                    # executed no longer matches the last element of the
+                    # shifted term or action.
+                    if reducing:
+                        to = new_sh[-1].src
+                    yield APS(to, new_st, new_sh, new_la, new_rp, hs + [edge], reducing)
             elif isinstance(a, FilterStates):
                 # FilterStates is added by the graph transformation and is
                 # expected to be added after the replacement of
@@ -301,21 +349,21 @@ class APS:
                 # destination if the state value from the top of the stack is
                 # in the list of states of this condition.
                 if self.shift[-1].src in a.states:
-                    # TODO: add the to-state destination common to all actions
-                    # which are following edges.
-                    yield APS(st, sh, la, rp, hs + [edge], self.reducing)
+                    yield APS(to, st, sh, la, rp, hs + [edge], False)
             else:
                 edge_to = Edge(to, None)
-                yield APS(st, prev_sh + [edge_to], la, rp, hs + [edge], self.reducing)
+                yield APS(to, st, prev_sh + [edge_to], la, rp, hs + [edge], self.reducing)
 
     def stable_str(self, states: typing.List[StateAndTransitions], name: str = "aps") -> str:
-        return """{}.stack = [{}]
+        return """{}.state = {}
+{}.stack = [{}]
 {}.shift = [{}]
 {}.lookahead = [{}]
 {}.replay = [{}]
 {}.history = [{}]
 {}.reducing = {}
         """.format(
+            name, self.state,
             name, " ".join(e.stable_str(states) for e in self.stack),
             name, " ".join(e.stable_str(states) for e in self.shift),
             name, ", ".join(repr(e) for e in self.lookahead),
@@ -325,13 +373,15 @@ class APS:
         )
 
     def string(self, name: str = "aps") -> str:
-        return """{}.stack = [{}]
+        return """{}.state = {}
+{}.stack = [{}]
 {}.shift = [{}]
 {}.lookahead = [{}]
 {}.replay = [{}]
 {}.history = [{}]
 {}.reducing = {}
         """.format(
+            name, self.state,
             name, " ".join(str(e) for e in self.stack),
             name, " ".join(str(e) for e in self.shift),
             name, ", ".join(repr(e) for e in self.lookahead),

--- a/jsparagus/emit/python.py
+++ b/jsparagus/emit/python.py
@@ -7,7 +7,7 @@ import typing
 
 from ..grammar import ErrorSymbol, Nt, Some
 from ..actions import (Accept, Action, CheckNotOnNewLine, FilterFlag, FilterStates, FunCall,
-                       Lookahead, OutputExpr, PopFlag, PushFlag, Reduce, Seq)
+                       Lookahead, OutputExpr, PopFlag, PushFlag, Reduce, Replay, Seq, Unwind)
 from ..runtime import ErrorToken, ErrorTokenClass
 from ..ordered import OrderedSet
 from ..lr0 import Term
@@ -44,7 +44,11 @@ def write_python_parse_table(out: io.TextIOBase, parse_table: ParseTable) -> Non
 
     def write_action(act: Action, indent: str = "") -> typing.Tuple[str, bool]:
         assert not act.is_inconsistent()
-        if isinstance(act, Reduce):
+        if isinstance(act, Replay):
+            for s in act.replay_steps:
+                out.write("{}parser.replay_action({})\n".format(indent, s))
+            return indent, True
+        if isinstance(act, (Unwind, Reduce)):
             stack_diff = act.update_stack_with()
             out.write("{}replay = [StateTermValue(0, {}, value, False)]\n"
                       .format(indent, repr(stack_diff.nt)))
@@ -53,7 +57,7 @@ def write_python_parse_table(out: io.TextIOBase, parse_table: ParseTable) -> Non
             if stack_diff.replay + stack_diff.pop > 0:
                 out.write("{}del parser.stack[-{}:]\n".format(indent, stack_diff.replay + stack_diff.pop))
             out.write("{}parser.shift_list(replay, lexer)\n".format(indent))
-            return indent, False
+            return indent, act.follow_edge()
         if isinstance(act, Accept):
             out.write("{}raise ShiftAccept()\n".format(indent))
             return indent, False

--- a/jsparagus/runtime.py
+++ b/jsparagus/runtime.py
@@ -175,6 +175,21 @@ class Parser:
             else:
                 break
 
+    def replay_action(self, dest):
+        # This code emulates the code which would be executed by the shift
+        # function, if we were to return to this shift function instead of
+        # staying within the action functions. The destination provided as
+        # argument should match the content of the parse table, otherwise this
+        # would imply that the replay action does not encode a transition from
+        # the parse table.
+        state = self.stack[-1].state
+        stv = self.replay.pop()
+        if self.debug:
+            self._dbg_where("(inline-replay: {})".format(repr(stv.term)))
+        goto = self.actions[state].get(stv.term, ERROR)
+        assert goto == dest
+        self.stack.append(StateTermValue(dest, stv.term, stv.value, stv.new_line))
+
     def shift_list(self, stv_list, lexer):
         self.replay.extend(reversed(stv_list))
 


### PR DESCRIPTION
Previously `APS.shift_next` was maintaining the invariant that the state was always the state of the last edge in the shift list, which is emulating the Parser stack.

Now, as we want to remove unnecessary iteration of the `shift` function of the parser, we want to be able to express transitions which are in the parse table by using `Actions` when possible. As a consequence, the state of the parser might momentarily no longer correspond to the last shifted state of the Parser.

This case can happen, when executing an `Unwind` action which is not wrapped with a `Reduce` action, when executing a `Replay` action, when evaluating an action where the state does not already match such as `FilterState`.

However, an assertion is raised if a terminal or non-terminal is shifted while the state does not match the parse table state. This assertion ensures that whatever is being executed with actions converge back to what is represented by the parse table.

Note: The `Unwind` and `Replay` states are modifying the stack, but still are following the edges (`Action.follow_edge`). `reduce_path` (in `aps.py`) attempts to reconstruct any potential Parser stacks. As `Unwind` and `Replay` are ignored from this process as they are redundant with the rest of the ParseTable.

This work is part of #430 and #429 goals, as a way to fold reduce actions, and automatically remove most of the replay actions.