### PR TITLE
Optimize with filter and replay

### DIFF
--- a/jsparagus/actions.py
+++ b/jsparagus/actions.py
@@ -152,6 +152,15 @@ class Action:
         the new indexes"""
         return self
 
+    def fold_by_destination(self, actions: typing.List[Action]) -> typing.List[Action]:
+        """If after rewriting state indexes, multiple condition are reaching the same
+        destination state, we attempt to fold them by destination. Not
+        implementing this function can lead to the introduction of inconsistent
+        states, as the conditions might be redundant. """
+
+        # By default do nothing.
+        return actions
+
     def __eq__(self, other: object) -> bool:
         if self.__class__ != other.__class__:
             return False
@@ -403,6 +412,15 @@ class FilterStates(Action):
     def rewrite_state_indexes(self, state_map: typing.Dict[StateId, StateId]) -> FilterStates:
         states = list(state_map[s] for s in self.states)
         return FilterStates(states)
+
+    def fold_by_destination(self, actions: typing.List[Action]) -> typing.List[Action]:
+        states: typing.List[StateId] = []
+        for a in actions:
+            if not isinstance(a, FilterStates):
+                # Do nothing in case the state is inconsistent.
+                return actions
+            states.extend(a.states)
+        return [FilterStates(states)]
 
     def __str__(self) -> str:
         return "FilterStates({})".format(self.states)

--- a/jsparagus/actions.py
+++ b/jsparagus/actions.py
@@ -200,7 +200,7 @@ class Replay(Action):
     this does not Shift a term given as argument as the replay action should
     always be garanteed and that we want to maximize the sharing of code when
     possible."""
-    __slots__ = ['replay_dest']
+    __slots__ = ['replay_steps']
 
     replay_steps: typing.Tuple[StateId, ...]
 

