### PR TITLE
Add state arguments for replay

### DIFF
--- a/jsparagus/actions.py
+++ b/jsparagus/actions.py
@@ -12,6 +12,7 @@ from . import types, grammar
 if typing.TYPE_CHECKING:
     from .parse_table import StateId
 
+
 @dataclasses.dataclass(frozen=True)
 class StackDiff:
     """StackDiff represent stack mutations which have to be performed when executing an action.
@@ -269,7 +270,6 @@ class Unwind(Action):
         return StackDiff(self.pop, self.nt, self.replay)
 
     def unshift_action(self, num: int) -> Unwind:
-        assert self.replay >= num
         return Unwind(self.nt, self.pop, replay=self.replay - num)
 
     def shifted_action(self, shifted_term: Element) -> Unwind:
@@ -280,6 +280,8 @@ class Reduce(Action):
     """Prevent the fall-through to the epsilon transition and returns to the shift
     table execution to resume shifting or replaying terms."""
     __slots__ = ['unwind']
+
+    unwind: Unwind
 
     def __init__(self, unwind: Unwind) -> None:
         nt_name = unwind.nt.name
@@ -577,7 +579,6 @@ class FunCall(Action):
         ])))
 
     def unshift_action(self, num: int) -> FunCall:
-        assert self.offset >= num
         return FunCall(self.method, self.args,
                        trait=self.trait,
                        fallible=self.fallible,

--- a/jsparagus/aps.py
+++ b/jsparagus/aps.py
@@ -55,6 +55,7 @@ def reduce_path(pt: ParseTable, shifted: Path) -> typing.Iterator[Path]:
     nt = stack_diff.nt
     assert nt is not None
     depth = stack_diff.pop + stack_diff.replay
+    assert depth >= 0
     if depth > 0:
         # We are reducing at least one element from the stack.
         stacked = [i for i, e in enumerate(shifted) if pt.term_is_stacked(e.term)]
@@ -273,7 +274,6 @@ class APS:
                 reducing = not a.follow_edge()
                 assert stack_diff.pop >= 0
                 assert stack_diff.nt is not None
-                assert stack_diff.replay >= 0
                 for path in reduce_path(pt, prev_sh):
                     # path contains the chains of state shifted, including
                     # epsilon transitions. The head of the path should be able

--- a/jsparagus/aps.py
+++ b/jsparagus/aps.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import typing
 from dataclasses import dataclass
 from .lr0 import ShiftedTerm, Term
-from .actions import Action, FilterStates
+from .actions import Action, FilterStates, Replay
 
 # Avoid circular reference between this module and parse_table.py
 if typing.TYPE_CHECKING:
@@ -240,10 +240,12 @@ class APS:
             # TODO: Add support for Lookahead and flag manipulation rules, as
             # both of these would invalide potential reduce paths.
             if a.update_stack():
+                new_rp: typing.List[ShiftedTerm]
                 stack_diff = a.update_stack_with()
-                if stack_diff.replay < 0:
+                if isinstance(a, Replay):
                     assert stack_diff.pop == 0
                     assert stack_diff.nt is None
+                    assert stack_diff.replay < 0
                     num_replay = -stack_diff.replay
                     assert len(self.replay) >= num_replay
                     new_rp = self.replay[:]
@@ -267,6 +269,7 @@ class APS:
                     # we might loop on Optional rules. Which would not match
                     # the expected behaviour of the parser.
                     continue
+
                 reducing = not a.follow_edge()
                 assert stack_diff.pop >= 0
                 assert stack_diff.nt is not None
@@ -314,21 +317,31 @@ class APS:
                     new_sh = prev_sh[:-len(path)] + [Edge(path[0].src, None)]
                     assert pt.is_valid_path(new_sh)
 
-                    # When reducing, we replay terms which got previously
-                    # pushed on the stack as our lookahead. These terms are
-                    # computed here such that we can traverse the graph from
-                    # `to` state, using the replayed terms.
+                    # Update the replay list of the new APS, starting with the
+                    # reduced non-terminal and followed by the lookahead terms
+                    # which have to be replayed and/or the truncated replay
+                    # list, if any are consumed while reducing.
                     replay = stack_diff.replay
                     nt = stack_diff.nt
                     assert nt is not None
                     new_rp = [nt]
                     if replay > 0:
+                        # Move previously shifted terms to the replay list, as
+                        # they would have to be replayed after reducing the
+                        # non-terminal.
                         stacked_terms = [
                             typing.cast(ShiftedTerm, edge.term)
                             for edge in path if pt.term_is_stacked(edge.term)
                         ]
-                        new_rp = new_rp + stacked_terms[-replay:]
-                    new_rp = new_rp + rp
+                        new_rp = new_rp + stacked_terms[-replay:] + rp
+                    elif replay == 0:
+                        new_rp = new_rp + rp
+                    elif replay < 0:
+                        # Remove the replayed tokens from the front of the
+                        # replay list as they are consumed by this Unwind
+                        # action.
+                        assert len(rp) >= -replay
+                        new_rp = new_rp + rp[-replay:]
                     new_la = la[:max(len(la) - replay, 0)]
 
                     # If we are reducing, this implies that we are not

--- a/jsparagus/emit/rust.py
+++ b/jsparagus/emit/rust.py
@@ -118,12 +118,14 @@ class RustActionWriter:
     ast_builder = types.Type("AstBuilderDelegate", (types.Lifetime("alloc"),))
 
     def __init__(self, writer, mode, traits, indent):
+        self.states = writer.states
         self.writer = writer
         self.mode = mode
         self.traits = traits
         self.indent = indent
         self.has_ast_builder = self.ast_builder in traits
         self.used_variables = set()
+        self.replay_args = []
 
     def implement_trait(self, funcall):
         "Returns True if this function call should be encoded"
@@ -167,9 +169,10 @@ class RustActionWriter:
         "Delegate to the RustParserWriter.write function"
         self.writer.write(self.indent, string, *format_args)
 
-    def write_state_transitions(self, state):
+    def write_state_transitions(self, state, replay_args):
         "Given a state, generate the code corresponding to all outgoing epsilon edges."
         try:
+            self.replay_args = replay_args
             assert not state.is_inconsistent()
             assert len(list(state.shifted_edges())) == 0
             for ctx in self.writer.parse_table.debug_context(state.index, None):
@@ -189,12 +192,24 @@ class RustActionWriter:
             print(self.writer.parse_table.debug_context(state.index, "\n", "# "))
             raise exc
 
+    def write_replay_args(self, n):
+        rp_args = self.replay_args[:n]
+        rp_stck = self.replay_args[n:]
+        for tv in rp_stck:
+            self.write("parser.replay({});", tv)
+        return rp_args
+
+
     def write_epsilon_transition(self, dest):
-        self.write("// --> {}", dest)
-        if dest >= self.writer.shift_count:
-            self.write("{}_{}(parser)", self.mode, dest)
+        # Replay arguments which are not accepted as input of the next state.
+        dest = self.states[dest]
+        rp_args = self.write_replay_args(dest.arguments)
+        self.write("// --> {}", dest.index)
+        if dest.index >= self.writer.shift_count:
+            self.write("{}_{}(parser{})", self.mode, dest.index, "".join(map(lambda v: ", " + v, rp_args)))
         else:
-            self.write("parser.epsilon({});", dest)
+            assert dest.arguments == 0
+            self.write("parser.epsilon({});", dest.index)
             self.write("Ok(false)")
 
     def write_condition(self, state, first_act):
@@ -213,6 +228,7 @@ class RustActionWriter:
             # to make this backtracking visible through APS.
             assert len(list(state.edges())) == 1
             act, dest = next(state.edges())
+            assert len(self.replay_args) == 0
             assert -act.offset > 0
             self.write("// {}", str(act))
             self.write("if !parser.check_not_on_new_line({})? {{", -act.offset)
@@ -274,15 +290,44 @@ class RustActionWriter:
             stack_diff = act.update_stack_with()
             start = 0
             depth = stack_diff.pop
-            if stack_diff.replay > 0:
-                self.write("parser.rewind({});", stack_diff.replay)
-                start = stack_diff.replay
+            args = len(self.replay_args)
+            replay = stack_diff.replay
+            if replay < 0:
+                # At the moment, we do not handle having more arguments than
+                # what is being popped and replay, thus write back the extra
+                # arguments and continue.
+                if stack_diff.pop + replay < 0:
+                    self.replay_args = self.write_replay_args(replay)
+                replay = 0
+            if replay + stack_diff.pop - args > 0:
+                assert (replay >= 0 and args == 0) or \
+                    (replay == 0 and args >= 0)
+            if replay > 0:
+                # At the moment, assume that arguments are only added once we
+                # consumed all replayed terms. Thus the replay_args can only be
+                # non-empty once replay is 0. Otherwise some of the replay_args
+                # would have to be replayed.
+                assert args == 0
+                self.write("parser.rewind({});", replay)
+                start = replay
                 depth += start
+
+            inputs = []
             for i in range(start, depth):
-                name = 's'
+                name = 's{}'.format(i + 1)
                 if i + 1 not in self.used_variables:
-                    name = '_s'
-                self.write("let {}{} = parser.pop();", name, i + 1)
+                    name = '_' + name
+                inputs.append(name)
+            if stack_diff.pop > 0:
+                args_pop = min(len(self.replay_args), stack_diff.pop)
+                # Pop by moving arguments of the action function.
+                for i, name in enumerate(inputs[:args_pop]):
+                    self.write("let {} = {};", name, self.replay_args[-i - 1])
+                # Pop by removing elements from the parser stack.
+                for name in inputs[args_pop:]:
+                    self.write("let {} = parser.pop();", name)
+                if args_pop > 0:
+                    del self.replay_args[-args_pop:]
 
         if isinstance(act, Seq):
             for a in act.actions:
@@ -316,6 +361,7 @@ class RustActionWriter:
             raise ValueError("Unexpected action type")
 
     def write_replay(self, act):
+        assert len(self.replay_args) == 0
         for shift_state in act.replay_steps:
             self.write("parser.shift_replayed({});", shift_state)
 
@@ -343,9 +389,8 @@ class RustActionWriter:
                    self.writer.nonterminal_to_camel(stack_diff.nt))
         if value != "value":
             self.write("let value = {};", value)
-        self.write("parser.replay(TermValue { term, value });")
-        if not act.follow_edge():
-            self.write("return Ok(false)")
+        self.write("let reduced = TermValue { term, value };")
+        self.replay_args.append("reduced")
 
     def write_accept(self):
         self.write("return Ok(true);")
@@ -743,6 +788,11 @@ class RustParserWriter:
             traits_text = ' + '.join(map(self.type_to_rust, traits))
             table_holder_name = self.to_camel_case(mode)
             table_holder_type = table_holder_name + "<'alloc, Handler>"
+            # As we do not have default associated types yet in Rust
+            # (rust-lang#29661), we have to peak from the parameter of the
+            # ParserTrait.
+            assert list(traits)[0].name == "ParserTrait"
+            arg_type = "TermValue<" + self.type_to_rust(list(traits)[0].args[1]) + ">"
             self.write(0, "struct {} {{", table_holder_type)
             self.write(1, "fns: [fn(&mut Handler) -> Result<'alloc, bool>; {}]",
                        self.action_from_shift_count)
@@ -754,6 +804,7 @@ class RustParserWriter:
             self.write(1, "const TABLE : {} = {} {{", table_holder_type, table_holder_name)
             self.write(2, "fns: [")
             for state in self.states[start_at:end_at]:
+                assert state.arguments == 0
                 self.write(3, "{}_{},", mode, state.index)
             self.write(2, "],")
             self.write(1, "};")
@@ -771,16 +822,20 @@ class RustParserWriter:
             self.write(0, "}")
             self.write(0, "")
             for state in self.states[self.shift_count:]:
+                state_args = ""
+                for i in range(state.arguments):
+                    state_args += ", v{}: {}".format(i, arg_type)
+                replay_args = ["v{}".format(i) for i in range(state.arguments)]
                 self.write(0, "#[inline]")
                 self.write(0, "#[allow(unused)]")
                 self.write(0,
-                           "pub fn {}_{}<'alloc, Handler>(parser: &mut Handler) "
+                           "pub fn {}_{}<'alloc, Handler>(parser: &mut Handler{}) "
                            "-> Result<'alloc, bool>",
-                           mode, state.index)
+                           mode, state.index, state_args)
                 self.write(0, "where")
                 self.write(1, "Handler: {}", ' + '.join(map(self.type_to_rust, traits)))
                 self.write(0, "{")
-                action_writer.write_state_transitions(state)
+                action_writer.write_state_transitions(state, replay_args)
                 self.write(0, "}")
 
     def entry(self):

--- a/jsparagus/parse_pgen_generated.py
+++ b/jsparagus/parse_pgen_generated.py
@@ -5,379 +5,492 @@ from jsparagus.runtime import (Nt, InitNt, End, ErrorToken, StateTermValue,
                                ShiftError, ShiftAccept)
 
 def state_43_actions(parser, lexer):
+    # { value = AstBuilder::id(1) [off: 0]; Unwind(Nt(InitNt(goal=Nt('grammar'))), 1, 0) }
 
     value = None
     value = parser.stack[-1].value
-    replay = [StateTermValue(0, Nt(InitNt(goal=Nt('grammar'))), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt(InitNt(goal=Nt('grammar'))), value, False))
     del parser.stack[-1:]
-    parser.shift_list(replay, lexer)
-    state_84_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_84_actions(parser, lexer, r0)
     return
 
 def state_44_actions(parser, lexer):
+    # { value = AstBuilder::nt_defs_single(1) [off: 0]; Unwind(Nt('nt_defs'), 1, 0) }
 
     value = None
     value = parser.methods.nt_defs_single(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('nt_defs'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('nt_defs'), value, False))
     del parser.stack[-1:]
-    parser.shift_list(replay, lexer)
-    state_82_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_82_actions(parser, lexer, r0)
     return
 
 def state_45_actions(parser, lexer):
+    # { value = AstBuilder::single(1) [off: 0]; Unwind(Nt('token_defs'), 1, 0) }
 
     value = None
     value = parser.methods.single(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('token_defs'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('token_defs'), value, False))
     del parser.stack[-1:]
-    parser.shift_list(replay, lexer)
-    state_83_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_83_actions(parser, lexer, r0)
     return
 
 def state_46_actions(parser, lexer):
+    # { value = AstBuilder::nt_defs_append(2, 1) [off: 0]; Unwind(Nt('nt_defs'), 2, 0) }
 
     value = None
     value = parser.methods.nt_defs_append(parser.stack[-2].value, parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('nt_defs'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('nt_defs'), value, False))
     del parser.stack[-2:]
-    parser.shift_list(replay, lexer)
-    state_82_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_82_actions(parser, lexer, r0)
     return
 
 def state_47_actions(parser, lexer):
+    # { value = AstBuilder::append(2, 1) [off: 0]; Unwind(Nt('token_defs'), 2, 0) }
 
     value = None
     value = parser.methods.append(parser.stack[-2].value, parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('token_defs'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('token_defs'), value, False))
     del parser.stack[-2:]
-    parser.shift_list(replay, lexer)
-    state_83_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_83_actions(parser, lexer, r0)
     return
 
 def state_48_actions(parser, lexer):
+    # { Accept(); Unwind(Nt(InitNt(goal=Nt('grammar'))), 2, 0) }
 
     value = None
     raise ShiftAccept()
-    replay = [StateTermValue(0, Nt(InitNt(goal=Nt('grammar'))), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt(InitNt(goal=Nt('grammar'))), value, False))
     del parser.stack[-2:]
-    parser.shift_list(replay, lexer)
-    state_84_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_84_actions(parser, lexer, r0)
     return
 
 def state_49_actions(parser, lexer):
+    # { value = AstBuilder::nt_def(None, None, 3, None) [off: 0]; Unwind(Nt('nt_def'), 4, 0) }
 
     value = None
     value = parser.methods.nt_def(None, None, parser.stack[-3].value, None)
-    replay = [StateTermValue(0, Nt('nt_def'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('nt_def'), value, False))
     del parser.stack[-4:]
-    parser.shift_list(replay, lexer)
-    state_107_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_107_actions(parser, lexer, r0)
     return
 
 def state_50_actions(parser, lexer):
+    # { value = AstBuilder::single(1) [off: 0]; Unwind(Nt('prods'), 1, 0) }
 
     value = None
     value = parser.methods.single(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('prods'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('prods'), value, False))
     del parser.stack[-1:]
-    parser.shift_list(replay, lexer)
-    state_94_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_94_actions(parser, lexer, r0)
     return
 
 def state_51_actions(parser, lexer):
+    # { value = AstBuilder::single(1) [off: 0]; Unwind(Nt('terms'), 1, 0) }
 
     value = None
     value = parser.methods.single(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('terms'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('terms'), value, False))
     del parser.stack[-1:]
-    parser.shift_list(replay, lexer)
-    state_97_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_97_actions(parser, lexer, r0)
     return
 
 def state_52_actions(parser, lexer):
+    # { value = AstBuilder::ident(1) [off: 0]; Unwind(Nt('symbol'), 1, 0) }
 
     value = None
     value = parser.methods.ident(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('symbol'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('symbol'), value, False))
     del parser.stack[-1:]
-    parser.shift_list(replay, lexer)
-    state_91_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_91_actions(parser, lexer, r0)
     return
 
 def state_53_actions(parser, lexer):
+    # { value = AstBuilder::str(1) [off: 0]; Unwind(Nt('symbol'), 1, 0) }
 
     value = None
     value = parser.methods.str(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('symbol'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('symbol'), value, False))
     del parser.stack[-1:]
-    parser.shift_list(replay, lexer)
-    state_91_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_91_actions(parser, lexer, r0)
     return
 
 def state_54_actions(parser, lexer):
+    # { value = AstBuilder::empty(1) [off: 0]; Unwind(Nt('prods'), 1, 0) }
 
     value = None
     value = parser.methods.empty(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('prods'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('prods'), value, False))
     del parser.stack[-1:]
-    parser.shift_list(replay, lexer)
-    state_94_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_94_actions(parser, lexer, r0)
     return
 
 def state_55_actions(parser, lexer):
+    # { value = AstBuilder::var_token(2) [off: 0]; Unwind(Nt('token_def'), 4, 0) }
 
     value = None
     value = parser.methods.var_token(parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('token_def'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('token_def'), value, False))
     del parser.stack[-4:]
-    parser.shift_list(replay, lexer)
-    state_100_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_100_actions(parser, lexer, r0)
     return
 
 def state_56_actions(parser, lexer):
+    # { value = AstBuilder::nt_def(None, None, 4, Some(inner=2)) [off: 0]; Unwind(Nt('nt_def'), 5, 0) }
 
     value = None
     value = parser.methods.nt_def(None, None, parser.stack[-4].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('nt_def'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('nt_def'), value, False))
     del parser.stack[-5:]
-    parser.shift_list(replay, lexer)
-    state_107_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_107_actions(parser, lexer, r0)
     return
 
 def state_57_actions(parser, lexer):
+    # { value = AstBuilder::append(2, 1) [off: 0]; Unwind(Nt('prods'), 2, 0) }
 
     value = None
     value = parser.methods.append(parser.stack[-2].value, parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('prods'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('prods'), value, False))
     del parser.stack[-2:]
-    parser.shift_list(replay, lexer)
-    state_94_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_94_actions(parser, lexer, r0)
     return
 
 def state_58_actions(parser, lexer):
+    # { value = AstBuilder::prod(2, None) [off: 0]; Unwind(Nt('prod'), 2, 0) }
 
     value = None
     value = parser.methods.prod(parser.stack[-2].value, None)
-    replay = [StateTermValue(0, Nt('prod'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('prod'), value, False))
     del parser.stack[-2:]
-    parser.shift_list(replay, lexer)
-    state_101_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_101_actions(parser, lexer, r0)
     return
 
 def state_59_actions(parser, lexer):
+    # { value = AstBuilder::append(2, 1) [off: 0]; Unwind(Nt('terms'), 2, 0) }
 
     value = None
     value = parser.methods.append(parser.stack[-2].value, parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('terms'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('terms'), value, False))
     del parser.stack[-2:]
-    parser.shift_list(replay, lexer)
-    state_97_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_97_actions(parser, lexer, r0)
     return
 
 def state_60_actions(parser, lexer):
+    # { value = AstBuilder::optional(2) [off: 0]; Unwind(Nt('term'), 2, 0) }
 
     value = None
     value = parser.methods.optional(parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('term'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('term'), value, False))
     del parser.stack[-2:]
-    parser.shift_list(replay, lexer)
-    state_111_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_111_actions(parser, lexer, r0)
     return
 
 def state_61_actions(parser, lexer):
+    # { value = AstBuilder::nt_def(Some(inner=5), None, 3, None) [off: 0]; Unwind(Nt('nt_def'), 5, 0) }
 
     value = None
     value = parser.methods.nt_def(parser.stack[-5].value, None, parser.stack[-3].value, None)
-    replay = [StateTermValue(0, Nt('nt_def'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('nt_def'), value, False))
     del parser.stack[-5:]
-    parser.shift_list(replay, lexer)
-    state_107_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_107_actions(parser, lexer, r0)
     return
 
 def state_62_actions(parser, lexer):
+    # { value = AstBuilder::nt_def(None, Some(inner=5), 3, None) [off: 0]; Unwind(Nt('nt_def'), 5, 0) }
 
     value = None
     value = parser.methods.nt_def(None, parser.stack[-5].value, parser.stack[-3].value, None)
-    replay = [StateTermValue(0, Nt('nt_def'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('nt_def'), value, False))
     del parser.stack[-5:]
-    parser.shift_list(replay, lexer)
-    state_107_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_107_actions(parser, lexer, r0)
     return
 
 def state_63_actions(parser, lexer):
+    # { value = AstBuilder::const_token(4, 2) [off: 0]; Unwind(Nt('token_def'), 5, 0) }
 
     value = None
     value = parser.methods.const_token(parser.stack[-4].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('token_def'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('token_def'), value, False))
     del parser.stack[-5:]
-    parser.shift_list(replay, lexer)
-    state_100_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_100_actions(parser, lexer, r0)
     return
 
 def state_64_actions(parser, lexer):
+    # { value = AstBuilder::prod(3, Some(inner=2)) [off: 0]; Unwind(Nt('prod'), 3, 0) }
 
     value = None
     value = parser.methods.prod(parser.stack[-3].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('prod'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('prod'), value, False))
     del parser.stack[-3:]
-    parser.shift_list(replay, lexer)
-    state_101_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_101_actions(parser, lexer, r0)
     return
 
 def state_65_actions(parser, lexer):
+    # { value = AstBuilder::id(1) [off: 0]; Unwind(Nt('reducer'), 2, 0) }
 
     value = None
     value = parser.stack[-1].value
-    replay = [StateTermValue(0, Nt('reducer'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('reducer'), value, False))
     del parser.stack[-2:]
-    parser.shift_list(replay, lexer)
-    state_102_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_102_actions(parser, lexer, r0)
     return
 
 def state_66_actions(parser, lexer):
+    # { value = AstBuilder::expr_match(1) [off: 0]; Unwind(Nt('expr'), 1, 0) }
 
     value = None
     value = parser.methods.expr_match(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('expr'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('expr'), value, False))
     del parser.stack[-1:]
-    parser.shift_list(replay, lexer)
-    state_108_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_108_actions(parser, lexer, r0)
     return
 
 def state_67_actions(parser, lexer):
+    # { value = AstBuilder::expr_none() [off: 0]; Unwind(Nt('expr'), 1, 0) }
 
     value = None
     value = parser.methods.expr_none()
-    replay = [StateTermValue(0, Nt('expr'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('expr'), value, False))
     del parser.stack[-1:]
-    parser.shift_list(replay, lexer)
-    state_108_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_108_actions(parser, lexer, r0)
     return
 
 def state_68_actions(parser, lexer):
+    # { value = AstBuilder::nt_def(Some(inner=6), None, 4, Some(inner=2)) [off: 0]; Unwind(Nt('nt_def'), 6, 0) }
 
     value = None
     value = parser.methods.nt_def(parser.stack[-6].value, None, parser.stack[-4].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('nt_def'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('nt_def'), value, False))
     del parser.stack[-6:]
-    parser.shift_list(replay, lexer)
-    state_107_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_107_actions(parser, lexer, r0)
     return
 
 def state_69_actions(parser, lexer):
+    # { value = AstBuilder::nt_def(Some(inner=6), Some(inner=5), 3, None) [off: 0]; Unwind(Nt('nt_def'), 6, 0) }
 
     value = None
     value = parser.methods.nt_def(parser.stack[-6].value, parser.stack[-5].value, parser.stack[-3].value, None)
-    replay = [StateTermValue(0, Nt('nt_def'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('nt_def'), value, False))
     del parser.stack[-6:]
-    parser.shift_list(replay, lexer)
-    state_107_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_107_actions(parser, lexer, r0)
     return
 
 def state_70_actions(parser, lexer):
+    # { value = AstBuilder::nt_def(None, Some(inner=6), 4, Some(inner=2)) [off: 0]; Unwind(Nt('nt_def'), 6, 0) }
 
     value = None
     value = parser.methods.nt_def(None, parser.stack[-6].value, parser.stack[-4].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('nt_def'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('nt_def'), value, False))
     del parser.stack[-6:]
-    parser.shift_list(replay, lexer)
-    state_107_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_107_actions(parser, lexer, r0)
     return
 
 def state_71_actions(parser, lexer):
+    # { value = AstBuilder::nt_def(Some(inner=7), Some(inner=6), 4, Some(inner=2)) [off: 0]; Unwind(Nt('nt_def'), 7, 0) }
 
     value = None
     value = parser.methods.nt_def(parser.stack[-7].value, parser.stack[-6].value, parser.stack[-4].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('nt_def'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('nt_def'), value, False))
     del parser.stack[-7:]
-    parser.shift_list(replay, lexer)
-    state_107_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_107_actions(parser, lexer, r0)
     return
 
 def state_72_actions(parser, lexer):
+    # { value = AstBuilder::expr_call(3, None) [off: 0]; Unwind(Nt('expr'), 3, 0) }
 
     value = None
     value = parser.methods.expr_call(parser.stack[-3].value, None)
-    replay = [StateTermValue(0, Nt('expr'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('expr'), value, False))
     del parser.stack[-3:]
-    parser.shift_list(replay, lexer)
-    state_108_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_108_actions(parser, lexer, r0)
     return
 
 def state_73_actions(parser, lexer):
+    # { value = AstBuilder::args_single(1) [off: 0]; Unwind(Nt('expr_args'), 1, 0) }
 
     value = None
     value = parser.methods.args_single(parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('expr_args'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('expr_args'), value, False))
     del parser.stack[-1:]
-    parser.shift_list(replay, lexer)
-    state_109_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_109_actions(parser, lexer, r0)
     return
 
 def state_74_actions(parser, lexer):
+    # { value = AstBuilder::expr_call(4, Some(inner=2)) [off: 0]; Unwind(Nt('expr'), 4, 0) }
 
     value = None
     value = parser.methods.expr_call(parser.stack[-4].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('expr'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('expr'), value, False))
     del parser.stack[-4:]
-    parser.shift_list(replay, lexer)
-    state_108_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_108_actions(parser, lexer, r0)
     return
 
 def state_75_actions(parser, lexer):
+    # { value = AstBuilder::expr_some(2) [off: 0]; Unwind(Nt('expr'), 4, 0) }
 
     value = None
     value = parser.methods.expr_some(parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('expr'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('expr'), value, False))
     del parser.stack[-4:]
-    parser.shift_list(replay, lexer)
-    state_108_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_108_actions(parser, lexer, r0)
     return
 
 def state_76_actions(parser, lexer):
+    # { value = AstBuilder::args_append(3, 1) [off: 0]; Unwind(Nt('expr_args'), 3, 0) }
 
     value = None
     value = parser.methods.args_append(parser.stack[-3].value, parser.stack[-1].value)
-    replay = [StateTermValue(0, Nt('expr_args'), value, False)]
+    replay = []
+    replay.append(StateTermValue(0, Nt('expr_args'), value, False))
     del parser.stack[-3:]
-    parser.shift_list(replay, lexer)
-    state_109_actions(parser, lexer)
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_109_actions(parser, lexer, r0)
     return
 
 def state_77_actions(parser, lexer):
+    # { value = AstBuilder::grammar(None, 1) [off: 1]; Unwind(Nt('grammar'), 1, 1) }
 
     value = None
     value = parser.methods.grammar(None, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('grammar'), value, False)]
-    replay = replay + parser.stack[-1:]
-    del parser.stack[-2:]
-    parser.shift_list(replay, lexer)
-    state_110_actions(parser, lexer)
+    replay = []
+    replay.append(parser.stack.pop())
+    replay.append(StateTermValue(0, Nt('grammar'), value, False))
+    del parser.stack[-1:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_110_actions(parser, lexer, r0)
     return
 
 def state_78_actions(parser, lexer):
+    # { value = AstBuilder::grammar(Some(inner=2), 1) [off: 1]; Unwind(Nt('grammar'), 2, 1) }
 
     value = None
     value = parser.methods.grammar(parser.stack[-3].value, parser.stack[-2].value)
-    replay = [StateTermValue(0, Nt('grammar'), value, False)]
-    replay = replay + parser.stack[-1:]
-    del parser.stack[-3:]
-    parser.shift_list(replay, lexer)
-    state_110_actions(parser, lexer)
+    replay = []
+    replay.append(parser.stack.pop())
+    replay.append(StateTermValue(0, Nt('grammar'), value, False))
+    del parser.stack[-2:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_110_actions(parser, lexer, r0)
     return
 
 def state_79_actions(parser, lexer):
+    # { value = AstBuilder::id(1) [off: 1]; Unwind(Nt('term'), 1, 1) }
 
     value = None
     value = parser.stack[-2].value
-    replay = [StateTermValue(0, Nt('term'), value, False)]
-    replay = replay + parser.stack[-1:]
-    del parser.stack[-2:]
-    parser.shift_list(replay, lexer)
-    state_111_actions(parser, lexer)
+    replay = []
+    replay.append(parser.stack.pop())
+    replay.append(StateTermValue(0, Nt('term'), value, False))
+    del parser.stack[-1:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_111_actions(parser, lexer, r0)
     return
 
-def state_80_actions(parser, lexer):
+def state_80_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((12,))
 
     value = None
     parser.replay_action(12)
@@ -386,7 +499,9 @@ def state_80_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_81_actions(parser, lexer):
+def state_81_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((13,))
 
     value = None
     parser.replay_action(13)
@@ -395,17 +510,22 @@ def state_81_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_82_actions(parser, lexer):
+def state_82_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
 
     value = None
     if parser.top_state() in [10]:
-        state_80_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_80_actions(parser, lexer, r0)
         return
     if parser.top_state() in [11]:
-        state_81_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_81_actions(parser, lexer, r0)
         return
 
-def state_83_actions(parser, lexer):
+def state_83_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((11,))
 
     value = None
     parser.replay_action(11)
@@ -414,7 +534,9 @@ def state_83_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_84_actions(parser, lexer):
+def state_84_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((23,))
 
     value = None
     parser.replay_action(23)
@@ -423,21 +545,39 @@ def state_84_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_85_actions(parser, lexer):
+def state_85_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # { value = AstBuilder::nt_defs_single(1) [off: -1]; Unwind(Nt('nt_defs'), 1, -1) }
+    parser.stack.append(parser.replay.pop())
 
     value = None
-    parser.replay_action(44)
-    state_44_actions(parser, lexer)
+    value = parser.methods.nt_defs_single(parser.stack[-1].value)
+    replay = []
+    replay.append(StateTermValue(0, Nt('nt_defs'), value, False))
+    del parser.stack[-1:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_82_actions(parser, lexer, r0)
     return
 
-def state_86_actions(parser, lexer):
+def state_86_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # { value = AstBuilder::nt_defs_append(2, 1) [off: -1]; Unwind(Nt('nt_defs'), 2, -1) }
+    parser.stack.append(parser.replay.pop())
 
     value = None
-    parser.replay_action(46)
-    state_46_actions(parser, lexer)
+    value = parser.methods.nt_defs_append(parser.stack[-2].value, parser.stack[-1].value)
+    replay = []
+    replay.append(StateTermValue(0, Nt('nt_defs'), value, False))
+    del parser.stack[-2:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_82_actions(parser, lexer, r0)
     return
 
-def state_87_actions(parser, lexer):
+def state_87_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((4,))
 
     value = None
     parser.replay_action(4)
@@ -446,7 +586,9 @@ def state_87_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_88_actions(parser, lexer):
+def state_88_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((5,))
 
     value = None
     parser.replay_action(5)
@@ -455,7 +597,9 @@ def state_88_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_89_actions(parser, lexer):
+def state_89_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((6,))
 
     value = None
     parser.replay_action(6)
@@ -464,7 +608,9 @@ def state_89_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_90_actions(parser, lexer):
+def state_90_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((7,))
 
     value = None
     parser.replay_action(7)
@@ -473,7 +619,9 @@ def state_90_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_91_actions(parser, lexer):
+def state_91_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((9,))
 
     value = None
     parser.replay_action(9)
@@ -482,51 +630,90 @@ def state_91_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_92_actions(parser, lexer):
+def state_92_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # { value = AstBuilder::single(1) [off: -1]; Unwind(Nt('token_defs'), 1, -1) }
+    parser.stack.append(parser.replay.pop())
 
     value = None
-    parser.replay_action(45)
-    state_45_actions(parser, lexer)
+    value = parser.methods.single(parser.stack[-1].value)
+    replay = []
+    replay.append(StateTermValue(0, Nt('token_defs'), value, False))
+    del parser.stack[-1:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_83_actions(parser, lexer, r0)
     return
 
-def state_93_actions(parser, lexer):
+def state_93_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # { value = AstBuilder::append(2, 1) [off: -1]; Unwind(Nt('token_defs'), 2, -1) }
+    parser.stack.append(parser.replay.pop())
 
     value = None
-    parser.replay_action(47)
-    state_47_actions(parser, lexer)
+    value = parser.methods.append(parser.stack[-2].value, parser.stack[-1].value)
+    replay = []
+    replay.append(StateTermValue(0, Nt('token_defs'), value, False))
+    del parser.stack[-2:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_83_actions(parser, lexer, r0)
     return
 
-def state_94_actions(parser, lexer):
+def state_94_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
 
     value = None
     if parser.top_state() in [0]:
-        state_87_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_87_actions(parser, lexer, r0)
         return
     if parser.top_state() in [1]:
-        state_88_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_88_actions(parser, lexer, r0)
         return
     if parser.top_state() in [2]:
-        state_89_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_89_actions(parser, lexer, r0)
         return
     if parser.top_state() in [3]:
-        state_90_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_90_actions(parser, lexer, r0)
         return
 
-def state_95_actions(parser, lexer):
+def state_95_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # { value = AstBuilder::single(1) [off: -1]; Unwind(Nt('prods'), 1, -1) }
+    parser.stack.append(parser.replay.pop())
 
     value = None
-    parser.replay_action(50)
-    state_50_actions(parser, lexer)
+    value = parser.methods.single(parser.stack[-1].value)
+    replay = []
+    replay.append(StateTermValue(0, Nt('prods'), value, False))
+    del parser.stack[-1:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_94_actions(parser, lexer, r0)
     return
 
-def state_96_actions(parser, lexer):
+def state_96_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # { value = AstBuilder::append(2, 1) [off: -1]; Unwind(Nt('prods'), 2, -1) }
+    parser.stack.append(parser.replay.pop())
 
     value = None
-    parser.replay_action(57)
-    state_57_actions(parser, lexer)
+    value = parser.methods.append(parser.stack[-2].value, parser.stack[-1].value)
+    replay = []
+    replay.append(StateTermValue(0, Nt('prods'), value, False))
+    del parser.stack[-2:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_94_actions(parser, lexer, r0)
     return
 
-def state_97_actions(parser, lexer):
+def state_97_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((8,))
 
     value = None
     parser.replay_action(8)
@@ -535,41 +722,65 @@ def state_97_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_98_actions(parser, lexer):
+def state_98_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # { value = AstBuilder::single(1) [off: -1]; Unwind(Nt('terms'), 1, -1) }
+    parser.stack.append(parser.replay.pop())
 
     value = None
-    parser.replay_action(51)
-    state_51_actions(parser, lexer)
+    value = parser.methods.single(parser.stack[-1].value)
+    replay = []
+    replay.append(StateTermValue(0, Nt('terms'), value, False))
+    del parser.stack[-1:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_97_actions(parser, lexer, r0)
     return
 
-def state_99_actions(parser, lexer):
+def state_99_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # { value = AstBuilder::append(2, 1) [off: -1]; Unwind(Nt('terms'), 2, -1) }
+    parser.stack.append(parser.replay.pop())
 
     value = None
-    parser.replay_action(59)
-    state_59_actions(parser, lexer)
+    value = parser.methods.append(parser.stack[-2].value, parser.stack[-1].value)
+    replay = []
+    replay.append(StateTermValue(0, Nt('terms'), value, False))
+    del parser.stack[-2:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_97_actions(parser, lexer, r0)
     return
 
-def state_100_actions(parser, lexer):
+def state_100_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
 
     value = None
     if parser.top_state() in [10]:
-        state_92_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_92_actions(parser, lexer, r0)
         return
     if parser.top_state() in [11]:
-        state_93_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_93_actions(parser, lexer, r0)
         return
 
-def state_101_actions(parser, lexer):
+def state_101_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
 
     value = None
     if parser.top_state() in [0, 1, 2, 3]:
-        state_95_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_95_actions(parser, lexer, r0)
         return
     if parser.top_state() in [4, 5, 6, 7]:
-        state_96_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_96_actions(parser, lexer, r0)
         return
 
-def state_102_actions(parser, lexer):
+def state_102_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((38,))
 
     value = None
     parser.replay_action(38)
@@ -578,21 +789,39 @@ def state_102_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_103_actions(parser, lexer):
+def state_103_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # { value = AstBuilder::id(1) [off: -1]; Unwind(Nt('reducer'), 2, -1) }
+    parser.stack.append(parser.replay.pop())
 
     value = None
-    parser.replay_action(65)
-    state_65_actions(parser, lexer)
+    value = parser.stack[-1].value
+    replay = []
+    replay.append(StateTermValue(0, Nt('reducer'), value, False))
+    del parser.stack[-2:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_102_actions(parser, lexer, r0)
     return
 
-def state_104_actions(parser, lexer):
+def state_104_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # { value = AstBuilder::args_single(1) [off: -1]; Unwind(Nt('expr_args'), 1, -1) }
+    parser.stack.append(parser.replay.pop())
 
     value = None
-    parser.replay_action(73)
-    state_73_actions(parser, lexer)
+    value = parser.methods.args_single(parser.stack[-1].value)
+    replay = []
+    replay.append(StateTermValue(0, Nt('expr_args'), value, False))
+    del parser.stack[-1:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_109_actions(parser, lexer, r0)
     return
 
-def state_105_actions(parser, lexer):
+def state_105_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((42,))
 
     value = None
     parser.replay_action(42)
@@ -601,40 +830,58 @@ def state_105_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_106_actions(parser, lexer):
+def state_106_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # { value = AstBuilder::args_append(3, 1) [off: -1]; Unwind(Nt('expr_args'), 3, -1) }
+    parser.stack.append(parser.replay.pop())
 
     value = None
-    parser.replay_action(76)
-    state_76_actions(parser, lexer)
+    value = parser.methods.args_append(parser.stack[-3].value, parser.stack[-1].value)
+    replay = []
+    replay.append(StateTermValue(0, Nt('expr_args'), value, False))
+    del parser.stack[-3:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_109_actions(parser, lexer, r0)
     return
 
-def state_107_actions(parser, lexer):
+def state_107_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
 
     value = None
     if parser.top_state() in [10, 11]:
-        state_85_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_85_actions(parser, lexer, r0)
         return
     if parser.top_state() in [12, 13]:
-        state_86_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_86_actions(parser, lexer, r0)
         return
 
-def state_108_actions(parser, lexer):
+def state_108_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
 
     value = None
     if parser.top_state() in [15]:
-        state_103_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_103_actions(parser, lexer, r0)
         return
     if parser.top_state() in [14]:
-        state_104_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_104_actions(parser, lexer, r0)
         return
     if parser.top_state() in [16]:
-        state_105_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_105_actions(parser, lexer, r0)
         return
     if parser.top_state() in [17]:
-        state_106_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_106_actions(parser, lexer, r0)
         return
 
-def state_109_actions(parser, lexer):
+def state_109_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # Replay((41,))
 
     value = None
     parser.replay_action(41)
@@ -643,21 +890,32 @@ def state_109_actions(parser, lexer):
     parser.stack.append(top)
     return
 
-def state_110_actions(parser, lexer):
+def state_110_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
+    # { value = AstBuilder::id(1) [off: -1]; Unwind(Nt(InitNt(goal=Nt('grammar'))), 1, -1) }
+    parser.stack.append(parser.replay.pop())
 
     value = None
-    parser.replay_action(43)
-    state_43_actions(parser, lexer)
+    value = parser.stack[-1].value
+    replay = []
+    replay.append(StateTermValue(0, Nt(InitNt(goal=Nt('grammar'))), value, False))
+    del parser.stack[-1:]
+    parser.replay.extend(replay)
+    r0 = parser.replay.pop()
+    state_84_actions(parser, lexer, r0)
     return
 
-def state_111_actions(parser, lexer):
+def state_111_actions(parser, lexer, a0):
+    parser.replay.extend([a0])
 
     value = None
     if parser.top_state() in [0, 1, 2, 3, 4, 5, 6, 7]:
-        state_98_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_98_actions(parser, lexer, r0)
         return
     if parser.top_state() in [8]:
-        state_99_actions(parser, lexer)
+        r0 = parser.replay.pop()
+        state_99_actions(parser, lexer, r0)
         return
 
 actions = [
@@ -1182,6 +1440,18 @@ class DefaultMethods:
         return ('grammar', x0, x1)
     def grammar(self, x0, x1):
         return ('grammar', x0, x1)
+    def nt_defs_single(self, x0):
+        return ('nt_defs_single', x0)
+    def nt_defs_append(self, x0, x1):
+        return ('nt_defs_append', x0, x1)
+    def single(self, x0):
+        return ('single', x0)
+    def append(self, x0, x1):
+        return ('append', x0, x1)
+    def args_single(self, x0):
+        return ('args_single', x0)
+    def args_append(self, x0, x1):
+        return ('args_append', x0, x1)
 
 class Parser(runtime.Parser):
     def __init__(self, goal='grammar', builder=None):

--- a/jsparagus/parse_table.py
+++ b/jsparagus/parse_table.py
@@ -33,7 +33,7 @@ class StateAndTransitions:
     """
 
     __slots__ = ["index", "locations", "terminals", "nonterminals", "errors",
-                 "epsilon", "delayed_actions", "backedges", "_hash",
+                 "epsilon", "delayed_actions", "arguments", "backedges", "_hash",
                  "stable_hash"]
 
     # Numerical index of this state.
