### PR TITLE
Expand ASI using the Parse Table.

### DIFF
--- a/crates/ast/ast.json
+++ b/crates/ast/ast.json
@@ -2,6 +2,9 @@
   "Void": {
     "_type": "enum"
   },
+  "Asi": {
+    "_type": "struct"
+  },
   "Argument": {
     "_type": "enum",
     "SpreadElement": "Box<Expression>",

--- a/crates/ast/src/source_location.rs
+++ b/crates/ast/src/source_location.rs
@@ -25,8 +25,10 @@ impl SourceLocation {
         self.start = start.start;
         self.end = end.end;
     }
+}
 
-    pub fn default() -> Self {
+impl Default for SourceLocation {
+    fn default() -> Self {
         Self { start: 0, end: 0 }
     }
 }

--- a/crates/generated_parser/src/ast_builder.rs
+++ b/crates/generated_parser/src/ast_builder.rs
@@ -84,6 +84,11 @@ impl<'alloc> AstBuilder<'alloc> {
         list.append(elements);
     }
 
+    // Automatic Semicolon Insertion
+    pub fn asi(&self) -> arena::Box<'alloc, Asi> {
+        self.alloc_with(|| Asi::default())
+    }
+
     // IdentifierReference : Identifier
     pub fn identifier_reference(
         &self,

--- a/crates/generated_parser/src/traits/mod.rs
+++ b/crates/generated_parser/src/traits/mod.rs
@@ -32,5 +32,5 @@ pub trait ParserTrait<'alloc, Value> {
     fn replay(&mut self, tv: TermValue<Value>);
     fn epsilon(&mut self, state: usize);
     fn top_state(&self) -> usize;
-    fn check_not_on_new_line(&mut self, peek: usize) -> Result<'alloc, bool>;
+    fn is_on_new_line(&self) -> Result<'alloc, bool>;
 }

--- a/crates/parser/src/simulator.rs
+++ b/crates/parser/src/simulator.rs
@@ -114,8 +114,8 @@ impl<'alloc, 'parser> ParserTrait<'alloc, ()> for Simulator<'alloc, 'parser> {
     fn top_state(&self) -> usize {
         self.state()
     }
-    fn check_not_on_new_line(&mut self, _peek: usize) -> Result<'alloc, bool> {
-        Ok(true)
+    fn is_on_new_line(&self) -> Result<'alloc, bool> {
+        Ok(false)
     }
 }
 

--- a/jsparagus/actions.py
+++ b/jsparagus/actions.py
@@ -226,6 +226,37 @@ class Action:
 ShiftedAction = typing.Union[Action, bool]
 
 