--- a/jsparagus/aps.py
+++ b/jsparagus/aps.py
@@ -19,13 +19,13 @@ def shifted_path_to(pt: ParseTable, n: int, right_of: Path) -> typing.Iterator[P
     state = right_of[0].src
     assert isinstance(state, int)
     for edge in pt.states[state].backedges:
-        assert pt.term_is_shifted(edge.term)
         if isinstance(edge.term, Action) and edge.term.update_stack():
             # Some Action such as Unwind and Replay are actions which are
             # forking the execution state from the parse stable state.
             # While computing the shifted_path_to, we only iterate over the
             # parse table states.
             continue
+        assert pt.term_is_shifted(edge.term)
         if pt.term_is_stacked(edge.term):
             s_n = n - 1
             if n == 0:

--- a/jsparagus/aps.py
+++ b/jsparagus/aps.py
@@ -32,6 +32,12 @@ def shifted_path_to(pt: ParseTable, n: int, right_of: Path) -> typing.Iterator[P
                 continue
         else:
             s_n = n
+            if n == 0 and not pt.assume_inconsistent:
+                # If the parse table is no longer inconsistent, then there is
+                # no point on walking back on actions as they are expected to
+                # be resolved. Thus we cannot have the restrictions issue that
+                # we have on inconsistent parse tables.
+                continue
         from_edge = Edge(edge.src, edge.term)
         for path in shifted_path_to(pt, s_n, [from_edge] + right_of):
             yield path

--- a/jsparagus/parse_pgen_generated.py
+++ b/jsparagus/parse_pgen_generated.py
@@ -11,6 +11,7 @@ def state_43_actions(parser, lexer):
     replay = [StateTermValue(0, Nt(InitNt(goal=Nt('grammar'))), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
+    state_86_actions(parser, lexer)
     return
 
 def state_44_actions(parser, lexer):
@@ -20,6 +21,7 @@ def state_44_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('nt_defs'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
+    state_84_actions(parser, lexer)
     return
 
 def state_45_actions(parser, lexer):
@@ -29,6 +31,7 @@ def state_45_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('token_defs'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
+    state_85_actions(parser, lexer)
     return
 
 def state_46_actions(parser, lexer):
@@ -38,6 +41,7 @@ def state_46_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('nt_defs'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
+    state_84_actions(parser, lexer)
     return
 
 def state_47_actions(parser, lexer):
@@ -47,6 +51,7 @@ def state_47_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('token_defs'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
+    state_85_actions(parser, lexer)
     return
 
 def state_48_actions(parser, lexer):
@@ -56,6 +61,7 @@ def state_48_actions(parser, lexer):
     replay = [StateTermValue(0, Nt(InitNt(goal=Nt('grammar'))), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
+    state_86_actions(parser, lexer)
     return
 
 def state_49_actions(parser, lexer):
@@ -65,6 +71,7 @@ def state_49_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('nt_def'), value, False)]
     del parser.stack[-4:]
     parser.shift_list(replay, lexer)
+    state_112_actions(parser, lexer)
     return
 
 def state_50_actions(parser, lexer):
@@ -74,6 +81,7 @@ def state_50_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('prods'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
+    state_98_actions(parser, lexer)
     return
 
 def state_51_actions(parser, lexer):
@@ -83,6 +91,7 @@ def state_51_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('terms'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
+    state_101_actions(parser, lexer)
     return
 
 def state_52_actions(parser, lexer):
@@ -92,6 +101,7 @@ def state_52_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('symbol'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
+    state_95_actions(parser, lexer)
     return
 
 def state_53_actions(parser, lexer):
@@ -101,6 +111,7 @@ def state_53_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('symbol'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
+    state_95_actions(parser, lexer)
     return
 
 def state_54_actions(parser, lexer):
@@ -110,6 +121,7 @@ def state_54_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('prods'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
+    state_98_actions(parser, lexer)
     return
 
 def state_55_actions(parser, lexer):
@@ -119,6 +131,7 @@ def state_55_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('token_def'), value, False)]
     del parser.stack[-4:]
     parser.shift_list(replay, lexer)
+    state_104_actions(parser, lexer)
     return
 
 def state_56_actions(parser, lexer):
@@ -128,6 +141,7 @@ def state_56_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('nt_def'), value, False)]
     del parser.stack[-5:]
     parser.shift_list(replay, lexer)
+    state_112_actions(parser, lexer)
     return
 
 def state_57_actions(parser, lexer):
@@ -137,6 +151,7 @@ def state_57_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('prods'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
+    state_98_actions(parser, lexer)
     return
 
 def state_58_actions(parser, lexer):
@@ -146,6 +161,7 @@ def state_58_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('prod'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
+    state_105_actions(parser, lexer)
     return
 
 def state_59_actions(parser, lexer):
@@ -155,6 +171,7 @@ def state_59_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('terms'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
+    state_101_actions(parser, lexer)
     return
 
 def state_60_actions(parser, lexer):
@@ -164,6 +181,7 @@ def state_60_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('term'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
+    state_118_actions(parser, lexer)
     return
 
 def state_61_actions(parser, lexer):
@@ -173,6 +191,7 @@ def state_61_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('nt_def'), value, False)]
     del parser.stack[-5:]
     parser.shift_list(replay, lexer)
+    state_112_actions(parser, lexer)
     return
 
 def state_62_actions(parser, lexer):
@@ -182,6 +201,7 @@ def state_62_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('nt_def'), value, False)]
     del parser.stack[-5:]
     parser.shift_list(replay, lexer)
+    state_112_actions(parser, lexer)
     return
 
 def state_63_actions(parser, lexer):
@@ -191,6 +211,7 @@ def state_63_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('token_def'), value, False)]
     del parser.stack[-5:]
     parser.shift_list(replay, lexer)
+    state_104_actions(parser, lexer)
     return
 
 def state_64_actions(parser, lexer):
@@ -200,6 +221,7 @@ def state_64_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('prod'), value, False)]
     del parser.stack[-3:]
     parser.shift_list(replay, lexer)
+    state_105_actions(parser, lexer)
     return
 
 def state_65_actions(parser, lexer):
@@ -209,6 +231,7 @@ def state_65_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('reducer'), value, False)]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
+    state_106_actions(parser, lexer)
     return
 
 def state_66_actions(parser, lexer):
@@ -218,6 +241,7 @@ def state_66_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('expr'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
+    state_114_actions(parser, lexer)
     return
 
 def state_67_actions(parser, lexer):
@@ -227,6 +251,7 @@ def state_67_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('expr'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
+    state_114_actions(parser, lexer)
     return
 
 def state_68_actions(parser, lexer):
@@ -236,6 +261,7 @@ def state_68_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('nt_def'), value, False)]
     del parser.stack[-6:]
     parser.shift_list(replay, lexer)
+    state_112_actions(parser, lexer)
     return
 
 def state_69_actions(parser, lexer):
@@ -245,6 +271,7 @@ def state_69_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('nt_def'), value, False)]
     del parser.stack[-6:]
     parser.shift_list(replay, lexer)
+    state_112_actions(parser, lexer)
     return
 
 def state_70_actions(parser, lexer):
@@ -254,6 +281,7 @@ def state_70_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('nt_def'), value, False)]
     del parser.stack[-6:]
     parser.shift_list(replay, lexer)
+    state_112_actions(parser, lexer)
     return
 
 def state_71_actions(parser, lexer):
@@ -263,6 +291,7 @@ def state_71_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('nt_def'), value, False)]
     del parser.stack[-7:]
     parser.shift_list(replay, lexer)
+    state_112_actions(parser, lexer)
     return
 
 def state_72_actions(parser, lexer):
@@ -272,6 +301,7 @@ def state_72_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('expr'), value, False)]
     del parser.stack[-3:]
     parser.shift_list(replay, lexer)
+    state_114_actions(parser, lexer)
     return
 
 def state_73_actions(parser, lexer):
@@ -281,6 +311,7 @@ def state_73_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('expr_args'), value, False)]
     del parser.stack[-1:]
     parser.shift_list(replay, lexer)
+    state_115_actions(parser, lexer)
     return
 
 def state_74_actions(parser, lexer):
@@ -290,6 +321,7 @@ def state_74_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('expr'), value, False)]
     del parser.stack[-4:]
     parser.shift_list(replay, lexer)
+    state_114_actions(parser, lexer)
     return
 
 def state_75_actions(parser, lexer):