@@ -47,6 +47,13 @@ class StateAndTransitions:
     # Ordered set of Actions which are pushed to the next state after a
     # conflict.
     delayed_actions: OrderedFrozenSet[DelayedAction]
+
+    # Number of argument of an action state.
+    #
+    # Instead of having action states with a non-empty replay list of terms, we
+    # have a non-empty list of argument which size is described by this
+    # variable.
+    arguments: int
 
     # Outgoing edges taken when shifting terminals.
     terminals: typing.Dict[str, StateId]
@@ -76,7 +83,8 @@ class StateAndTransitions:
             self,
             index: StateId,
             locations: OrderedFrozenSet[str],
-            delayed_actions: OrderedFrozenSet[DelayedAction] = OrderedFrozenSet()
+            delayed_actions: OrderedFrozenSet[DelayedAction] = OrderedFrozenSet(),
+            arguments: int = 0
     ) -> None:
         assert isinstance(locations, OrderedFrozenSet)
         assert isinstance(delayed_actions, OrderedFrozenSet)
@@ -87,6 +95,7 @@ class StateAndTransitions:
         self.epsilon = []
         self.locations = locations
         self.delayed_actions = delayed_actions
+        self.arguments = arguments
         self.backedges = OrderedSet()
 
         # NOTE: The hash of a state depends on its location in the LR0
