### PR TITLE
Bump opcode for Bug 1766730

### DIFF
--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -1017,17 +1017,8 @@ impl InstructionWriter {
         self.emit_op(Opcode::Exception);
     }
 
-    pub fn resume_index(&mut self, resume_index: u24) {
-        self.emit_op(Opcode::ResumeIndex);
-        self.write_u24(resume_index);
-    }
-
     pub fn finally(&mut self) {
         self.emit_op(Opcode::Finally);
-    }
-
-    pub fn retsub(&mut self) {
-        self.emit_op(Opcode::Retsub);
     }
 
     pub fn uninitialized(&mut self) {

--- a/crates/stencil/src/copy/BytecodeFormatFlags.h
+++ b/crates/stencil/src/copy/BytecodeFormatFlags.h
@@ -24,7 +24,7 @@ enum {
   JOF_ARGC = 10,        /* uint16_t argument count */
   JOF_QARG = 11,        /* function argument index */
   JOF_LOCAL = 12,       /* var or block-local variable */
-  JOF_RESUMEINDEX = 13, /* yield, await, or retsub resume index */
+  JOF_RESUMEINDEX = 13, /* yield or await resume index */
   JOF_DOUBLE = 14,      /* inline DoubleValue */
   JOF_GCTHING = 15,     /* uint32_t generic gc-thing index */
   JOF_ATOM = 16,        /* uint32_t constant index */

--- a/crates/stencil/src/copy/Opcodes.h
+++ b/crates/stencil/src/copy/Opcodes.h
@@ -2610,20 +2610,6 @@
      */ \
     MACRO(Exception, exception, NULL, 1, 0, 1, JOF_BYTE) \
     /*
-     * Push `resumeIndex`.
-     *
-     * This value must be used only by `JSOp::Retsub`.
-     *
-     * The stack depth when retsub resumes at the given offset must
-     * agree with any other paths to that offset.
-     *
-     *   Category: Control flow
-     *   Type: Exceptions
-     *   Operands: uint24_t resumeIndex
-     *   Stack: => resumeIndex
-     */ \
-    MACRO(ResumeIndex, resume_index, NULL, 4, 0, 1, JOF_RESUMEINDEX) \
-    /*
      * No-op instruction that marks the start of a `finally` block.
      *
      *   Category: Control flow
@@ -2632,20 +2618,6 @@
      *   Stack: =>
      */ \
     MACRO(Finally, finally, NULL, 1, 0, 0, JOF_BYTE) \
-    /*
-     * Jump to the instruction at the offset given by
-     * `script->resumeOffsets(resumeIndex)`, in bytes from the start of the
-     * current script's bytecode.
-     *
-     * This is used at the end of finally blocks to jump to the correct
-     * continuation.
-     *
-     *   Category: Control flow
-     *   Type: Exceptions
-     *   Operands:
-     *   Stack: resumeIndex =>
-     */ \
-    MACRO(Retsub, retsub, NULL, 1, 1, 0, JOF_BYTE) \
     /*
      * Push `MagicValue(JS_UNINITIALIZED_LEXICAL)`, a magic value used to mark
      * a binding as uninitialized.
@@ -3527,13 +3499,15 @@
  * a power of two.  Use this macro to do so.
  */
 #define FOR_EACH_TRAILING_UNUSED_OPCODE(MACRO) \
+  IF_RECORD_TUPLE(/* empty */, MACRO(223))     \
+  IF_RECORD_TUPLE(/* empty */, MACRO(224))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(225))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(226))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(227))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(228))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(229))     \
-  IF_RECORD_TUPLE(/* empty */, MACRO(230))     \
-  IF_RECORD_TUPLE(/* empty */, MACRO(231))     \
+  MACRO(230)                                   \
+  MACRO(231)                                   \
   MACRO(232)                                   \
   MACRO(233)                                   \
   MACRO(234)                                   \

--- a/crates/stencil/src/opcode.rs
+++ b/crates/stencil/src/opcode.rs
@@ -174,9 +174,7 @@ macro_rules! using_opcode_database {
                 (Try, try_, NULL, 1, 0, 0, JOF_BYTE),
                 (TryDestructuring, try_destructuring, NULL, 1, 0, 0, JOF_BYTE),
                 (Exception, exception, NULL, 1, 0, 1, JOF_BYTE),
-                (ResumeIndex, resume_index, NULL, 4, 0, 1, JOF_RESUMEINDEX),
                 (Finally, finally, NULL, 1, 0, 0, JOF_BYTE),
-                (Retsub, retsub, NULL, 1, 1, 0, JOF_BYTE),
                 (Uninitialized, uninitialized, NULL, 1, 0, 1, JOF_BYTE),
                 (InitLexical, init_lexical, NULL, 4, 1, 1, JOF_LOCAL|JOF_NAME),
                 (InitGLexical, init_g_lexical, NULL, 5, 1, 1, JOF_ATOM|JOF_NAME|JOF_PROPINIT|JOF_GNAME|JOF_IC),
@@ -308,7 +306,7 @@ const JOF_QARG: u32 = 11;
 /// var or block-local variable
 const JOF_LOCAL: u32 = 12;
 
-/// yield, await, or retsub resume index
+/// yield or await resume index
 const JOF_RESUMEINDEX: u32 = 13;
 
 /// inline DoubleValue


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1766730 removed JSOp::Retsub and JSOp::ResumeIndex.
there's no consumer in jsparagus, so just updated the definition.