@@ -299,6 +331,7 @@ def state_75_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('expr'), value, False)]
     del parser.stack[-4:]
     parser.shift_list(replay, lexer)
+    state_114_actions(parser, lexer)
     return
 
 def state_76_actions(parser, lexer):
@@ -308,6 +341,7 @@ def state_76_actions(parser, lexer):
     replay = [StateTermValue(0, Nt('expr_args'), value, False)]
     del parser.stack[-3:]
     parser.shift_list(replay, lexer)
+    state_115_actions(parser, lexer)
     return
 
 def state_77_actions(parser, lexer):
@@ -318,6 +352,7 @@ def state_77_actions(parser, lexer):
     replay = replay + parser.stack[-1:]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
+    state_116_actions(parser, lexer)
     return
 
 def state_78_actions(parser, lexer):
@@ -328,6 +363,7 @@ def state_78_actions(parser, lexer):
     replay = replay + parser.stack[-1:]
     del parser.stack[-3:]
     parser.shift_list(replay, lexer)
+    state_116_actions(parser, lexer)
     return
 
 def state_79_actions(parser, lexer):
@@ -338,180 +374,513 @@ def state_79_actions(parser, lexer):
     replay = replay + parser.stack[-1:]
     del parser.stack[-2:]
     parser.shift_list(replay, lexer)
+    state_118_actions(parser, lexer)
     return