@@ -98,6 +107,8 @@ class StateAndTransitions:
             yield "delayed_actions"
             for action in self.delayed_actions:
                 yield hash(action)
+            yield "arguments"
+            yield arguments
 
         self._hash = hash(tuple(hashed_content()))
         h = hashlib.md5()
@@ -251,7 +262,8 @@ class StateAndTransitions:
     def __eq__(self, other: object) -> bool:
         return (isinstance(other, StateAndTransitions)
                 and sorted(self.locations) == sorted(other.locations)
-                and sorted(self.delayed_actions) == sorted(other.delayed_actions))
+                and sorted(self.delayed_actions) == sorted(other.delayed_actions)
+                and self.arguments == other.arguments)
 
     def __hash__(self) -> int:
         return self._hash
@@ -439,13 +451,14 @@ class ParseTable:
     def new_state(
             self,
             locations: OrderedFrozenSet[str],
-            delayed_actions: OrderedFrozenSet[DelayedAction] = OrderedFrozenSet()
+            delayed_actions: OrderedFrozenSet[DelayedAction] = OrderedFrozenSet(),
+            arguments: int = 0
     ) -> typing.Tuple[bool, StateAndTransitions]:
         """Get or create state with an LR0 location and delayed actions. Returns a tuple
         where the first element is whether the element is newly created, and
         the second element is the State object."""
         index = len(self.states)
