### PR TITLE
Update opcodes for bug 1730843

### DIFF
--- a/crates/stencil/src/copy/Opcodes.h
+++ b/crates/stencil/src/copy/Opcodes.h
@@ -211,6 +211,9 @@
  *
  * [Index]
  *   [Constants]
+ *   [Compound primitives]
+ *     Record literals
+ *     Tuple literals
  *   [Expressions]
  *     Unary operators
  *     Binary operators
@@ -1528,6 +1531,94 @@
      *   Stack: => regexp
      */ \
     MACRO(RegExp, reg_exp, NULL, 5, 0, 1, JOF_REGEXP) \
+    /*
+     * Initialize a new record, preallocating `length` memory slots. `length` can still grow
+     * if needed, for example when using the spread operator.
+     *
+     * Implements: [RecordLiteral Evaluation][1] step 1.
+     *
+     * [1]: https://tc39.es/proposal-record-tuple/#sec-record-initializer-runtime-semantics-evaluation
+     *
+     *   Category: Compound primitives
+     *   Type: Record literals
+     *   Operands: uint32_t length
+     *   Stack: => rval
+     */ \
+    IF_RECORD_TUPLE(MACRO(InitRecord, init_record, NULL, 5, 0, 1, JOF_UINT32)) \
+    /*
+     * Add the last element in the stack to the preceding tuple.
+     *
+     * Implements: [AddPropertyIntoRecordEntriesList][1].
+     *
+     * [1]: https://tc39.es/proposal-record-tuple/#sec-addpropertyintorecordentrieslist
+     *
+     *   Category: Compound primitives
+     *   Type: Record literals
+     *   Operands:
+     *   Stack: record, key, value => record
+     */ \
+    IF_RECORD_TUPLE(MACRO(AddRecordProperty, add_record_property, NULL, 1, 3, 1, JOF_BYTE)) \
+    /*
+     * Add the last element in the stack to the preceding tuple.
+     *
+     * Implements: [RecordPropertyDefinitionEvaluation][1] for
+     *   RecordPropertyDefinition : ... AssignmentExpression
+     *
+     * [1]: https://tc39.es/proposal-record-tuple/#sec-addpropertyintorecordentrieslist
+     *
+     *   Category: Compound primitives
+     *   Type: Record literals
+     *   Operands:
+     *   Stack: record, value => record
+     */ \
+    IF_RECORD_TUPLE(MACRO(AddRecordSpread, add_record_spread, NULL, 1, 2, 1, JOF_BYTE)) \
+    /*
+     * Mark a record as "initialized", going from "write-only" mode to
+     * "read-only" mode.
+     *
+     *   Category: Compound primitives
+     *   Type: Record literals
+     *   Operands:
+     *   Stack: record => record
+     */ \
+    IF_RECORD_TUPLE(MACRO(FinishRecord, finish_record, NULL, 1, 1, 1, JOF_BYTE)) \
+    /*
+     * Initialize a new tuple, preallocating `length` memory slots. `length` can still grow
+     * if needed, for example when using the spread operator.
+     *
+     * Implements: [TupleLiteral Evaluation][1] step 1.
+     *
+     * [1]: https://tc39.es/proposal-record-tuple/#sec-tuple-initializer-runtime-semantics-evaluation
+     *
+     *   Category: Compound primitives
+     *   Type: Tuple literals
+     *   Operands: uint32_t length
+     *   Stack: => rval
+     */ \
+    IF_RECORD_TUPLE(MACRO(InitTuple, init_tuple, NULL, 5, 0, 1, JOF_UINT32)) \
+    /*
+     * Add the last element in the stack to the preceding tuple.
+     *
+     * Implements: [AddValueToTupleSequenceList][1].
+     *
+     * [1]: https://tc39.es/proposal-record-tuple/#sec-addvaluetotuplesequencelist
+     *
+     *   Category: Compound primitives
+     *   Type: Tuple literals
+     *   Operands:
+     *   Stack: tuple, element => tuple
+     */ \
+    IF_RECORD_TUPLE(MACRO(AddTupleElement, add_tuple_element, NULL, 1, 2, 1, JOF_BYTE)) \
+    /*
+     * Mark a tuple as "initialized", going from "write-only" mode to
+     * "read-only" mode.
+     *
+     *   Category: Compound primitives
+     *   Type: Tuple literals
+     *   Operands:
+     *   Stack: tuple => tuple
+     */ \
+    IF_RECORD_TUPLE(MACRO(FinishTuple, finish_tuple, NULL, 1, 1, 1, JOF_BYTE)) \
     /*
      * Push a new function object.
      *
@@ -3511,13 +3602,13 @@
  * a power of two.  Use this macro to do so.
  */
 #define FOR_EACH_TRAILING_UNUSED_OPCODE(MACRO) \
