### PR TITLE
Update opcode for bug 885514

### DIFF
--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -1035,11 +1035,6 @@ impl InstructionWriter {
         self.write_u24(resume_index);
     }
 
-    pub fn gosub(&mut self, forward_offset: BytecodeOffsetDiff) {
-        self.emit_op(Opcode::Gosub);
-        self.write_bytecode_offset_diff(forward_offset);
-    }
-
     pub fn finally(&mut self) {
         self.emit_op(Opcode::Finally);
     }

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -429,7 +429,7 @@ fn test_numbers_large() {
     assert_same_number("0xfffffffffffff", 4503599627370495.0);
     assert_not_implemented("0x10000000000000");
 
-    assert_not_implemented("4.9406564584124654417656879286822e-324");
+    assert_same_number("4.9406564584124654417656879286822e-324", 5e-324);
 }
 
 #[test]

--- a/crates/stencil/src/copy/BytecodeFormatFlags.h
+++ b/crates/stencil/src/copy/BytecodeFormatFlags.h
@@ -24,7 +24,7 @@ enum {
   JOF_ARGC = 10,        /* uint16_t argument count */
   JOF_QARG = 11,        /* function argument index */
   JOF_LOCAL = 12,       /* var or block-local variable */
-  JOF_RESUMEINDEX = 13, /* yield, await, or gosub resume index */
+  JOF_RESUMEINDEX = 13, /* yield, await, or retsub resume index */
   JOF_DOUBLE = 14,      /* inline DoubleValue */
   JOF_GCTHING = 15,     /* uint32_t generic gc-thing index */
   JOF_ATOM = 16,        /* uint32_t constant index */

--- a/crates/stencil/src/copy/Opcodes.h
+++ b/crates/stencil/src/copy/Opcodes.h
@@ -159,8 +159,6 @@
  *     The formula above is correct for the next instruction. The jump target
  *     has a stack depth that is 1 less.
  *
- * -   See `JSOp::Gosub` for another special case.
- *
  * -   The `JSOp::JumpTarget` instruction immediately following a `JSTRY_CATCH`
  *     or `JSTRY_FINALLY` span has the same stack depth as the `JSOp::Try`
  *     instruction that precedes the span.
@@ -2632,7 +2630,10 @@
     /*
      * Push `resumeIndex`.
      *
-     * This value must be used only by `JSOp::Gosub`, `JSOp::Finally`, and `JSOp::Retsub`.
+     * This value must be used only by `JSOp::Retsub`.
+     *
+     * The stack depth when retsub resumes at the given offset must
+     * agree with any other paths to that offset.
      *
      *   Category: Control flow
      *   Type: Exceptions
@@ -2641,86 +2642,28 @@
      */ \
     MACRO(ResumeIndex, resume_index, NULL, 4, 0, 1, JOF_RESUMEINDEX) \
     /*
-     * Jump to the start of a `finally` block.
-     *
-     * `JSOp::Gosub` is unusual: if the finally block finishes normally, it will
-     * reach the `JSOp::Retsub` instruction at the end, and control then
-     * "returns" to the `JSOp::Gosub` and picks up at the next instruction, like
-     * a function call but within a single script and stack frame. (It's named
-     * after the thing in BASIC.)
-     *
-     * We need this because a `try` block can terminate in several different
-     * ways: control can flow off the end, return, throw an exception, `break`
-     * with or without a label, or `continue`. Exceptions are handled
-     * separately; but all those success paths are written as bytecode, and
-     * each one needs to run the `finally` block before continuing with
-     * whatever they were doing. They use `JSOp::Gosub` for this. It is thus
-     * normal for multiple `Gosub` instructions in a script to target the same
-     * `finally` block.
-     *
-     * Rules: `forwardOffset` must be positive and must target a
-     * `JSOp::JumpTarget` instruction followed by `JSOp::Finally`. The
-     * instruction immediately following `JSOp::Gosub` in the script must be a
-     * `JSOp::JumpTarget` instruction, and `resumeIndex` must be the index into
-     * `script->resumeOffsets()` that points to that instruction.
-     *
-     * Note: This op doesn't actually push or pop any values. Its use count of
-     * 2 is a lie to make the stack depth math work for this very odd control
-     * flow instruction.
-     *
-     * `JSOp::Gosub` is considered to have two "successors": the target of
-     * `offset`, which is the actual next instruction to run; and the
-     * instruction immediately following `JSOp::Gosub`, even though it won't run
-     * until later. We define the successor graph this way in order to support
-     * knowing the stack depth at that instruction without first reading the
-     * whole `finally` block.
-     *
-     * The stack depth at that instruction is, as it happens, the current stack
-     * depth minus 2. So this instruction gets nuses == 2.
-     *
-     * Unfortunately there is a price to be paid in horribleness. When
-     * `JSOp::Gosub` runs, it leaves two values on the stack that the stack
-     * depth math doesn't know about. It jumps to the finally block, where
-     * `JSOp::Finally` again does nothing to the stack, but with a bogus def
-     * count of 2, restoring balance to the accounting. If `JSOp::Retsub` is
-     * reached, it pops the two values (for real this time) and control
-     * resumes at the instruction that follows JSOp::Gosub in memory.
-     *
-     *   Category: Control flow
-     *   Type: Exceptions
-     *   Operands: int32_t forwardOffset
-     *   Stack: false, resumeIndex =>
-     */ \
-    MACRO(Gosub, gosub, NULL, 5, 2, 0, JOF_JUMP) \
-    /*
-     * No-op instruction that marks the start of a `finally` block. This has a
-     * def count of 2, but the values are already on the stack (they're
-     * actually left on the stack by `JSOp::Gosub`).
-     *
-     * These two values must not be used except by `JSOp::Retsub`.
+     * No-op instruction that marks the start of a `finally` block.
      *
      *   Category: Control flow
      *   Type: Exceptions
      *   Operands:
-     *   Stack: => false, resumeIndex
+     *   Stack: =>
      */ \
-    MACRO(Finally, finally, NULL, 1, 0, 2, JOF_BYTE) \
+    MACRO(Finally, finally, NULL, 1, 0, 0, JOF_BYTE) \
     /*
-     * Jump back to the next instruction, or rethrow an exception, at the end
-     * of a `finally` block. See `JSOp::Gosub` for the explanation.
+     * Jump to the instruction at the offset given by
+     * `script->resumeOffsets(resumeIndex)`, in bytes from the start of the
+     * current script's bytecode.
      *
-     * If `throwing` is true, throw `v`. Otherwise, `v` must be a resume index;
-     * jump to the corresponding offset within the script.
-     *
-     * The two values popped must be the ones notionally pushed by
-     * `JSOp::Finally`.
+     * This is used at the end of finally blocks to jump to the correct
+     * continuation.
      *
      *   Category: Control flow
      *   Type: Exceptions
      *   Operands:
-     *   Stack: throwing, v =>
+     *   Stack: resumeIndex =>
      */ \
-    MACRO(Retsub, retsub, NULL, 1, 2, 0, JOF_BYTE) \
+    MACRO(Retsub, retsub, NULL, 1, 1, 0, JOF_BYTE) \
     /*
      * Push `MagicValue(JS_UNINITIALIZED_LEXICAL)`, a magic value used to mark
      * a binding as uninitialized.
@@ -3602,13 +3545,14 @@
  * a power of two.  Use this macro to do so.
  */
 #define FOR_EACH_TRAILING_UNUSED_OPCODE(MACRO) \
+  IF_RECORD_TUPLE(/* empty */, MACRO(227))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(228))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(229))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(230))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(231))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(232))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(233))     \
-  IF_RECORD_TUPLE(/* empty */, MACRO(234))     \
+  MACRO(234)                                   \
   MACRO(235)                                   \
   MACRO(236)                                   \
   MACRO(237)                                   \

