### PR TITLE
Fix source extent for function

### DIFF
--- a/crates/scope/src/builder.rs
+++ b/crates/scope/src/builder.rs
@@ -2202,7 +2202,7 @@ impl FunctionScriptStencilBuilder {
     {
         let loc = params.get_loc();
         let params_start = loc.start;
-        self.current_mut().set_to_string_starts(params_start);
+        self.current_mut().set_source_starts(params_start);
     }
 
     fn on_non_rest_parameter(&mut self) {

--- a/crates/stencil/src/script.rs
+++ b/crates/stencil/src/script.rs
@@ -392,14 +392,18 @@ impl ScriptStencil {
         self.fun_nargs += 1;
     }
 
-    pub fn set_to_string_starts(&mut self, to_string_start: usize) {
-        self.extent.to_string_start = to_string_start as u32;
+    /// source_start should point the start of parameter for functions.
+    pub fn set_source_starts(&mut self, source_start: usize) {
+        self.extent.source_start = source_start as u32;
     }
 
+    /// to_string_end should point the end of function body for function,
+    /// and the end of class for constructor.
     pub fn set_to_string_end(&mut self, to_string_end: usize) {
         self.extent.to_string_end = to_string_end as u32;
     }
 
+    /// source_end should point the end of function body.
     pub fn set_source_end(&mut self, source_end: usize) {
         self.extent.source_end = source_end as u32;
     }


### PR DESCRIPTION
I mixed up toStringStart and sourceStart.
https://searchfox.org/mozilla-central/rev/b2395478c6adf6e5b241be1610fb1d920ed995ed/js/src/vm/JSScript.h#1499-1504

when we hit parameter start, we should set sourceStart, instead of toStringStart.