### PR TITLE
 Add smoosh_tools bench command.

### DIFF
--- a/benchmarks/compare-spidermonkey-parsers.js
+++ b/benchmarks/compare-spidermonkey-parsers.js
@@ -1,0 +1,255 @@
+// This script runs multipe parsers from a single engine.
+"use strict";
+
+// Directory where to find the list of JavaScript sources to be used for
+// benchmarking.
+var dir = ".";
+if (scriptArgs && scriptArgs[0]) {
+    // If an argument is given on the command line, assume this is the path to
+    // one of real-js-samples directory containing thousabds of JS files,
+    // otherwise this is assumed to be the current working directory.
+    dir = scriptArgs[0]; //  "~/real-js-samples/20190416"
+}
+
+// Execution mode of the parser, either "script" or "module".
+var mode = "script";
+
+// Number of times each JavaScript source is used for benchmarking.
+var runs_per_script = 10;
+
+// First parser
+var name_1 = "SpiderMonkey parser";
+function parse_1(path) {
+    var start = performance.now();
+    parse(path, { module: mode == "module", smoosh: false });
+    return performance.now() - start;
+}
+
+// Second parser
+var name_2 = "SmooshMonkey parser";
+function parse_2(path) {
+    var start = performance.now();
+    parse(path, { module: mode == "module", smoosh: true });
+    return performance.now() - start;
+}
+
+// For a given `parse` function, execute it with the content of each file in
+// `dir`. This process is repeated `N` times and the results are added to the
+// `result` argument using the `prefix` key for the filenames.
+function for_all_files(parse, N = 1, prefix = "", result = {}) {
+    var path = "", content = "";
+    var t = 0;
+    var list = os.file.listDir(dir);
+    for (var file of list) {
+        try {
+            path = os.path.join(dir, file);
+            content = os.file.readRelativeToScript(path);
+            try {
+                t = 0;
+                for (var n = 0; n < N; n++)
+                    t += parse(content);
+                result[prefix + path] = { time: t / N, bytes: content.length };
+            } catch (e) {
+                // ignore all errors for now.
+                result[prefix + path] = { time: null, bytes: content.length };
+            }
+        } catch (e) {
+            // ignore all read errors.
+        }
+    }
+    return result;
+}
+
+// Compare the results of 2 parser runs and compute the speed ratio between the
+// 2 parsers. Results from both parsers are assuming to be comparing the same
+// things if they have the same property name.
+//
+// The aggregated results is returned as an object, which reports the total time
+// for each parser, the quantity of bytes parsed and skipped and an array of
+// speed ratios for each file tested.
+function compare(res1, res2) {
+    var result = {
+        time1: 0,
+        time2: 0,
+        parsed_files: 0,
+        parsed_bytes: 0,
+        skipped_files: 0,
+        skipped_bytes: 0,
+        ratios_2over1: [],
+    };
+    for (var path of Object.keys(res1)) {
+        if (!(path in res1 && path in res2)) {
+            continue;
+        }
+        var p1 = res1[path];
+        var p2 = res2[path];
+        if (p1.time !== null && p2.time !== null) {
+            result.time1 += p1.time;
+            result.time2 += p2.time;
+            result.parsed_files += 1;
+            result.parsed_bytes += p1.bytes;
+            result.ratios_2over1.push(p2.time / p1.time);
+        } else {
+            result.skipped_files += 1;
+            result.skipped_bytes += p1.bytes;
+        }
+    }
+    return result;
+}
+
+// Given a `table` of speed ratios, display a distribution chart of speed
+// ratios. This is useful to check if the data is noisy, bimodal, and to easily
+// eye-ball characteristics of the distribution.
+function spread(table, min, max, step) {
+    // var chars = ["\xa0", "\u2591", "\u2592", "\u2593", "\u2588"];
+    var chars = ["\xa0", "\u2581", "\u2582", "\u2583", "\u2584", "\u2585", "\u2586", "\u2587", "\u2588"];
+    var s = ["\xa0", "\xa0", "" + min, "\xa0", "\xa0"];
+    var ending = ["\xa0", "\xa0", "" + max, "\xa0", "\xa0"];
+    var ranges = [];
+    var vmax = table.length / 10;
+    for (var i = min; i < max; i += step) {
+        ranges.push(0);
+    }
+    for (var x of table) {
+        if (x < min || max < x) continue;
+        var idx = ((x - min) / step)|0;
+        ranges[idx] += 1;
+    }
+    var max_index = chars.length * s.length;
+    var ratio = max_index / vmax;
+    for (i = 0; i < s.length; i++)
+        s[i] += "\xa0\u2595";
+    for (var v of ranges) {
+        var d = Math.min((v * ratio)|0, max_index - 1);
+        var offset = max_index;
+        for (i = 0; i < s.length; i++) {
+            offset -= chars.length;
+            var c = Math.max(0, Math.min(d - offset, chars.length - 1));
+            s[i] += chars[c];
+        }
+    }
+    for (i = 0; i < s.length; i++)
+        s[i] += "\u258f\xa0" + ending[i];
+    var res = "";
+    for (i = 0; i < s.length; i++)
+        res += "\n" + s[i];
+    return res;
+}
+
+// NOTE: We have multiple strategies depending whether we want to check the
+// throughput of the parser assuming the parser is cold/hot in memory, the data is
+// cold/hot in the cache, and the adaptive CPU throttle is low/high.
+//
+// Ideally we should be comparing comparable things, but due to the adaptive
+// behavior of CPU and Disk, we can only approximate it while keeping results
+// comparable to what users might see.
+
+// Compare Hot-parsers on cold data.
+function strategy_1() {
+    var res1 = for_all_files(parse_1, runs_per_script);
+    var res2 = for_all_files(parse_2, runs_per_script);
+    var result = compare(res1, res2);
+    print(name_1, "\t", result.time1, "ms\t", 1e6 * result.time1 / result.parsed_bytes, 'ns/byte\t', result.parsed_bytes / (1e6 * result.time1), 'bytes/ns\t');
+    print(name_2, "\t", result.time2, "ms\t", 1e6 * result.time2 / result.parsed_bytes, 'ns/byte\t', result.parsed_bytes / (1e6 * result.time2), 'bytes/ns\t');
+    print("Total parsed  (scripts:", result.parsed_files, ", bytes:", result.parsed_bytes, ")");
+    print("Total skipped (scripts:", result.skipped_files, ", bytes:", result.skipped_bytes, ")");
+    print(name_2, "/", name_1, ":", result.time2 / result.time1);
+    print(name_2, "/", name_1, ":", spread(result.ratios_2over1, 0, 3, 0.05));
+}
+
+// Compare Hot-parsers on cold data, and swap parse order.
+function strategy_2() {
+    var res2 = for_all_files(parse_2, runs_per_script);
+    var res1 = for_all_files(parse_1, runs_per_script);
+    var result = compare(res1, res2);
+    print(name_1, "\t", result.time1, "ms\t", 1e6 * result.time1 / result.parsed_bytes, 'ns/byte\t', result.parsed_bytes / (1e6 * result.time1), 'bytes/ns\t');
+    print(name_2, "\t", result.time2, "ms\t", 1e6 * result.time2 / result.parsed_bytes, 'ns/byte\t', result.parsed_bytes / (1e6 * result.time2), 'bytes/ns\t');
+    print("Total parsed  (scripts:", result.parsed_files, ", bytes:", result.parsed_bytes, ")");
+    print("Total skipped (scripts:", result.skipped_files, ", bytes:", result.skipped_bytes, ")");
+    print(name_2, "/", name_1, ":", result.time2 / result.time1);
+    print(name_2, "/", name_1, ":", spread(result.ratios_2over1, 0, 3, 0.05));
+}
+
+// Interleaves N hot-parser results. (if N=1, then strategy_3 is identical to strategy_1)
+//
+// At the moment, this is assumed to be the best approach which might mimic how
+// a helper-thread would behave if it was saturated with content to be parsed.
+function strategy_3() {
+    var res1 = {};
+    var res2 = {};
+    var N = runs_per_script;
+    for (var n = 0; n < N; n++) {
+        for_all_files(parse_1, 1, "" + n, res1);
+        for_all_files(parse_2, 1, "" + n, res2);
+    }
+    var result = compare(res1, res2);
+    print(name_1, "\t", result.time1, "ms\t", 1e6 * result.time1 / result.parsed_bytes, 'ns/byte\t', result.parsed_bytes / (1e6 * result.time1), 'bytes/ns\t');
+    print(name_2, "\t", result.time2, "ms\t", 1e6 * result.time2 / result.parsed_bytes, 'ns/byte\t', result.parsed_bytes / (1e6 * result.time2), 'bytes/ns\t');
+    print("Total parsed  (scripts:", result.parsed_files, ", bytes:", result.parsed_bytes, ")");
+    print("Total skipped (scripts:", result.skipped_files, ", bytes:", result.skipped_bytes, ")");
+    print(name_2, "/", name_1, ":", result.time2 / result.time1);
+    print(name_2, "/", name_1, ":", spread(result.ratios_2over1, 0, 5, 0.05));
+}
+
+// Compare cold parsers, with alternatetively cold/hot data.
+//
+// By swapping parser order of execution after each file, we expect that the
+// previous parser execution would be enough to evict the other from the L2
+// cache, and as such cause the other parser to hit cold instruction cache where
+// the instruction have to be reloaded.
+//
+// At the moment, this is assumed to be the best approach which might mimic how
+// parsers are effectively used on the main thread.
+function strategy_0() {
+    var path = "", content = "";
+    var t_1= 0, t_2 = 0, time_1 = 0, time_2 = 0;
+    var count = 0, count_bytes = 0, skipped = 0, skipped_bytes = 0;
+    var parse1_first = false;
+    var list = os.file.listDir(dir);
+    var ratios_2over1 = [];
+    var parse1_first = true;
+    for (var file of list) {
+        path = os.path.join(dir, file);
+        content = "";
+        try {
+            // print(Math.round(100 * f / list.length), file);
+            content = os.file.readRelativeToScript(path);
+            parse1_first = !parse1_first; // Math.random() > 0.5;
+            for (var i = 0; i < runs_per_script; i++) {
+                // Randomize the order in which parsers are executed as they are
+                // executed in the same process and the parsed content might be
+                // faster to load for the second parser as it is already in memory.
+                if (parse1_first) {
+                    t_1 = parse_1(content);
+                    t_2 = parse_2(content);
+                } else {
+                    t_2 = parse_2(content);
+                    t_1 = parse_1(content);
+                }
+                time_1 += t_1;
+                time_2 += t_2;
+                ratios_2over1.push(t_2 / t_1);
+            }
+            count++;
+            count_bytes += content.length;
+        } catch (e) {
+            // ignore all errors for now.
+            skipped++;
+            skipped_bytes += content.length;
+        }
+    }
+
+    var total_bytes = count_bytes * runs_per_script;
+    print(name_1, "\t", time_1, "ms\t", 1e6 * time_1 / total_bytes, 'ns/byte\t', total_bytes / (1e6 * time_1), 'bytes/ns\t');
+    print(name_2, "\t", time_2, "ms\t", 1e6 * time_2 / total_bytes, 'ns/byte\t', total_bytes / (1e6 * time_2), 'bytes/ns\t');
+    print("Total parsed  (scripts:", count * runs_per_script, ", bytes:", total_bytes, ")");
+    print("Total skipped (scripts:", skipped * runs_per_script, ", bytes:", skipped_bytes, ")");
+    print(name_2, "/", name_1, ":", time_2 / time_1);
+    print(name_2, "/", name_1, ":", spread(ratios_2over1, 0, 5, 0.05));
+}
+
+print("Main thread comparison:")
+strategy_0();
+print("")
+print("Off-thread comparison:")
+strategy_3();

