### PR TITLE
Reject unsupported scope (fixes #602)

### DIFF
--- a/.metrics/populate_not_implemented.sh
+++ b/.metrics/populate_not_implemented.sh
@@ -20,7 +20,7 @@ for commit in $(cat $topdir/tmp/commit-list)
 do
   git checkout $commit
   # python script pulls from env variables, export those
-  export total_count=$(find $topdir/rust -iname '*.rs' -type f -exec cat {} + | grep -c -E "(Emit|Parse)Error::NotImplemented")
+  export total_count=$(find $topdir/rust -iname '*.rs' -type f -exec cat {} + | grep -c -E "(Emit|Parse|ScopeBuild)Error::NotImplemented")
   export current_commit=$commit
   python not_implemented_count.py
   python not_implemented_badge.py

--- a/crates/emitter/src/lib.rs
+++ b/crates/emitter/src/lib.rs
@@ -23,7 +23,7 @@ use crate::compilation_info::CompilationInfo;
 
 use ast::source_atom_set::SourceAtomSet;
 use ast::source_slice_list::SourceSliceList;
-use scope::ScopePassResult;
+use scope::{ScopeBuildError, ScopePassResult};
 use stencil::result::EmitResult;
 
 pub fn emit<'alloc>(
@@ -38,7 +38,18 @@ pub fn emit<'alloc>(
         function_stencil_indices,
         function_declaration_properties,
         functions,
+        error,
     } = scope::generate_scope_data(ast);
