### PR TITLE
Update opcode for bug 1722002

### DIFF
--- a/crates/stencil/src/copy/Opcodes.h
+++ b/crates/stencil/src/copy/Opcodes.h
@@ -2426,10 +2426,11 @@
     /*
      * Check the return value in a derived class constructor.
      *
-     * -   If the current stack frame's `returnValue` is an object, do nothing.
+     * -   If the current stack frame's `returnValue` is an object, push
+     *     `returnValue` onto the stack.
      *
      * -   Otherwise, if the `returnValue` is undefined and `thisval` is an
-     *     object, store `thisval` in the `returnValue` slot.
+     *     object, push `thisval` onto the stack.
      *
      * -   Otherwise, throw a TypeError.
      *
@@ -2445,9 +2446,9 @@
      *   Category: Control flow
      *   Type: Return
      *   Operands:
-     *   Stack: thisval =>
+     *   Stack: thisval => rval
      */ \
-    MACRO(CheckReturn, check_return, NULL, 1, 1, 0, JOF_BYTE) \
+    MACRO(CheckReturn, check_return, NULL, 1, 1, 1, JOF_BYTE) \
     /*
      * Throw `exc`. (ノಠ益ಠ)ノ彡┴──┴
      *

--- a/crates/stencil/src/opcode.rs
+++ b/crates/stencil/src/opcode.rs
@@ -168,7 +168,7 @@ macro_rules! using_opcode_database {
                 (GetRval, get_rval, NULL, 1, 0, 1, JOF_BYTE),
                 (SetRval, set_rval, NULL, 1, 1, 0, JOF_BYTE),
                 (RetRval, ret_rval, NULL, 1, 0, 0, JOF_BYTE),
-                (CheckReturn, check_return, NULL, 1, 1, 0, JOF_BYTE),
+                (CheckReturn, check_return, NULL, 1, 1, 1, JOF_BYTE),
                 (Throw, throw_, NULL, 1, 1, 0, JOF_BYTE),
                 (ThrowMsg, throw_msg, NULL, 2, 0, 0, JOF_UINT8),
                 (ThrowSetConst, throw_set_const, NULL, 5, 0, 0, JOF_ATOM|JOF_NAME),


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1722002 changed the behavior of JSOp::CheckReturn.
we don't use `check_return`, so just updated Opcode.h

will be vendored in https://bugzilla.mozilla.org/show_bug.cgi?id=1723457