### PR TITLE
Visit this, and fix condition to declare arguments

### DIFF
--- a/crates/scope/src/builder.rs
+++ b/crates/scope/src/builder.rs
@@ -2859,12 +2859,10 @@ impl ScopeDataMapBuilder {
             }
 
             if try_declare_arguments {
-                let has_defined_arguments = parameter_has_arguments || body_has_defined_arguments;
-                let declare_arguments = if has_extra_body_var {
-                    !parameter_has_arguments
-                } else {
-                    has_defined_arguments
-                };
+                // if extra body var scope exists, the existence of `arguments`
+                // binding in function body doesn't affect.
+                let declare_arguments =
+                    !parameter_has_arguments && (has_extra_body_var || !body_has_defined_arguments);
 
                 if declare_arguments {
                     fun_stencil.set_should_declare_arguments();

--- a/crates/scope/src/pass.rs
+++ b/crates/scope/src/pass.rs
@@ -11,6 +11,7 @@ use crate::builder::{ScopeDataMapAndScriptStencilList, ScopeDataMapBuilder};
 use crate::data::FunctionDeclarationPropertyMap;
 use ast::arena;
 use ast::associated_data::AssociatedData;
+use ast::source_atom_set::CommonSourceAtomSetIndices;
 use ast::{types::*, visit::Pass};
 use std::collections::HashMap;
 use stencil::scope::ScopeDataMap;
@@ -118,6 +119,11 @@ impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
     // IdentifierExpression or AssignmentTargetIdentifier.
     fn visit_identifier(&mut self, ast: &'alloc Identifier) {
         self.builder.on_non_binding_identifier(ast.value);
+    }
+
+    fn visit_enum_expression_variant_this_expression(&mut self) {
+        self.builder
+            .on_non_binding_identifier(CommonSourceAtomSetIndices::this());
     }
 
     fn enter_enum_statement_variant_function_declaration(&mut self, ast: &'alloc Function<'alloc>) {


### PR DESCRIPTION
We weren't visiting `this` expression.
the existence of `this` affects function's script's flag.

also, the condition to declare arguments were flipped.