+
+def state_80_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(23)
+    top = parser.stack.pop()
+    top = StateTermValue(23, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_81_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(12)
+    top = parser.stack.pop()
+    top = StateTermValue(12, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_82_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(13)
+    top = parser.stack.pop()
+    top = StateTermValue(13, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_83_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(11)
+    top = parser.stack.pop()
+    top = StateTermValue(11, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_84_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [10]:
+        state_81_actions(parser, lexer)
+        return
+    if parser.top_state() in [11]:
+        state_82_actions(parser, lexer)
+        return
+
+def state_85_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [10]:
+        state_83_actions(parser, lexer)
+        return
+
+def state_86_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [10]:
+        state_80_actions(parser, lexer)
+        return
+
+def state_87_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(44)
+    state_44_actions(parser, lexer)
+    return
+
+def state_88_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(46)
+    state_46_actions(parser, lexer)
+    return
+
+def state_89_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(4)
+    top = parser.stack.pop()
+    top = StateTermValue(4, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_90_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(5)
+    top = parser.stack.pop()
+    top = StateTermValue(5, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_91_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(6)
+    top = parser.stack.pop()
+    top = StateTermValue(6, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_92_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(7)
+    top = parser.stack.pop()
+    top = StateTermValue(7, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_93_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(8)
+    top = parser.stack.pop()
+    top = StateTermValue(8, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_94_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(9)
+    top = parser.stack.pop()
+    top = StateTermValue(9, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_95_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [0, 1, 2, 3, 4, 5, 6, 7, 8]:
+        state_94_actions(parser, lexer)
+        return
+
+def state_96_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(45)
+    state_45_actions(parser, lexer)
+    return
+
+def state_97_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(47)
+    state_47_actions(parser, lexer)
+    return
+
+def state_98_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [0]:
+        state_89_actions(parser, lexer)
+        return
+    if parser.top_state() in [1]:
+        state_90_actions(parser, lexer)
+        return
+    if parser.top_state() in [2]:
+        state_91_actions(parser, lexer)
+        return
+    if parser.top_state() in [3]:
+        state_92_actions(parser, lexer)
+        return
+
+def state_99_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(50)
+    state_50_actions(parser, lexer)
+    return
+
+def state_100_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(57)
+    state_57_actions(parser, lexer)
+    return
+
+def state_101_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [0, 1, 2, 3, 4, 5, 6, 7]:
+        state_93_actions(parser, lexer)
+        return
+
+def state_102_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(51)
+    state_51_actions(parser, lexer)
+    return
+
+def state_103_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(59)
+    state_59_actions(parser, lexer)
+    return
+
+def state_104_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [10]:
+        state_96_actions(parser, lexer)
+        return
+    if parser.top_state() in [11]:
+        state_97_actions(parser, lexer)
+        return
+
+def state_105_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [0, 1, 2, 3]:
+        state_99_actions(parser, lexer)
+        return
+    if parser.top_state() in [4, 5, 6, 7]:
+        state_100_actions(parser, lexer)
+        return
+
+def state_106_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [8]:
+        state_107_actions(parser, lexer)
+        return
+
+def state_107_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(38)
+    top = parser.stack.pop()
+    top = StateTermValue(38, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_108_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(65)
+    state_65_actions(parser, lexer)
+    return
+
+def state_109_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(73)
+    state_73_actions(parser, lexer)
+    return
+
+def state_110_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(42)
+    top = parser.stack.pop()
+    top = StateTermValue(42, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_111_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(76)
+    state_76_actions(parser, lexer)
+    return
+
+def state_112_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [10, 11]:
+        state_87_actions(parser, lexer)
+        return
+    if parser.top_state() in [12, 13]:
+        state_88_actions(parser, lexer)
+        return
+
+def state_113_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(41)
+    top = parser.stack.pop()
+    top = StateTermValue(41, top.term, top.value, top.new_line)
+    parser.stack.append(top)
+    return
+
+def state_114_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [15]:
+        state_108_actions(parser, lexer)
+        return
+    if parser.top_state() in [14]:
+        state_109_actions(parser, lexer)
+        return
+    if parser.top_state() in [16]:
+        state_110_actions(parser, lexer)
+        return
+    if parser.top_state() in [17]:
+        state_111_actions(parser, lexer)
+        return
+
+def state_115_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [14]:
+        state_113_actions(parser, lexer)
+        return
+
+def state_116_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [10]:
+        state_117_actions(parser, lexer)
+        return
+
+def state_117_actions(parser, lexer):
+
+    value = None
+    parser.replay_action(43)
+    state_43_actions(parser, lexer)
+    return
+
+def state_118_actions(parser, lexer):
+
+    value = None
+    if parser.top_state() in [0, 1, 2, 3, 4, 5, 6, 7]:
+        state_102_actions(parser, lexer)
+        return
+    if parser.top_state() in [8]:
+        state_103_actions(parser, lexer)
+        return
 
 actions = [
     # 0.
 
-    {'nt': 2, 'COMMENT': 3, 'goal': 4, 'token': 6, 'var': 7, Nt('grammar'): 43, Nt('nt_defs'): 1, Nt('nt_def'): 44, Nt('token_defs'): 5, Nt('token_def'): 45, Nt(InitNt(goal=Nt('grammar'))): 8},
+    {'}': 49, 'IDENT': 52, 'STR': 53, 'COMMENT': 54, Nt('prods'): 4, Nt('prod'): 50, Nt('terms'): 8, Nt('term'): 51, Nt('symbol'): 9},
 
     # 1.
 
-    {End(): 77, 'goal': 4, 'COMMENT': 3, 'nt': 2, Nt('nt_def'): 46},
+    {'}': 61, 'IDENT': 52, 'STR': 53, 'COMMENT': 54, Nt('prods'): 5, Nt('prod'): 50, Nt('terms'): 8, Nt('term'): 51, Nt('symbol'): 9},
 
     # 2.
 
-    {'IDENT': 10},
+    {'}': 62, 'IDENT': 52, 'STR': 53, 'COMMENT': 54, Nt('prods'): 6, Nt('prod'): 50, Nt('terms'): 8, Nt('term'): 51, Nt('symbol'): 9},
 
     # 3.
 
-    {'nt': 11, 'goal': 12},
+    {'}': 69, 'IDENT': 52, 'STR': 53, 'COMMENT': 54, Nt('prods'): 7, Nt('prod'): 50, Nt('terms'): 8, Nt('term'): 51, Nt('symbol'): 9},
 
     # 4.
 
-    {'nt': 13},
+    {'}': 56, 'IDENT': 52, 'STR': 53, Nt('prod'): 57, Nt('terms'): 8, Nt('term'): 51, Nt('symbol'): 9},
 
     # 5.
 
-    {'nt': 2, 'COMMENT': 3, 'goal': 4, 'token': 6, 'var': 7, Nt('nt_defs'): 14, Nt('nt_def'): 44, Nt('token_def'): 47},
+    {'}': 68, 'IDENT': 52, 'STR': 53, Nt('prod'): 57, Nt('terms'): 8, Nt('term'): 51, Nt('symbol'): 9},
 
     # 6.
 
-    {'IDENT': 15},
+    {'}': 70, 'IDENT': 52, 'STR': 53, Nt('prod'): 57, Nt('terms'): 8, Nt('term'): 51, Nt('symbol'): 9},
 
     # 7.
 
-    {'token': 16},
+    {'}': 71, 'IDENT': 52, 'STR': 53, Nt('prod'): 57, Nt('terms'): 8, Nt('term'): 51, Nt('symbol'): 9},
 
     # 8.
 
-    {End(): 48},
+    {';': 58, 'IDENT': 52, 'STR': 53, '=>': 15, Nt('term'): 59, Nt('symbol'): 9, Nt('reducer'): 38},
 
     # 9.
 
-    {},
+    {'=>': 79, 'STR': 79, 'IDENT': 79, ';': 79, '?': 60, Nt('reducer'): 79, Nt('symbol'): 79, Nt('term'): 79},
 
     # 10.
 
-    {'{': 17},
+    {'nt': 18, 'COMMENT': 19, 'goal': 20, 'token': 21, 'var': 22, Nt('grammar'): 43, Nt('nt_defs'): 12, Nt('nt_def'): 44, Nt('token_defs'): 11, Nt('token_def'): 45, Nt(InitNt(goal=Nt('grammar'))): 23},
 
     # 11.
 
-    {'IDENT': 18},
+    {'nt': 18, 'COMMENT': 19, 'goal': 20, 'token': 21, 'var': 22, Nt('nt_defs'): 13, Nt('nt_def'): 44, Nt('token_def'): 47},
 
     # 12.
 
-    {'nt': 19},
+    {End(): 77, 'goal': 20, 'COMMENT': 19, 'nt': 18, Nt('nt_def'): 46},
 
     # 13.
 
-    {'IDENT': 20},
+    {End(): 78, 'goal': 20, 'COMMENT': 19, 'nt': 18, Nt('nt_def'): 46},
 
     # 14.
 
-    {End(): 78, 'goal': 4, 'COMMENT': 3, 'nt': 2, Nt('nt_def'): 46},
+    {')': 72, 'MATCH': 66, 'IDENT': 39, 'Some': 40, 'None': 67, Nt('expr_args'): 41, Nt('expr'): 73},
 
     # 15.
 
-    {'=': 21},
+    {'MATCH': 66, 'IDENT': 39, 'Some': 40, 'None': 67, Nt('expr'): 65},
 
     # 16.
 
-    {'IDENT': 22},
+    {'MATCH': 66, 'IDENT': 39, 'Some': 40, 'None': 67, Nt('expr'): 42},
 
     # 17.
 
-    {'}': 49, 'IDENT': 52, 'STR': 53, 'COMMENT': 54, Nt('prods'): 23, Nt('prod'): 50, Nt('terms'): 24, Nt('term'): 51, Nt('symbol'): 25},
+    {'MATCH': 66, 'IDENT': 39, 'Some': 40, 'None': 67, Nt('expr'): 76},
 
     # 18.
 
-    {'{': 26},
+    {'IDENT': 25},
 
     # 19.
 
-    {'IDENT': 27},
+    {'nt': 26, 'goal': 27},
 
     # 20.
 
-    {'{': 28},
+    {'nt': 28},
 
     # 21.
 
-    {'STR': 29},
+    {'IDENT': 29},
 
     # 22.
 
-    {';': 55},
+    {'token': 30},
 
     # 23.
 
-    {'}': 56, 'IDENT': 52, 'STR': 53, Nt('prod'): 57, Nt('terms'): 24, Nt('term'): 51, Nt('symbol'): 25},
+    {End(): 48},
 
     # 24.
 
-    {';': 58, 'IDENT': 52, 'STR': 53, '=>': 31, Nt('term'): 59, Nt('symbol'): 25, Nt('reducer'): 30},
+    {},
 
     # 25.
 
-    {'=>': 79, 'STR': 79, 'IDENT': 79, ';': 79, '?': 60, Nt('reducer'): 79, Nt('symbol'): 79, Nt('term'): 79},
+    {'{': 0},
 
     # 26.
 
-    {'}': 61, 'IDENT': 52, 'STR': 53, 'COMMENT': 54, Nt('prods'): 32, Nt('prod'): 50, Nt('terms'): 24, Nt('term'): 51, Nt('symbol'): 25},
+    {'IDENT': 31},
 
     # 27.
 
-    {'{': 33},
+    {'nt': 32},
 
     # 28.
 
-    {'}': 62, 'IDENT': 52, 'STR': 53, 'COMMENT': 54, Nt('prods'): 34, Nt('prod'): 50, Nt('terms'): 24, Nt('term'): 51, Nt('symbol'): 25},
+    {'IDENT': 33},
 
     # 29.
 
-    {';': 63},
+    {'=': 34},
 
     # 30.
 
-    {';': 64},
+    {'IDENT': 35},
 
     # 31.
 
-    {'MATCH': 66, 'IDENT': 35, 'Some': 36, 'None': 67, Nt('expr'): 65},
+    {'{': 1},
 
     # 32.
 
-    {'}': 68, 'IDENT': 52, 'STR': 53, Nt('prod'): 57, Nt('terms'): 24, Nt('term'): 51, Nt('symbol'): 25},
+    {'IDENT': 36},
 
     # 33.
 
-    {'}': 69, 'IDENT': 52, 'STR': 53, 'COMMENT': 54, Nt('prods'): 37, Nt('prod'): 50, Nt('terms'): 24, Nt('term'): 51, Nt('symbol'): 25},
+    {'{': 2},
 
     # 34.
 
-    {'}': 70, 'IDENT': 52, 'STR': 53, Nt('prod'): 57, Nt('terms'): 24, Nt('term'): 51, Nt('symbol'): 25},
+    {'STR': 37},
 
     # 35.
 
-    {'(': 38},
+    {';': 55},
 
     # 36.
 
-    {'(': 39},
+    {'{': 3},
 
     # 37.
 
-    {'}': 71, 'IDENT': 52, 'STR': 53, Nt('prod'): 57, Nt('terms'): 24, Nt('term'): 51, Nt('symbol'): 25},
+    {';': 63},
 
     # 38.
 
-    {')': 72, 'MATCH': 66, 'IDENT': 35, 'Some': 36, 'None': 67, Nt('expr_args'): 40, Nt('expr'): 73},
+    {';': 64},
 
     # 39.
 
-    {'MATCH': 66, 'IDENT': 35, 'Some': 36, 'None': 67, Nt('expr'): 41},
+    {'(': 14},
 
     # 40.
 
-    {')': 74, ',': 42},
+    {'(': 16},
 
     # 41.
 
-    {')': 75},
+    {')': 74, ',': 17},
 
     # 42.
 
-    {'MATCH': 66, 'IDENT': 35, 'Some': 36, 'None': 67, Nt('expr'): 76},
+    {')': 75},
 
     # 43.
 
@@ -661,6 +1030,162 @@ actions = [
 
     state_79_actions,
 
+    # 80.
+
+    state_80_actions,
+
+    # 81.
+
+    state_81_actions,
+
+    # 82.
+
+    state_82_actions,
+
+    # 83.
+
+    state_83_actions,
+
+    # 84.
+
+    state_84_actions,
+
+    # 85.
+
+    state_85_actions,
+
+    # 86.
+
+    state_86_actions,
+
+    # 87.
+
+    state_87_actions,
+
+    # 88.
+
+    state_88_actions,
+
+    # 89.
+
+    state_89_actions,
+
+    # 90.
+
+    state_90_actions,
+
+    # 91.
+
+    state_91_actions,
+
+    # 92.
+
+    state_92_actions,
+
+    # 93.
+
+    state_93_actions,
+
+    # 94.
+
+    state_94_actions,
+
+    # 95.
+
+    state_95_actions,
+
+    # 96.
+
+    state_96_actions,
+
+    # 97.
+
+    state_97_actions,
+
+    # 98.
+
+    state_98_actions,
+
+    # 99.
+
+    state_99_actions,
+
+    # 100.
+
+    state_100_actions,
+
+    # 101.
+
+    state_101_actions,
+
+    # 102.
+
+    state_102_actions,
+
+    # 103.
+
+    state_103_actions,
+
+    # 104.
+
+    state_104_actions,
+
+    # 105.
+
+    state_105_actions,
+
+    # 106.
+
+    state_106_actions,
+
+    # 107.
+
+    state_107_actions,
+
+    # 108.
+
+    state_108_actions,
+
+    # 109.
+
+    state_109_actions,
+
+    # 110.
+
+    state_110_actions,
+
+    # 111.
+
+    state_111_actions,
+
+    # 112.
+
+    state_112_actions,
+
+    # 113.
+
+    state_113_actions,
+
+    # 114.
+
+    state_114_actions,
+
+    # 115.
+
+    state_115_actions,
+
+    # 116.
+
+    state_116_actions,
+
+    # 117.
+
+    state_117_actions,
+
+    # 118.
+
+    state_118_actions,
+
 ]
 
 error_codes = [
@@ -669,9 +1194,12 @@ error_codes = [
     None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
     None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
     None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None,
 ]
 
-goal_nt_to_init_state = {'grammar': 0}
+goal_nt_to_init_state = {'grammar': 10}
 
 class DefaultMethods:
     def nt_defs_single(self, x0):

--- a/jsparagus/parse_table.py
+++ b/jsparagus/parse_table.py
@@ -11,7 +11,7 @@ import itertools
 from . import types
 from .utils import consume, keep_until, split
 from .ordered import OrderedSet, OrderedFrozenSet
-from .actions import Action, FilterFlag
+from .actions import Action, Replay, Reduce, FilterStates, Seq
 from .grammar import End, ErrorSymbol, InitNt, Nt
 from .rewrites import CanonicalGrammar
 from .lr0 import LR0Generator, Term
@@ -19,6 +19,9 @@ from .aps import APS, Edge, Path
 
 # StateAndTransitions objects are indexed using a StateId which is an integer.
 StateId = int
+
+# Action or ordered sequence of action which have to be performed.
+DelayedAction = typing.Union[Action, typing.Tuple[Action, ...]]
 
 
 class StateAndTransitions:
@@ -41,6 +44,10 @@ class StateAndTransitions:
     # i.e. how we got to this state.
     locations: OrderedFrozenSet[str]
 
+    # Ordered set of Actions which are pushed to the next state after a
+    # conflict.
+    delayed_actions: OrderedFrozenSet[DelayedAction]
+
     # Outgoing edges taken when shifting terminals.
     terminals: typing.Dict[str, StateId]
 
@@ -52,10 +59,6 @@ class StateAndTransitions:
 
     # List of epsilon transitions with associated actions.
     epsilon: typing.List[typing.Tuple[Action, StateId]]
-
-    # Ordered set of Actions which are pushed to the next state after a
-    # conflict.
-    delayed_actions: OrderedFrozenSet[Action]
 
     # Set of edges that lead to this state.
     backedges: OrderedSet[Edge]
@@ -73,7 +76,7 @@ class StateAndTransitions:
             self,
             index: StateId,
             locations: OrderedFrozenSet[str],
-            delayed_actions: OrderedFrozenSet[Action] = OrderedFrozenSet()
+            delayed_actions: OrderedFrozenSet[DelayedAction] = OrderedFrozenSet()
     ) -> None:
         assert isinstance(locations, OrderedFrozenSet)
         assert isinstance(delayed_actions, OrderedFrozenSet)
@@ -351,10 +354,15 @@ class ParseTable:
         # Optimize by removing unused states.
         self.remove_all_unreachable_state(verbose, progress)
         # TODO: Statically compute replayed terms. (maybe?)
+        # Replace reduce actions by programmatic stack manipulation.
+        self.remove_reduce(verbose, progress)
         # Fold paths which have the same ending.
         self.fold_identical_endings(verbose, progress)
+        # Group state with similar non-terminal edges close-by, to improve the
+        # generated Rust code by grouping matched state numbers.
+        self.group_nonterminal_states(verbose, progress)
         # Split shift states from epsilon states.
-        self.group_epsilon_states(verbose, progress)
+        # self.group_epsilon_states(verbose, progress)
 
     def save(self, filename: os.PathLike) -> None:
         with open(filename, 'wb') as f:
@@ -397,7 +405,7 @@ class ParseTable:
     def new_state(
             self,
             locations: OrderedFrozenSet[str],
-            delayed_actions: OrderedFrozenSet[Action] = OrderedFrozenSet()
+            delayed_actions: OrderedFrozenSet[DelayedAction] = OrderedFrozenSet()
     ) -> typing.Tuple[bool, StateAndTransitions]:
         """Get or create state with an LR0 location and delayed actions. Returns a tuple
         where the first element is whether the element is newly created, and
@@ -414,7 +422,7 @@ class ParseTable:
     def get_state(
             self,
             locations: OrderedFrozenSet[str],
-            delayed_actions: OrderedFrozenSet[Action] = OrderedFrozenSet()
+            delayed_actions: OrderedFrozenSet[DelayedAction] = OrderedFrozenSet()
     ) -> StateAndTransitions:
         """Like new_state(), but only returns the state without returning whether it is
         newly created or not."""
@@ -1126,7 +1134,7 @@ class ParseTable:
                 # Compute the unique name, based on the locations and actions
                 # which are delayed.
                 locations: OrderedSet[str] = OrderedSet()
-                delayed: OrderedSet[Action] = OrderedSet()
+                delayed: OrderedSet[DelayedAction] = OrderedSet()
                 new_shift_map: typing.DefaultDict[
                     Term,
                     typing.List[typing.Tuple[StateAndTransitions, typing.List[Edge]]]
@@ -1314,6 +1322,138 @@ class ParseTable:
         self.states = [s for s in self.states if s is not None]
         self.rewrite_reordered_state_indexes()
 
+    def remove_reduce(self, verbose: bool, progress: bool) -> None:
+        # Remove Reduce actions and replace them by the programmatic
+        # equivalent.
+        #
+        # This transformation preserves the stack manipulations of the parse
+        # table. It only changes it from being implicitly executed by the shift
+        # function of the LR parser, by being executed as an action.
+        #
+        # This transformation converts the hard-to-predict load of the shift
+        # table into a branch prediction which is potentially easier to
+        # predict.
+        #
+        # A side-effect of this transformation is that it removes the need for
+        # replaying non-terminals, thus the backends could safely ignore the
+        # ability of the shift function from handling non-terminals.
+        if verbose or progress:
+            print("Remove Reduce actions.")
+
+        maybe_unreachable_set: OrderedSet[StateId] = OrderedSet()
+
+        def transform() -> typing.Iterator[None]:
+            for s in self.states:
+                term, _ = next(iter(s.epsilon), (None, None))
+                if self.term_is_shifted(term):
+                    continue
+                assert len(s.epsilon) == 1
+                yield  # progress bar.
+                reduce_state = s
+                if verbose:
+                    print("Inlining shift-operation for state {}".format(str(reduce_state)))
+
+                # The reduced_aps should contain all reduced path of the single
+                # Reduce action which is present on this state. However, as
+                # state of the graph are shared, some reduced paths might follow
+                # the same path and reach the same state.
+                #
+                # This code collect for each replayed path, the tops of the
+                # stack on top of which these states are replayed.
+                aps = APS.start(s.index)
+                states_by_replay_term = collections.defaultdict(list)
+                # print("Start:\n{}".format(aps.string(name="\titer_aps")))
+                # print(s.stable_str(self.states))
+                for reduced_aps in aps.shift_next(self):
+                    # As long as we have elements to replay, we should only
+                    # have a single path for each reduced path. If the next
+                    # state contains an action, then we stop here.
+                    iter_aps = reduced_aps
+                    next_is_action = self.states[iter_aps.state].epsilon != []
+                    has_replay = iter_aps.replay != []
+                    assert next_is_action is False and has_replay is True
+                    while (not next_is_action) and has_replay:
+                        # print("Step {}:\n{}".format(len(iter_aps.history),
+                        #                             iter_aps.string(name="\titer_aps")))
+                        next_aps = list(iter_aps.shift_next(self))
+                        if len(next_aps) == 0:
+                            # Note, this might happen as we are adding
+                            # lookahead tokens from any successor, we might not
+                            # always have a way to replay all tokens, in such
+                            # case an error should be produced, but in the mean
+                            # time, let's use the shift function as usual.
+                            break
+                        assert len(next_aps) == 1
+                        iter_aps = next_aps[0]
+                        next_is_action = self.states[iter_aps.state].epsilon != []
+                        has_replay = iter_aps.replay != []
+                    # print("End at {}:\n{}".format(len(iter_aps.history),
+                    #                               iter_aps.string(name="\titer_aps")))
+                    replay_list = list(map(lambda e: e.src, iter_aps.shift))
+                    assert len(replay_list) >= 2
+                    replay_term = Replay(replay_list[1:])
+                    states_by_replay_term[replay_term].append(replay_list[0])
+
+                # Create FilterStates actions.
+                filter_by_replay_term = {
+                    replay_term: FilterStates(states)
+                    for replay_term, states in states_by_replay_term.items()
+                }
+
+                # Convert the Reduce action to an Unwind action.
+                reduce_term, _ = next(iter(s.epsilon))
+                if isinstance(reduce_term, Reduce):
+                    unwind_term: Action = reduce_term.unwind
+                else:
+                    assert isinstance(reduce_term, Seq)
+                    assert isinstance(reduce_term.actions[-1], Reduce)
+                    unwind_term = Seq(list(reduce_term.actions[:-1]) + [reduce_term.actions[-1].unwind])
+
+                # Remove the old Reduce edge if still present.
+                # print("Before:\n{}".format(reduce_state.stable_str(self.states)))
+                self.remove_edge(reduce_state, reduce_term, maybe_unreachable_set)
+
+                # Add Unwind action.
+                # print("After:\n")
+                locations = OrderedFrozenSet(reduce_state.locations)
+                delayed: OrderedFrozenSet[DelayedAction] = OrderedFrozenSet(filter_by_replay_term.items())
+                is_new, filter_state = self.new_state(locations, delayed)
+                self.add_edge(reduce_state, unwind_term, filter_state.index)
+                if not is_new:
+                    for replay_term, filter_term in filter_by_replay_term.items():
+                        assert filter_term in filter_state
+                        replay_state = self.states[filter_state[filter_term]]
+                        assert replay_term in replay_state
+                        # print(replay_state.stable_str(self.states))
+                    # print(filter_state.stable_str(self.states))
+                    # print(reduce_state.stable_str(self.states))
+                    continue
+
+                for replay_term, filter_term in filter_by_replay_term.items():
+                    dest_idx = replay_term.replay_steps[-1]
+                    dest = self.states[dest_idx]
+
+                    # Add FilterStates action from the filter_state to the replay_state.
+                    locations = OrderedFrozenSet(dest.locations)
+                    delayed = OrderedFrozenSet(itertools.chain(dest.delayed_actions, [replay_term]))
+                    is_new, replay_state = self.new_state(locations, delayed)
+                    self.add_edge(filter_state, filter_term, replay_state.index)
+                    assert (not is_new) == (replay_term in replay_state)
+
+                    # Add Replay actions from the replay_state to the destination.
+                    if is_new:
+                        dest_idx = replay_term.replay_steps[-1]
+                        self.add_edge(replay_state, replay_term, dest_idx)
+                    # print(replay_state.stable_str(self.states))
+                    assert not replay_state.is_inconsistent()
+
+                # print(filter_state.stable_str(self.states))
+                # print(reduce_state.stable_str(self.states))
+                assert not reduce_state.is_inconsistent()
+                assert not filter_state.is_inconsistent()
+
+        consume(transform(), progress)
+
     def fold_identical_endings(self, verbose: bool, progress: bool) -> None:
         # If 2 states have the same outgoing edges, then we can merge the 2
         # states into a single state, and rewrite all the backedges leading to
@@ -1376,6 +1516,28 @@ class ParseTable:
         self.states.extend(shift_states)
         self.states.extend(from_shf_action_states)
         self.states.extend(from_act_action_states)
+        self.rewrite_reordered_state_indexes()
+
+    def group_nonterminal_states(self, verbose: bool, progress: bool) -> None:
+        # This function is used to reduce the range of FilterStates values,
+        # such that the Rust compiler can compile FilterStates match statements
+        # to a table-switch.
+        freq_count = collections.Counter(nt for s in self.states for nt in s.nonterminals)
+        freq_nt, _ = zip(*freq_count.most_common())
+
+        def state_value(s: StateAndTransitions) -> float:
+            value = 0.0
+            i = 1.0
+            if len(s.epsilon) != 0:
+                return 2.0
+            if len(s.nonterminals) == 0:
+                return 1.0
+            for nt in freq_nt:
+                if nt in s:
+                    value += i
+                i /= 2.0
+            return -value
+        self.states.sort(key=state_value)
         self.rewrite_reordered_state_indexes()
 
     def count_shift_states(self) -> int:

--- a/jsparagus/parse_table.py
+++ b/jsparagus/parse_table.py
@@ -654,7 +654,7 @@ class ParseTable:
             self.debug_dump()
 
     def term_is_shifted(self, term: typing.Optional[Term]) -> bool:
-        return not (isinstance(term, Action) and term.update_stack())
+        return not isinstance(term, Action) or term.follow_edge()
 
     def is_valid_path(
             self,


### PR DESCRIPTION
This is the final patch which introduces usage of `FilterState` and `Replay`, fixing #430 . This change mainly adds the phase which replaces the `Reduce` operations by `Unwind`, `FilterState` and `Replay` actions.

Still this is not the final set of changes as more optimization are coming after, but are simply ParseTable optimization, made by folding state together or abstract the replay queue as state arguments, allowing to generate code which executes faster.