-        state = StateAndTransitions(index, locations, delayed_actions)
+        state = StateAndTransitions(index, locations, delayed_actions, arguments)
         try:
             return False, self.state_cache[state]
         except KeyError:
@@ -456,11 +469,12 @@ class ParseTable:
     def get_state(
             self,
             locations: OrderedFrozenSet[str],
-            delayed_actions: OrderedFrozenSet[DelayedAction] = OrderedFrozenSet()
+            delayed_actions: OrderedFrozenSet[DelayedAction] = OrderedFrozenSet(),
+            arguments: int = 0
     ) -> StateAndTransitions:
         """Like new_state(), but only returns the state without returning whether it is
         newly created or not."""
-        _, state = self.new_state(locations, delayed_actions)
+        _, state = self.new_state(locations, delayed_actions, arguments)
         return state
 
     def remove_state(self, s: StateId, maybe_unreachable_set: OrderedSet[StateId]) -> None:
@@ -1468,7 +1482,8 @@ class ParseTable:
                 # print("After:\n")
                 locations = reduce_state.locations
                 delayed: OrderedFrozenSet[DelayedAction] = OrderedFrozenSet(filter_by_replay_term.items())
-                is_new, filter_state = self.new_state(locations, delayed)
+                replay_size = 1  # Replay the unwound non-terminal
+                is_new, filter_state = self.new_state(locations, delayed, replay_size)
                 self.add_edge(reduce_state, unwind_term, filter_state.index)
                 if not is_new:
                     # The destination state already exists. Assert that all
