### PR TITLE
Pre-allocate SourceAtomSet to cover 75% of the loaded scripts.

### DIFF
--- a/crates/ast/src/source_atom_set.rs
+++ b/crates/ast/src/source_atom_set.rs
@@ -198,7 +198,9 @@ impl<'alloc> SourceAtomSet<'alloc> {
     // it with the result of this method.
     pub fn new_uninitialized() -> Self {
         Self {
-            atoms: IndexSet::new(),
+            // 256 is a number which should cover 75% of scripts without
+            // reallocation.
+            atoms: IndexSet::with_capacity(256),
         }
     }
 


### PR DESCRIPTION
This is simple attempt at addressing the `SourceAtomSet::insert` cost of the lexer ( #589 ).