--- a/src/bin/smoosh_tools.rs
+++ b/src/bin/smoosh_tools.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::env::{self, Args};
-use std::fs::{File, create_dir_all};
+use std::fs::{create_dir_all, File};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
@@ -327,13 +327,20 @@ impl FromStr for ObjDir {
             false => return Err(Error::Generic("unexpected start".into())),
         };
         if Some(0) != s.find(char::is_whitespace) {
-            return Err(Error::Generic("expected whitespace after mk_add_options".into()));
+            return Err(Error::Generic(
+                "expected whitespace after mk_add_options".into(),
+            ));
         }
         let s = s.trim_start();
-        let eq_idx = s.find('=').ok_or(Error::Generic("equal sign not found after mk_add_option".into()))?;
+        let eq_idx = s.find('=').ok_or(Error::Generic(
+            "equal sign not found after mk_add_option".into(),
+        ))?;
         let var_name = &s[..eq_idx];
         if var_name != "MOZ_OBJDIR" {
-            return Err(Error::Generic(format!("{}: unexpected variable, expected MOZ_OBJDIR", var_name)))
+            return Err(Error::Generic(format!(
+                "{}: unexpected variable, expected MOZ_OBJDIR",
+                var_name
+            )));
         }
         let s = &s[(eq_idx + 1)..];
         let s = s.trim();