@@ -1500,7 +1515,7 @@ class ParseTable:
                         # Add FilterStates action from the filter_state to the replay_state.
                         locations = dest.locations
                         delayed = OrderedFrozenSet(itertools.chain(dest.delayed_actions, [replay_term]))
-                        is_new, replay_state = self.new_state(locations, delayed)
+                        is_new, replay_state = self.new_state(locations, delayed, replay_size)
                         self.add_edge(filter_state, filter_term, replay_state.index)
                         assert (not is_new) == (replay_term in replay_state)
 

--- a/jsparagus/parse_table.py
+++ b/jsparagus/parse_table.py
@@ -1556,13 +1556,20 @@ class ParseTable:
             stack_diff = unwind_term.update_stack_with()
             if not stack_diff.reduce_stack():
                 return False
-            if stack_diff.replay <= 0:
+            if stack_diff.pop + stack_diff.replay <= 0:
                 return False
 
             # Remove replayed terms from the Unwind action.
             replayed = replay_term.replay_steps
-            unshifted = min(stack_diff.replay, len(replayed))
+            unshifted = min(stack_diff.replay + min(s.arguments, stack_diff.pop), len(replayed))
+            if unshifted < len(replayed):
+                # We do not have all replayed terms as arguments, thus do not
+                # consume arguments
+                unshifted = min(stack_diff.replay, len(replayed))
+            if unshifted == 0:
+                return False
             new_unwind_term = unwind_term.unshift_action(unshifted)
