### PR TITLE
Update opcode for bug 1282976

### DIFF
--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -754,11 +754,6 @@ impl InstructionWriter {
         self.write_g_c_thing_index(func_index);
     }
 
-    pub fn lambda_arrow(&mut self, func_index: GCThingIndex) {
-        self.emit_op(Opcode::LambdaArrow);
-        self.write_g_c_thing_index(func_index);
-    }
-
     pub fn set_fun_name(&mut self, prefix_kind: FunctionPrefixKind) {
         self.emit_op(Opcode::SetFunName);
         self.write_u8(prefix_kind as u8);

--- a/crates/stencil/src/copy/Opcodes.h
+++ b/crates/stencil/src/copy/Opcodes.h
@@ -788,9 +788,7 @@
      *
      * The result is a constructor or `undefined`.
      *
-     * This must be used only in scripts where `new.target` is allowed:
-     * non-arrow function scripts and other scripts that have a non-arrow
-     * function script on the scope chain.
+     * This must be used only in non-arrow function scripts.
      *
      * Implements: [GetNewTarget][1].
      *
@@ -1632,10 +1630,8 @@
      *
      * The new function inherits the current environment chain.
      *
-     * Used to create most JS functions. Notable exceptions are arrow functions
-     * and derived or default class constructors.
-     *
-     * The function indicated by `funcIndex` must be a non-arrow function.
+     * Used to create most JS functions. Notable exceptions are derived or
+     * default class constructors.
      *
      * Implements: [InstantiateFunctionObject][1], [Evaluation for
      * *FunctionExpression*][2], and so on.
@@ -1649,22 +1645,6 @@
      *   Stack: => fn
      */ \
     MACRO(Lambda, lambda, NULL, 5, 0, 1, JOF_OBJECT) \
-    /*
-     * Push a new arrow function.
-     *
-     * `newTarget` matters only if the arrow function uses the expression
-     * `new.target`. It should be the current value of `new.target`, so that
-     * the arrow function inherits `new.target` from the enclosing scope. (If
-     * `new.target` is illegal here, the value doesn't matter; use `null`.)
-     *
-     * The function indicated by `funcIndex` must be an arrow function.
-     *
-     *   Category: Functions
-     *   Type: Creating functions
-     *   Operands: uint32_t funcIndex
-     *   Stack: newTarget => arrowFn
-     */ \
-    MACRO(LambdaArrow, lambda_arrow, NULL, 5, 1, 1, JOF_OBJECT) \
     /*
      * Set the name of a function.
      *
@@ -3547,13 +3527,14 @@
  * a power of two.  Use this macro to do so.
  */
 #define FOR_EACH_TRAILING_UNUSED_OPCODE(MACRO) \
+  IF_RECORD_TUPLE(/* empty */, MACRO(225))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(226))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(227))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(228))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(229))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(230))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(231))     \
-  IF_RECORD_TUPLE(/* empty */, MACRO(232))     \
+  MACRO(232)                                   \
   MACRO(233)                                   \
   MACRO(234)                                   \
   MACRO(235)                                   \

--- a/crates/stencil/src/copy/StencilEnums.h
+++ b/crates/stencil/src/copy/StencilEnums.h
@@ -247,6 +247,11 @@ enum class ImmutableScriptFlagsEnum : uint32_t {
   // Large self-hosted methods that should be inlined anyway by the JIT for
   // performance reasons can be marked with this flag.
   IsInlinableLargeFunction = 1 << 28,
+
+  // This function has an internal .newTarget binding and we need to emit
+  // JSOp::NewTarget in the prologue to initialize it. This binding may be
+  // used directly for "new.target", or indirectly (e.g. in super() calls).
+  FunctionHasNewTargetBinding = 1 << 29,
 };
 
 enum class MutableScriptFlagsEnum : uint32_t {

--- a/crates/stencil/src/opcode.rs
+++ b/crates/stencil/src/opcode.rs
@@ -115,7 +115,6 @@ macro_rules! using_opcode_database {
                 (Hole, hole, NULL, 1, 0, 1, JOF_BYTE),
                 (RegExp, reg_exp, NULL, 5, 0, 1, JOF_REGEXP),
                 (Lambda, lambda, NULL, 5, 0, 1, JOF_OBJECT),
-                (LambdaArrow, lambda_arrow, NULL, 5, 1, 1, JOF_OBJECT),
                 (SetFunName, set_fun_name, NULL, 2, 2, 1, JOF_UINT8),
                 (InitHomeObject, init_home_object, NULL, 1, 2, 1, JOF_BYTE),
                 (CheckClassHeritage, check_class_heritage, NULL, 1, 1, 1, JOF_BYTE),

--- a/crates/stencil/src/script.rs
+++ b/crates/stencil/src/script.rs
@@ -72,6 +72,8 @@ pub enum ImmutableScriptFlagsEnum {
     HasMappedArgsObj = 1 << 27,
     #[allow(dead_code)]
     IsInlinableLargeFunction = 1 << 28,
+    #[allow(dead_code)]
+    FunctionHasNewTargetBinding = 1 << 29,
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
[bug 1282976](https://bugzilla.mozilla.org/show_bug.cgi?id=1282976) removed `JSOp::LambdaArrow`, and added `FunctionHasNewTargetBinding` flag for `new.target`.
we don't support them, so no change except the definition.