@@ -341,7 +348,6 @@ impl FromStr for ObjDir {
         Ok(ObjDir(s.into()))
     }
 }
-
 
 #[derive(Debug)]
 struct BuildTree {
@@ -361,8 +367,7 @@ impl BuildTree {
             // environmenet variable with the content provided by jsparagus.
             // This is useful to add additional compilation variants for
             // mozilla-central.
-            let env = env::var("MOZCONFIG")
-                .map_err(|e| Error::EnvVar("MOZCONFIG", e))?;
+            let env = env::var("MOZCONFIG").map_err(|e| Error::EnvVar("MOZCONFIG", e))?;
             let env_config = read_file(&env.into())?;
             let jsp_config = read_file(&jsp_mozconfig)?;
             let config = env_config + &jsp_config;
@@ -377,15 +382,19 @@ impl BuildTree {
                 }
             }
             let objdir = objdir.ok_or(Error::Generic("MOZ_OBJDIR must exists".into()))?;
-            let topsrcdir = moz.topsrcdir.to_str().ok_or(())
+            let topsrcdir = moz
+                .topsrcdir
+                .to_str()
+                .ok_or(())
                 .map_err(|_| Error::Generic("topsrcdir cannot be encoded in UTF-8.".into()))?;
             let objdir = objdir.replace("@TOPSRCDIR@", topsrcdir);
 
             // Create the object direcotry.
             let objdir: PathBuf = objdir.into();
             if !objdir.is_dir() {
-                create_dir_all(&objdir)
-                    .map_err(|e| Error::IO(format!("Failed to create directory {:?}", objdir), e))?;
+                create_dir_all(&objdir).map_err(|e| {
+                    Error::IO(format!("Failed to create directory {:?}", objdir), e)
+                })?;
             }
 
             // Create MOZCONFIG file.
@@ -397,11 +406,13 @@ impl BuildTree {
             jsp_mozconfig
         };
 
-        Ok(Self { moz, jsp, mozconfig })
+        Ok(Self {
+            moz,
+            jsp,
+            mozconfig,
+        })
     }
 }