--- a/crates/stencil/src/opcode.rs
+++ b/crates/stencil/src/opcode.rs
@@ -177,9 +177,8 @@ macro_rules! using_opcode_database {
                 (TryDestructuring, try_destructuring, NULL, 1, 0, 0, JOF_BYTE),
                 (Exception, exception, NULL, 1, 0, 1, JOF_BYTE),
                 (ResumeIndex, resume_index, NULL, 4, 0, 1, JOF_RESUMEINDEX),
-                (Gosub, gosub, NULL, 5, 2, 0, JOF_JUMP),
-                (Finally, finally, NULL, 1, 0, 2, JOF_BYTE),
-                (Retsub, retsub, NULL, 1, 2, 0, JOF_BYTE),
+                (Finally, finally, NULL, 1, 0, 0, JOF_BYTE),
+                (Retsub, retsub, NULL, 1, 1, 0, JOF_BYTE),
                 (Uninitialized, uninitialized, NULL, 1, 0, 1, JOF_BYTE),
                 (InitLexical, init_lexical, NULL, 4, 1, 1, JOF_LOCAL|JOF_NAME),
                 (InitGLexical, init_g_lexical, NULL, 5, 1, 1, JOF_ATOM|JOF_NAME|JOF_PROPINIT|JOF_GNAME|JOF_IC),
@@ -311,7 +310,7 @@ const JOF_QARG: u32 = 11;
 /// var or block-local variable
 const JOF_LOCAL: u32 = 12;
 
-/// yield, await, or gosub resume index
+/// yield, await, or retsub resume index
 const JOF_RESUMEINDEX: u32 = 13;
 
 /// inline DoubleValue


### PR DESCRIPTION
[bug 885514](https://bugzilla.mozilla.org/show_bug.cgi?id=885514) simplified gosub/finally/retsub.
we don't use them yet, so just updated opcode.

Also, fixed `test_numbers_large` test not to fail for unexpected pass