### PR TITLE
Add more function-related fields 

### DIFF
--- a/crates/stencil/src/scope.rs
+++ b/crates/stencil/src/scope.rs
@@ -453,10 +453,10 @@ pub struct FunctionScopeData {
     /// use Vec of Option<BindingName>, instead of BindingName like others.
     pub base: BaseScopeData<Option<BindingName>>,
 
-    has_parameter_exprs: bool,
+    pub has_parameter_exprs: bool,
 
-    non_positional_formal_start: usize,
-    var_start: usize,
+    pub non_positional_formal_start: usize,
+    pub var_start: usize,
 
     /// The first frame slot of this scope.
     ///

--- a/crates/stencil/src/scope.rs
+++ b/crates/stencil/src/scope.rs
@@ -471,6 +471,8 @@ pub struct FunctionScopeData {
     ///
     /// A parameter for ScopeCreationData::create.
     pub enclosing: ScopeIndex,
+
+    pub function_index: ScriptStencilIndex,
 }
 
 impl FunctionScopeData {
@@ -480,6 +482,7 @@ impl FunctionScopeData {
         non_positional_formal_start: usize,
         max_var_count: usize,
         enclosing: ScopeIndex,
+        function_index: ScriptStencilIndex,
     ) -> Self {
         let capacity = positional_parameter_count + non_positional_formal_start + max_var_count;
 
@@ -491,6 +494,7 @@ impl FunctionScopeData {
             // Set to the correct value in EmitterScopeStack::enter_function.
             first_frame_slot: FrameSlot::new(0),
             enclosing,
+            function_index,
         }
     }
 }

--- a/crates/stencil/src/script.rs
+++ b/crates/stencil/src/script.rs
@@ -3,6 +3,7 @@
 use crate::frame_slot::FrameSlot;
 use crate::function::FunctionFlags;
 use crate::gcthings::GCThing;
+use crate::scope::ScopeIndex;
 use crate::scope_notes::ScopeNote;
 use ast::source_atom_set::SourceAtomSetIndex;
 
@@ -262,6 +263,8 @@ pub struct ScriptStencil {
     pub fun_name: Option<SourceAtomSetIndex>,
     pub fun_nargs: u16,
     pub fun_flags: FunctionFlags,
+
+    pub lazy_function_enclosing_scope_index: Option<ScopeIndex>,
 }
 
 impl ScriptStencil {
@@ -278,6 +281,7 @@ impl ScriptStencil {
             fun_name: None,
             fun_nargs: 0,
             fun_flags: FunctionFlags::empty(),
+            lazy_function_enclosing_scope_index: None,
         }
     }
 
@@ -287,6 +291,7 @@ impl ScriptStencil {
         is_generator: bool,
         is_async: bool,
         fun_flags: FunctionFlags,
+        lazy_function_enclosing_scope_index: ScopeIndex,
     ) -> Self {
         let mut flags = ImmutableScriptFlagsEnum::IsFunction as u32;
         if is_generator {
@@ -304,6 +309,7 @@ impl ScriptStencil {
             fun_name,
             fun_nargs: 0,
             fun_flags,
+            lazy_function_enclosing_scope_index: Some(lazy_function_enclosing_scope_index),
         }
     }
 


### PR DESCRIPTION
 * Lazy Function needs enclosing scope information, so stored it into `ScriptStencil`
 * Also made `FunctionScopeData` fields public
 * Also stored Function's `ScriptStencilIndex` (`FunctionIndex` in m-c side) in `FunctionScopeData`