### PR TITLE
Fix Annex B function handling for closed over binding

### DIFF
--- a/src/bin/smoosh_tools.rs
+++ b/src/bin/smoosh_tools.rs
@@ -739,7 +739,10 @@ fn bench(args: &SimpleArgs) -> Result<(), Error> {
         "Unable to serialize benchmark script path".into(),
     ))?;
 
-    run_mach(&["run", "-f", cmp_parsers, "--", "--", "--dir", realjs_path], args)
+    run_mach(
+        &["run", "-f", cmp_parsers, "--", "--", "--dir", realjs_path],
+        args,
+    )
 }
 
 fn test(args: &SimpleArgs) -> Result<(), Error> {


### PR DESCRIPTION
1st and 3rd patches are just cleanup.
the main patch (2nd) moves the Annex B function handling (especially, adding the function name to defined variable in FreeNameTracker) before propagating free names to outer scope,
so that function body-level binding created by Annex B is reflected to free name tracking, and any use inside the function body won't close over enclosing scope's binding.