### PR TITLE
Support private fields in optional chain and assignment target

### DIFF
--- a/crates/ast/ast.json
+++ b/crates/ast/ast.json
@@ -289,11 +289,15 @@
     "StaticMemberExpressionTail": {
       "property": "IdentifierName"
     },
+    "PrivateFieldExpressionTail": {
+      "field": "PrivateIdentifier"
+    },
     "CallExpressionTail": {
       "arguments": "Arguments"
     },
     "ComputedMemberExpression": "ComputedMemberExpression",
     "StaticMemberExpression": "StaticMemberExpression",
+    "PrivateFieldExpression": "PrivateFieldExpression",
     "CallExpression": "CallExpression"
   },
   "PropertyName": {

--- a/crates/ast/ast.json
+++ b/crates/ast/ast.json
@@ -400,12 +400,18 @@
   "MemberAssignmentTarget": {
     "_type": "enum",
     "ComputedMemberAssignmentTarget": "ComputedMemberAssignmentTarget",
+    "PrivateFieldAssignmentTarget": "PrivateFieldAssignmentTarget",
     "StaticMemberAssignmentTarget": "StaticMemberAssignmentTarget"
   },
   "ComputedMemberAssignmentTarget": {
     "_type": "struct",
     "object": "ExpressionOrSuper",
     "expression": "Box<Expression>"
+  },
+  "PrivateFieldAssignmentTarget": {
+    "_type": "struct",
+    "object": "ExpressionOrSuper",
+    "field": "PrivateIdentifier"
   },
   "StaticMemberAssignmentTarget": {
     "_type": "struct",
@@ -633,7 +639,7 @@
   },
   "PrivateFieldExpression": {
     "_type": "struct",
-    "object": "Box<Expression>",
+    "object": "ExpressionOrSuper",
     "field": "PrivateIdentifier"
   },
   "TemplateExpressionElement": {

--- a/crates/generated_parser/src/ast_builder.rs
+++ b/crates/generated_parser/src/ast_builder.rs
@@ -1233,6 +1233,21 @@ impl<'alloc> AstBuilder<'alloc> {
         })
     }
 
+    // OptionalChain : `?.` PrivateIdentifier
+    pub fn optional_private_field_member_expr_tail(
+        &self,
+        start_token: arena::Box<'alloc, Token>,
+        private_identifier: arena::Box<'alloc, Token>,
+    ) -> arena::Box<'alloc, Expression<'alloc>> {
+        let private_identifier_loc = private_identifier.loc;
+        self.alloc_with(|| {
+            Expression::OptionalChain(OptionalChain::PrivateFieldExpressionTail {
+                field: self.private_identifier(private_identifier),
+                loc: SourceLocation::from_parts(start_token.loc, private_identifier_loc),
+            })
+        })
+    }
+
     // OptionalChain : `?.` Arguments
     pub fn optional_call_expr_tail(
         &self,
@@ -1288,6 +1303,25 @@ impl<'alloc> AstBuilder<'alloc> {
                     object: ExpressionOrSuper::Expression(object),
                     property: self.identifier_name(identifier_token),
                     loc: SourceLocation::from_parts(object_loc, identifier_token_loc),
+                },
+            ))
+        })
+    }
+
+    // OptionalChain : OptionalChain `.` PrivateIdentifier
+    pub fn optional_private_field_member_expr(
+        &self,
+        object: arena::Box<'alloc, Expression<'alloc>>,
+        private_identifier: arena::Box<'alloc, Token>,
+    ) -> arena::Box<'alloc, Expression<'alloc>> {
+        let object_loc = object.get_loc();
+        let private_identifier_loc = private_identifier.loc;
+        self.alloc_with(|| {
+            Expression::OptionalChain(OptionalChain::PrivateFieldExpression(
+                PrivateFieldExpression {
+                    object: ExpressionOrSuper::Expression(object),
+                    field: self.private_identifier(private_identifier),
+                    loc: SourceLocation::from_parts(object_loc, private_identifier_loc),
                 },
             ))
         })

--- a/crates/generated_parser/src/ast_builder.rs
+++ b/crates/generated_parser/src/ast_builder.rs
@@ -1388,7 +1388,7 @@ impl<'alloc> AstBuilder<'alloc> {
         self.alloc_with(|| {
             Expression::MemberExpression(MemberExpression::PrivateFieldExpression(
                 PrivateFieldExpression {
-                    object,
+                    object: ExpressionOrSuper::Expression(object),
                     field: self.private_identifier(private_identifier),
                     loc: SourceLocation::from_parts(object_loc, field_loc),
                 },
@@ -2128,6 +2128,13 @@ impl<'alloc> AstBuilder<'alloc> {
                         expression,
                         loc,
                     },
+                ),
+            ),
+            Expression::MemberExpression(MemberExpression::PrivateFieldExpression(
+                PrivateFieldExpression { object, field, loc },
+            )) => SimpleAssignmentTarget::MemberAssignmentTarget(
+                MemberAssignmentTarget::PrivateFieldAssignmentTarget(
+                    PrivateFieldAssignmentTarget { object, field, loc },
                 ),
             ),
 

--- a/js_parser/es-simplified.esgrammar
+++ b/js_parser/es-simplified.esgrammar
@@ -307,6 +307,8 @@ OptionalChain[Yield, Await] :
     => optional_computed_member_expr_tail($0, $2, $3)
   `?.` IdentifierName
     => optional_static_member_expr_tail($0, $1)
+  `?.` PrivateIdentifier
+    => optional_private_field_member_expr_tail($0, $1)
   `?.` Arguments[?Yield, ?Await]
     => optional_call_expr_tail($0, $1)
   `?.` TemplateLiteral[?Yield, ?Await, +Tagged]
@@ -315,6 +317,8 @@ OptionalChain[Yield, Await] :
     => optional_computed_member_expr($0, $2, $3)
   OptionalChain[?Yield, ?Await] `.` IdentifierName
     => optional_static_member_expr($0, $2)
+  OptionalChain[?Yield, ?Await] `.` PrivateIdentifier
+    => optional_private_field_member_expr($0, $2)
   OptionalChain[?Yield, ?Await] Arguments[?Yield, ?Await]
     => optional_call_expr($0, $1)
   OptionalChain[?Yield, ?Await] TemplateLiteral[?Yield, ?Await, +Tagged]


### PR DESCRIPTION
supports the following
 * `obj.#foo = x` (change in `private_field_expr`)
 * `obj?.#foo` (JSON, and `optional_private_field_member_expr_tail`)
 * `obj?.foo.#bar` (JSON and `optional_private_field_member_expr`)