+
+    // Error case for scope analysis will be removed once all syntax is
+    // supported. Use field instead of Result type here for simplicity.
+    match error {
+        Some(ScopeBuildError::NotImplemented(s)) => {
+            return Err(EmitError::NotImplemented(s));
+        }
+        None => {}
+    }
+
     let compilation_info = CompilationInfo::new(
         atoms,
         slices,

--- a/crates/scope/src/builder.rs
+++ b/crates/scope/src/builder.rs
@@ -3035,6 +3035,11 @@ impl ScopeDataMapBuilder {
         // FIXME: Propagate to script flags.
         self.set_error(ScopeBuildError::NotImplemented("delete operator"));
     }
+
+    pub fn on_lexical_for(&mut self) {
+        // FIXME: NewDeclarativeEnvironment in for statement
+        self.set_error(ScopeBuildError::NotImplemented("lexical for"));
+    }
 }
 
 pub struct ScopeDataMapAndScriptStencilList {

--- a/crates/scope/src/builder.rs
+++ b/crates/scope/src/builder.rs
@@ -2994,8 +2994,12 @@ impl ScopeDataMapBuilder {
         self.set_error(ScopeBuildError::NotImplemented("try-catch"));
     }
 
-    #[allow(dead_code)]
     pub fn on_direct_eval(&mut self) {
+        // FIXME: Propagate to script flags.
+        self.set_error(ScopeBuildError::NotImplemented(
+            "direct eval (script flags)",
+        ));
+
         if let Some(parameter_scope_builder) =
             self.builder_stack.maybe_innermost_function_parameters()
         {

--- a/crates/scope/src/builder.rs
+++ b/crates/scope/src/builder.rs
@@ -2989,6 +2989,11 @@ impl ScopeDataMapBuilder {
             .pop(ScopeKind::FunctionParametersAndBody);
     }
 
+    pub fn before_catch_clause(&mut self) {
+        // FIXME: NewDeclarativeEnvironment for catch parameter.
+        self.set_error(ScopeBuildError::NotImplemented("try-catch"));
+    }
+
     #[allow(dead_code)]
     pub fn on_direct_eval(&mut self) {
         if let Some(parameter_scope_builder) =

--- a/crates/scope/src/builder.rs
+++ b/crates/scope/src/builder.rs
@@ -3025,6 +3025,16 @@ impl ScopeDataMapBuilder {
         // FIXME: NewDeclarativeEnvironment for class tail.
         self.set_error(ScopeBuildError::NotImplemented("class"));
     }
+
+    pub fn on_with(&mut self) {
+        // FIXME: Propagate to script flags.
+        self.set_error(ScopeBuildError::NotImplemented("with statement"));
+    }
+
+    pub fn on_delete(&mut self) {
+        // FIXME: Propagate to script flags.
+        self.set_error(ScopeBuildError::NotImplemented("delete operator"));
+    }
 }
 
 pub struct ScopeDataMapAndScriptStencilList {

--- a/crates/scope/src/builder.rs
+++ b/crates/scope/src/builder.rs
@@ -2975,6 +2975,15 @@ impl ScopeDataMapBuilder {
                 if bindings_accessed_dynamically {
                     fun_stencil.set_always_needs_args_obj();
                 }
+
+                if has_used_this {
+                    // FIXME
+                    // IsLikelyConstructorWrapper should be set if
+                    // `.apply()` is used and `return` isn't used.
+                    self.set_error(ScopeBuildError::NotImplemented(
+                        "IsLikelyConstructorWrapper condition",
+                    ));
+                }
             }
         }
 

--- a/crates/scope/src/builder.rs
+++ b/crates/scope/src/builder.rs
@@ -3040,6 +3040,11 @@ impl ScopeDataMapBuilder {
         // FIXME: NewDeclarativeEnvironment in for statement
         self.set_error(ScopeBuildError::NotImplemented("lexical for"));
     }
+
+    pub fn on_switch(&mut self) {
+        // FIXME: NewDeclarativeEnvironment in for case block
+        self.set_error(ScopeBuildError::NotImplemented("switch"));
+    }
 }
 
 pub struct ScopeDataMapAndScriptStencilList {

--- a/crates/scope/src/builder.rs
+++ b/crates/scope/src/builder.rs
@@ -3011,6 +3011,11 @@ impl ScopeDataMapBuilder {
             .base_mut()
             .bindings_accessed_dynamically = true;
     }
+
+    pub fn on_class(&mut self) {
+        // FIXME: NewDeclarativeEnvironment for class tail.
+        self.set_error(ScopeBuildError::NotImplemented("class"));
+    }
 }
 
 pub struct ScopeDataMapAndScriptStencilList {

--- a/crates/scope/src/lib.rs
+++ b/crates/scope/src/lib.rs
@@ -19,6 +19,7 @@ extern crate jsparagus_stencil as stencil;
 
 use ast::visit::Pass;
 
+pub use builder::ScopeBuildError;
 pub use pass::ScopePassResult;
 
 /// Visit all nodes in the AST, and create a scope data.

--- a/crates/scope/src/pass.rs
+++ b/crates/scope/src/pass.rs
@@ -7,7 +7,7 @@
 //! but the goal is to do this analysis as part of the parse phase, even when
 //! no AST is built. So we try to keep AST use separate from the analysis code.
 
-use crate::builder::{ScopeDataMapAndScriptStencilList, ScopeDataMapBuilder};
+use crate::builder::{ScopeBuildError, ScopeDataMapAndScriptStencilList, ScopeDataMapBuilder};
 use crate::data::FunctionDeclarationPropertyMap;
 use ast::arena;
 use ast::associated_data::AssociatedData;
@@ -24,6 +24,7 @@ pub struct ScopePassResult<'alloc> {
     pub function_stencil_indices: AssociatedData<ScriptStencilIndex>,
     pub function_declaration_properties: FunctionDeclarationPropertyMap,
     pub functions: ScriptStencilList,
+    pub error: Option<ScopeBuildError>,
 }
 
 /// The top-level struct responsible for extracting the necessary information
@@ -53,6 +54,7 @@ impl<'alloc> From<ScopePass<'alloc>> for ScopePassResult<'alloc> {
             function_stencil_indices,
             function_declaration_properties,
             functions,
+            error,
         } = pass.builder.into();
         ScopePassResult {
             scope_data_map,
@@ -60,6 +62,7 @@ impl<'alloc> From<ScopePass<'alloc>> for ScopePassResult<'alloc> {
             function_stencil_indices,
             function_declaration_properties,
             functions,
+            error,
         }
     }
 }

--- a/crates/scope/src/pass.rs
+++ b/crates/scope/src/pass.rs
@@ -281,4 +281,18 @@ impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
     fn enter_catch_clause(&mut self, _ast: &'alloc CatchClause<'alloc>) {
         self.builder.before_catch_clause();
     }