-  MACRO(228)                                   \
-  MACRO(229)                                   \
-  MACRO(230)                                   \
-  MACRO(231)                                   \
-  MACRO(232)                                   \
-  MACRO(233)                                   \
-  MACRO(234)                                   \
+  IF_RECORD_TUPLE(/* empty */, MACRO(228))     \
+  IF_RECORD_TUPLE(/* empty */, MACRO(229))     \
+  IF_RECORD_TUPLE(/* empty */, MACRO(230))     \
+  IF_RECORD_TUPLE(/* empty */, MACRO(231))     \
+  IF_RECORD_TUPLE(/* empty */, MACRO(232))     \
+  IF_RECORD_TUPLE(/* empty */, MACRO(233))     \
+  IF_RECORD_TUPLE(/* empty */, MACRO(234))     \
   MACRO(235)                                   \
   MACRO(236)                                   \
   MACRO(237)                                   \

--- a/crates/stencil/src/copy/StencilEnums.h
+++ b/crates/stencil/src/copy/StencilEnums.h
@@ -325,6 +325,11 @@ enum class MutableScriptFlagsEnum : uint32_t {
   HadUnboxFoldingBailout = 1 << 27,
 };
 
+// Retrievable source can be retrieved using the source hook (and therefore
+// need not be XDR'd, can be discarded if desired because it can always be
+// reconstituted later, etc.).
+enum class SourceRetrievable { No = 0, Yes };
+
 }  // namespace js
 
 #endif /* vm_StencilEnums_h */

--- a/update_stencil.py
+++ b/update_stencil.py
@@ -80,6 +80,11 @@ def extract_opcodes(paths):
     with open(paths['Opcodes.h'], 'r') as f:
         for line in f:
             line = line.strip()
+
+            if line.startswith('IF_RECORD_TUPLE('):
+                # Ignore Record and Tuple opcodes
+                continue
+
             if line.startswith('MACRO(') and ',' in line:
                 line = line[5:]
                 if line.endswith(' \\'):
@@ -593,11 +598,24 @@ def generate_emit_methods(out_f, opcodes, types):
         """))
 
 
-def update_emitter(path, types):
+def get_filtered_opcodes():
     sys.path.append(vm_dir)
     from jsopcode import get_opcodes
 
     _, opcodes = get_opcodes(args.PATH_TO_MOZILLA_CENTRAL)
+
+    filtered_opcodes = {}
+    for op, opcode in opcodes.items():
+        if opcode.type_name in ['Record literals', 'Tuple literals']:
+            continue
+
+        filtered_opcodes[op] = opcode
+
+    return filtered_opcodes
+
+
+def update_emitter(path, types):
+    opcodes = get_filtered_opcodes()
 
     tmppath = f'{path}.tmp'
 
@@ -630,10 +648,7 @@ def update_emitter(path, types):
 
 
 def update_function(path, types, flags):
-    sys.path.append(vm_dir)
-    from jsopcode import get_opcodes
-
-    _, opcodes = get_opcodes(args.PATH_TO_MOZILLA_CENTRAL)
+    opcodes = get_filtered_opcodes()
 
     tmppath = f'{path}.tmp'
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1730843 modified `Opcodes.h`, with extra macro to conditionally enable those opcodes for Record and Tuple.

there are 2 places that reads `Opcodes.h`, `m-c/js/src/vm/jsopcode.py` and `jsparagus/update_stencil.py`.

`m-c/js/src/vm/jsopcode.py`'s pattern ignores the extra macro, and those opcodes are included in the return value.
`jsparagus/update_stencil.py`'s pattern filtered out the opcodes with extra macro.
So that results in inconsistency, and the first patch here fixes it by filtering out Record and Tuple opcodes from the value returned from `m-c/js/src/vm/jsopcode.py`.
(eventually we could drop the code that parses Opcodes.h from `jsparagus/update_stencil.py`, but that's for other bug)
