### PR TITLE
Update opcode for bug 1736060

### DIFF
--- a/crates/stencil/src/copy/Opcodes.h
+++ b/crates/stencil/src/copy/Opcodes.h
@@ -802,9 +802,9 @@
      *   Category: Expressions
      *   Type: Other expressions
      *   Operands:
-     *   Stack: moduleId => promise
+     *   Stack: moduleId, options => promise
      */ \
-    MACRO(DynamicImport, dynamic_import, NULL, 1, 1, 1, JOF_BYTE) \
+    MACRO(DynamicImport, dynamic_import, NULL, 1, 2, 1, JOF_BYTE) \
     /*
      * Push the `import.meta` object.
      *

--- a/crates/stencil/src/opcode.rs
+++ b/crates/stencil/src/opcode.rs
@@ -60,7 +60,7 @@ macro_rules! using_opcode_database {
                 (GlobalThis, global_this, NULL, 1, 0, 1, JOF_BYTE),
                 (NonSyntacticGlobalThis, non_syntactic_global_this, NULL, 1, 0, 1, JOF_BYTE),
                 (NewTarget, new_target, NULL, 1, 0, 1, JOF_BYTE),
-                (DynamicImport, dynamic_import, NULL, 1, 1, 1, JOF_BYTE),
+                (DynamicImport, dynamic_import, NULL, 1, 2, 1, JOF_BYTE),
                 (ImportMeta, import_meta, NULL, 1, 0, 1, JOF_BYTE),
                 (NewInit, new_init, NULL, 1, 0, 1, JOF_BYTE|JOF_IC),
                 (NewObject, new_object, NULL, 5, 0, 1, JOF_SHAPE|JOF_IC),


### PR DESCRIPTION
`JSOp::DynamicImport` is updated by https://bugzilla.mozilla.org/show_bug.cgi?id=1736060
we're not using it, so just updated the file.