+class Shift(Action):
+    """Shift action is the implicit action performed when a terminal or nonterminal
+    is used on an edge. However this state is not supported as an epsilon edge,
+    but only serves to annotate delayed actions of states. """
+    __slots__ = ['term']
+
+    term: ShiftedTerm
+
+    def __init__(self, term: ShiftedTerm):
+        super().__init__()
+        self.term = term
+
+    def is_inconsistent(self) -> bool:
+        return True
+
+    def is_condition(self) -> bool:
+        return True
+
+    def condition(self) -> Shift:
+        return self
+
+    def update_stack(self) -> bool:
+        return True
+
+    def update_stack_with(self) -> StackDiff:
+        return StackDiff(0, None, -1)
+
+    def __str__(self) -> str:
+        return "Shift({})".format(str(self.term))
+
+
 class Replay(Action):
     """Replay a term which was previously saved by the Unwind function. Note that
     this does not Shift a term given as argument as the replay action should

--- a/jsparagus/actions.py
+++ b/jsparagus/actions.py
@@ -623,7 +623,7 @@ class FunCall(Action):
             args: typing.Tuple[OutputExpr, ...],
             trait: types.Type = types.Type("AstBuilder"),
             fallible: bool = False,
-            set_to: str = "val",
+            set_to: str = "value",
             offset: int = 0,
     ) -> None:
         super().__init__()

--- a/jsparagus/aps.py
+++ b/jsparagus/aps.py
@@ -217,6 +217,7 @@ class APS:
         last_edge = sh[-1]
         state = pt.states[last_edge.src]
         state_match_shift_end = self.state == self.shift[-1].src
+        term: Term
         if self.replay == []:
             assert state_match_shift_end
             for term, to in state.shifted_edges():

--- a/jsparagus/emit/python.py
+++ b/jsparagus/emit/python.py
@@ -6,7 +6,7 @@ import io
 import typing
 
 from ..grammar import ErrorSymbol, Nt, Some
-from ..actions import (Accept, Action, CheckNotOnNewLine, FilterFlag, FilterStates, FunCall,
+from ..actions import (Accept, Action, CheckLineTerminator, FilterFlag, FilterStates, FunCall,
                        Lookahead, OutputExpr, PopFlag, PushFlag, Reduce, Replay, Seq, Unwind)
 from ..runtime import ErrorToken, ErrorTokenClass
 from ..ordered import OrderedSet
@@ -73,7 +73,7 @@ def write_python_parse_table(out: io.TextIOBase, parse_table: ParseTable) -> Non
             return indent, False
         if isinstance(act, Lookahead):
             raise ValueError("Unexpected Lookahead action")
-        if isinstance(act, CheckNotOnNewLine):
+        if isinstance(act, CheckLineTerminator):
             out.write("{}if not parser.check_not_on_new_line(lexer, {}):\n".format(indent, -act.offset))
             out.write("{}    return\n".format(indent))
             return indent, True

--- a/jsparagus/emit/rust.py
+++ b/jsparagus/emit/rust.py
@@ -12,7 +12,7 @@ from ..runtime import (ERROR, ErrorToken, SPECIAL_CASE_TAG)
 from ..ordered import OrderedSet
 
 from ..grammar import (Some, Nt, InitNt, End, ErrorSymbol)
-from ..actions import (Accept, Action, Replay, Unwind, Reduce, CheckNotOnNewLine, FilterStates,
+from ..actions import (Accept, Action, Replay, Unwind, Reduce, CheckLineTerminator, FilterStates,
                        PushFlag, PopFlag, FunCall, Seq)
 
 from .. import types
@@ -223,7 +223,7 @@ class RustActionWriter:
         # states. Thus we use the first action to produce the match statement.
         assert isinstance(first_act, Action)
         assert first_act.is_condition()
-        if isinstance(first_act, CheckNotOnNewLine):
+        if isinstance(first_act, CheckLineTerminator):
             # TODO: At the moment this is Action is implemented as a single
             # operation with a single destination. However, we should implement
             # it in the future as 2 branches, one which is verifying the lack
@@ -234,6 +234,7 @@ class RustActionWriter:
             act, dest = next(state.edges())
             assert len(self.replay_args) == 0
             assert -act.offset > 0
+            assert act.is_on_new_line == False
             self.write("// {}", str(act))
             self.write("if !parser.check_not_on_new_line({})? {{", -act.offset)
             with indent(self):

--- a/jsparagus/emit/rust.py
+++ b/jsparagus/emit/rust.py
@@ -230,17 +230,36 @@ class RustActionWriter:
             # of new lines, and one which is shifting an extra error token.
             # This might help remove the overhead of backtracking in addition
             # to make this backtracking visible through APS.
-            assert len(list(state.edges())) == 1
-            act, dest = next(state.edges())
             assert len(self.replay_args) == 0
-            assert -act.offset > 0
-            assert act.is_on_new_line == False
-            self.write("// {}", str(act))
-            self.write("if !parser.check_not_on_new_line({})? {{", -act.offset)
-            with indent(self):
-                self.write("return Ok(false);")
-            self.write("}")
-            self.write_epsilon_transition(dest)
+            assert first_act.offset == -1
+            if len(state.epsilon) == 1:
+                # Generate if-not-then-error code.
+                act, dest = next(state.edges())
+                test = "!" if act.is_on_new_line else ""
+                self.write("// {}", str(act))
+                self.write("if {}parser.is_on_new_line()? {{", test)
+                with indent(self):
+                    self.write("return Ok(false);")
+                self.write("}")
+                self.write_epsilon_transition(dest)
+            else:
+                # Generate if-else code
+                assert len(list(state.edges())) == 2
+                edges = state.edges()
+                true_act, true_dest = next(edges)
+                if not true_act.is_on_new_line:
+                    false_act, false_dest = true_act, true_dest
+                    true_act, true_dest = next(edges)
+                else:
+                    false_act, false_dest = next(edges)
+                self.write("// {} & {}", str(true_act), str(false_act))
+                self.write("if parser.is_on_new_line()? {")
+                with indent(self):
+                    self.write_epsilon_transition(true_dest)
+                self.write("} else {")
+                with indent(self):
+                    self.write_epsilon_transition(false_dest)
+                self.write("}")
         elif isinstance(first_act, FilterStates):
             if len(state.epsilon) == 1:
                 # This is an attempt to avoid huge unending compilations.

--- a/jsparagus/grammar.py
+++ b/jsparagus/grammar.py
@@ -1145,7 +1145,7 @@ class End:
 @dataclass(frozen=True)
 class ErrorSymbol:
     """Special grammar symbol that can be consumed to handle a syntax error."""
-    error_code: int
+    error_code: str
 
 
 Element = typing.Union[

--- a/jsparagus/lr0.py
+++ b/jsparagus/lr0.py
@@ -11,7 +11,7 @@ import collections
 from dataclasses import dataclass
 import typing
 
-from .actions import (Accept, Action, CheckNotOnNewLine, FunCall, Lookahead,
+from .actions import (Accept, Action, CheckLineTerminator, FunCall, Lookahead,
                       OutputExpr, Unwind, Reduce, Seq)
 from .ordered import OrderedFrozenSet
 from .grammar import (CallMethod, Element, End, ErrorSymbol, Grammar,
@@ -336,7 +336,7 @@ class LR0Generator:
                 # Check whether the following terminal is on a new line. If
                 # not, this would produce a syntax error. The argument is the
                 # terminal offset.
-                term = CheckNotOnNewLine()
+                term = CheckLineTerminator()
             elif isinstance(term, CallMethod):
                 funcalls: typing.List[Action] = []
                 pop = sum(1 for e in prod.rhs[:lr_item.offset] if on_stack(self.grammar.grammar, e))

--- a/jsparagus/lr0.py
+++ b/jsparagus/lr0.py
@@ -140,7 +140,7 @@ class LRItem:
 # A Term is the label on an edge from one state to another. It's normally a
 # terminal, nonterminal, or epsilon action. A state can also have a special
 # catchall edge, labeled with an ErrorSymbol.
-ShiftedTerm = typing.Union[str, Nt, ErrorSymbol]
+ShiftedTerm = typing.Union[str, End, Nt, ErrorSymbol]
 Term = typing.Union[ShiftedTerm, Action]
 
 

--- a/jsparagus/parse_table.py
+++ b/jsparagus/parse_table.py
@@ -1049,21 +1049,22 @@ class ParseTable:
         dead_end = self.get_state(OrderedFrozenSet())
 
         # Add Reduce ErrorSymbol("asi")
-        asi_nt = Nt(str(ErrorSymbol("asi")))
+        asi_nt = Nt("ASI")
+        asi_term = Seq([FunCall("asi", ()), Reduce(Unwind(asi_nt, 0, 0))])
         self.nonterminals.append(asi_nt)
         reduce_asi: typing.Dict[ShiftedTerm, StateAndTransitions] = {}
         for t in self.terminals:
             reduce_asi[t] = self.get_state(
-                OrderedFrozenSet(['ErrorSymbol("asi") ::= {} ·'.format(str(t)),
-                                  'ErrorSymbol("asi") ::= [LineTerminator here] {} ·'.format(str(t))]))
-            self.add_edge(reduce_asi[t], Reduce(Unwind(asi_nt, 0, 1)), dead_end.index)
+                OrderedFrozenSet(['ASI ::= {} ·'.format(str(t)),
+                                  'ASI ::= [LineTerminator here] {} ·'.format(str(t))]))
+            self.add_edge(reduce_asi[t], asi_term.shifted_action(t), dead_end.index)
 
         # Add CheckLineTerminator -> Reduce ErrorSymbol("asi")
         newline_asi_term = CheckLineTerminator(-1, True)
         newline_asi: typing.Dict[ShiftedTerm, StateAndTransitions] = {}
         for t in self.terminals:
             newline_asi[t] = self.get_state(
-                OrderedFrozenSet(['ErrorSymbol("asi") ::= [LineTerminator here] {} ·'.format(str(t))]),
+                OrderedFrozenSet(['ASI ::= [LineTerminator here] {} ·'.format(str(t))]),
                 OrderedFrozenSet([newline_asi_term]))
             self.add_edge(newline_asi[t], newline_asi_term, reduce_asi[t].index)
 


### PR DESCRIPTION
[ASI](https://tc39.es/ecma262/#sec-automatic-semicolon-insertion) is quite complex as it relates to "offensive tokens" and "restricted tokens", and it would verbose and complex to convert these to grammar rules.

These changes aim at fixing #623 by expanding the ASI rules, such that `lower_reduce_action` can reason about the fact that ASI move the current failing token to the replay list before reducing an `ErrorSymbol`.

By adding these rules to the parse table, we would be able of making optimization which would be crossing the presence of `CheckNotOnNewLine` (renamed to `CheckLineTerminator`), which would imply adding arguments to states which have a `CheckLineTerminator` as an out-going edges, and thus should be able to avoid usage of the replay list completely.

(This is a draft, as the generate file phase takes ~10 minutes)