+            new_replay = new_unwind_term.update_stack_with().replay
 
             # Replace the replay_term and unwind_term by terms which are
             # avoiding extra replay actions.
@@ -1570,11 +1577,12 @@ class ParseTable:
             if len(replayed) == unshifted:
                 # The Unwind action replay more terms than what we originally
                 # had. The replay term is replaced by an Unwind edge instead.
+                assert s.arguments >= -new_replay
                 self.add_edge(s, new_unwind_term, unwind_dest_idx)
             else:
-                # The Unwind action replay less terms than what we originally
-                # had. The replay terms is shortened and a new state is created
-                # to accomodate the new Unwind action.
+                # The Unwind action replay and pop less terms than what we
+                # originally had. Thus the replay action is shortened and a new
+                # state is created to accomodate the new Unwind action.
                 assert unshifted >= 1
                 new_replay_term = Replay(replayed[:-unshifted])
                 implicit_replay_term = Replay(replayed[-unshifted:])
@@ -1588,6 +1596,7 @@ class ParseTable:
                 # Add new Replay and new Unwind actions.
                 self.add_edge(s, new_replay_term, unwind_state.index)
                 if is_new:
+                    assert unwind_state.arguments >= -new_replay
                     self.add_edge(unwind_state, new_unwind_term, unwind_dest_idx)
                 assert not unwind_state.is_inconsistent()
             assert not s.is_inconsistent()


### PR DESCRIPTION
This set of changes add the ability to add argument to action states. These arguments are used to account for the number of elements in the replay list.

These changes also make use of these arguments to fold even more the `Replay` action in the following `Unwind` action, to the point where we are capable of even removing the `Replay` action, however, this implies that `Unwind` action can now have a negative number of replay arguments.

This change should optimize the execution by removing the need for adding elements to the replay-list including their associated state, and thus taking a short-cut in the states taken by the LR parser.