+
+    fn enter_call_expression(&mut self, ast: &'alloc CallExpression<'alloc>) {
+        match &ast.callee {
+            ExpressionOrSuper::Expression(expr) => match &**expr {
+                Expression::IdentifierExpression(IdentifierExpression { name, .. }) => {
+                    if name.value == CommonSourceAtomSetIndices::eval() {
+                        self.builder.on_direct_eval();
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
 }

--- a/crates/scope/src/pass.rs
+++ b/crates/scope/src/pass.rs
@@ -303,4 +303,16 @@ impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
     fn enter_class_expression(&mut self, _ast: &'alloc ClassExpression<'alloc>) {
         self.builder.on_class();
     }
+
+    fn enter_enum_statement_variant_with_statement(
+        &mut self,
+        _object: &'alloc arena::Box<'alloc, Expression<'alloc>>,
+        _body: &'alloc arena::Box<'alloc, Statement<'alloc>>,
+    ) {
+        self.builder.on_with();
+    }
+
+    fn visit_enum_unary_operator_variant_delete(&mut self) {
+        self.builder.on_delete();
+    }
 }

--- a/crates/scope/src/pass.rs
+++ b/crates/scope/src/pass.rs
@@ -295,4 +295,12 @@ impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
             _ => {}
         }
     }
+
+    fn enter_class_declaration(&mut self, _ast: &'alloc ClassDeclaration<'alloc>) {
+        self.builder.on_class();
+    }
+
+    fn enter_class_expression(&mut self, _ast: &'alloc ClassExpression<'alloc>) {
+        self.builder.on_class();
+    }
 }

--- a/crates/scope/src/pass.rs
+++ b/crates/scope/src/pass.rs
@@ -350,4 +350,12 @@ impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
             _ => {}
         }
     }
+
+    fn enter_enum_statement_variant_switch_statement(
+        &mut self,
+        _discriminant: &'alloc arena::Box<'alloc, Expression<'alloc>>,
+        _cases: &'alloc arena::Vec<'alloc, SwitchCase<'alloc>>,
+    ) {
+        self.builder.on_switch();
+    }
 }

--- a/crates/scope/src/pass.rs
+++ b/crates/scope/src/pass.rs
@@ -277,4 +277,8 @@ impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
     ) {
         self.builder.after_function_body();
     }
+
+    fn enter_catch_clause(&mut self, _ast: &'alloc CatchClause<'alloc>) {
+        self.builder.before_catch_clause();
+    }
 }

--- a/crates/scope/src/pass.rs
+++ b/crates/scope/src/pass.rs
@@ -315,4 +315,39 @@ impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
     fn visit_enum_unary_operator_variant_delete(&mut self) {
         self.builder.on_delete();
     }
+
+    fn enter_enum_statement_variant_for_statement(
+        &mut self,
+        init: &'alloc Option<VariableDeclarationOrExpression<'alloc>>,
+        _test: &'alloc Option<arena::Box<'alloc, Expression<'alloc>>>,
+        _update: &'alloc Option<arena::Box<'alloc, Expression<'alloc>>>,
+        _block: &'alloc arena::Box<'alloc, Statement<'alloc>>,
+    ) {
+        match init {
+            Some(VariableDeclarationOrExpression::VariableDeclaration(decl)) => match decl.kind {
+                VariableDeclarationKind::Let { .. } | VariableDeclarationKind::Const { .. } => {
+                    self.builder.on_lexical_for();
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
+    fn enter_enum_statement_variant_for_in_statement(
+        &mut self,
+        left: &'alloc VariableDeclarationOrAssignmentTarget<'alloc>,
+        _right: &'alloc arena::Box<'alloc, Expression<'alloc>>,
+        _block: &'alloc arena::Box<'alloc, Statement<'alloc>>,
+    ) {
+        match left {
+            VariableDeclarationOrAssignmentTarget::VariableDeclaration(decl) => match decl.kind {
+                VariableDeclarationKind::Let { .. } | VariableDeclarationKind::Const { .. } => {
+                    self.builder.on_lexical_for();
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
 }


### PR DESCRIPTION
We don't yet support several syntax that affects scope.
Without lazy functions, most of those syntax are rejected by emitter.

Lazy function's body isn't handled by emitter, and we need to reject them in scope analysis.