-
-
 
 /// Run `command`, and check if the exit code is successful.
 /// Returns Err if failed to run the command, or the exit code is non-zero.

--- a/src/bin/smoosh_tools.rs
+++ b/src/bin/smoosh_tools.rs
@@ -20,6 +20,10 @@ COMMAND:
     test [--opt] [MOZILLA_CENTRAL]
         Run jstests/jit-test with SpiderMonkey JS shell binary built by
         "build" command
+    bench [--opt] [--samples-dir=REAL_JS_SAMPLES/DATE] [MOZILLA_CENTRAL]
+        Compare SpiderMonkey parser performance against SmooshMonkey on a
+        collection of JavaScript files, using the JS shell binary built by
+        "build" command.
     bump [MOZILLA_CENTRAL]
         Bump jsparagus version referred by mozilla-central to the latest
         "ci_generated" branch HEAD, and re-vendor jsparagus
@@ -43,6 +47,8 @@ OPTIONS:
     --concat-mozconfig For building mozilla-central, concatenates the content
                     of the MOZCONFIG environment variable with the content of
                     smoosh_tools mozconfig.
+    --samples-dir=DIR Directory containing thousands of JavaScripts to be used
+                    for measuring the performance of SmooshMonkey.
 "#;
 
 macro_rules! try_finally {
@@ -110,6 +116,7 @@ enum CommandType {
     Build,
     Shell,
     Test,
+    Bench,
     Bump,
     Gen,
     Try,
@@ -130,6 +137,7 @@ struct SimpleArgs {
     command: CommandType,
     build_type: BuildType,
     moz_path: String,
+    realjs_path: String,
     remote: String,
     concat_mozconfig: bool,
 }
@@ -144,6 +152,7 @@ impl SimpleArgs {
                 "build" => CommandType::Build,
                 "test" => CommandType::Test,
                 "shell" => CommandType::Shell,
+                "bench" => CommandType::Bench,
                 "bump" => CommandType::Bump,
                 "gen" => CommandType::Gen,
                 "try" => CommandType::Try,
@@ -156,6 +165,7 @@ impl SimpleArgs {
 
         let mut remote = "origin".to_string();
         let mut moz_path = Self::guess_moz();
+        let mut realjs_path = Self::guess_realjs();
         let mut build_type = BuildType::Debug;
         let mut concat_mozconfig = false;
 
@@ -175,6 +185,9 @@ impl SimpleArgs {
                     match name {
                         "--remote" => {
                             remote = value.to_string();
+                        }
+                        "--samples-dir" => {
+                            realjs_path = value.to_string();
                         }
                         _ => {
                             Self::show_usage();
@@ -210,6 +223,7 @@ impl SimpleArgs {
             command,
             build_type,
             moz_path,
+            realjs_path,
             remote,
             concat_mozconfig,
         }
@@ -234,6 +248,10 @@ impl SimpleArgs {
         }
 
         return "../mozilla-central".to_string();
+    }
+
+    fn guess_realjs() -> String {
+        return "../real-js-samples/20190416".to_string();
     }
 }
 
@@ -313,6 +331,12 @@ impl JsparagusTree {
             BuildType::Opt => "smoosh-opt",
             BuildType::Debug => "smoosh-debug",
         })
+    }
+
+    fn compare_parsers_js(&self) -> PathBuf {
+        self.topsrcdir
+            .join("benchmarks")
+            .join("compare-spidermonkey-parsers.js")
     }
 }
 
@@ -704,6 +728,20 @@ fn shell(args: &SimpleArgs) -> Result<(), Error> {
     run_mach(&["run", "--smoosh"], args)
 }
 
+fn bench(args: &SimpleArgs) -> Result<(), Error> {
+    let jsparagus = JsparagusTree::try_new()?;
+    let cmp_parsers = jsparagus.compare_parsers_js();
+    let cmp_parsers: &str = cmp_parsers.to_str().ok_or(Error::Generic(
+        "Unable to serialize benchmark script path".into(),
+    ))?;
+    let realjs_path = jsparagus.topsrcdir.join(&args.realjs_path);
+    let realjs_path: &str = realjs_path.to_str().ok_or(Error::Generic(
+        "Unable to serialize benchmark script path".into(),
+    ))?;
+
+    run_mach(&["run", "-f", cmp_parsers, "--", "--", realjs_path], args)
+}
+
 fn test(args: &SimpleArgs) -> Result<(), Error> {
     run_mach(&["jstests", "--args=-smoosh"], args)?;
     run_mach(&["jit-test", "--args=-smoosh"], args)
@@ -892,6 +930,7 @@ fn main() {
         CommandType::Build => build(&args),
         CommandType::Shell => shell(&args),
         CommandType::Test => test(&args),
+        CommandType::Bench => bench(&args),
         CommandType::Bump => bump(&args),
         CommandType::Gen => gen_branch(&args),
         CommandType::Try => push_try(&args),


### PR DESCRIPTION
The bench command will look for a a checkout of [real-js-samples](https://github.com/Yoric/real-js-samples) and use it for
comparing both SpiderMonkey and SmooshMonkey parsers.

It relies on the `benchmarks/compare-spidermonkey-parsers.js` file as a harness to
run both parsers on a all files contained in a directory.

The directory is by default set to the real-js-samples, or it can be overriden
by using the `--samples-dir=<DIR>` command line option.