### PR TITLE
Handle new.target (fixed #660)

### DIFF
--- a/crates/scope/src/builder.rs
+++ b/crates/scope/src/builder.rs
@@ -3454,8 +3454,9 @@ impl ScopeDataMapBuilder {
     }
 
     pub fn on_new_target(&mut self) {
-        let fun_stencil = self.function_stencil_builder.current_mut();
-        fun_stencil.set_function_has_new_target_binding();
+        if let Some(fun_stencil) = self.function_stencil_builder.maybe_current_mut() {
+            fun_stencil.set_function_has_new_target_binding()
+        }
     }
 }
 

--- a/crates/scope/src/builder.rs
+++ b/crates/scope/src/builder.rs
@@ -3452,6 +3452,11 @@ impl ScopeDataMapBuilder {
         // FIXME: NewDeclarativeEnvironment in for case block
         self.set_error(ScopeBuildError::NotImplemented("switch"));
     }
+
+    pub fn on_new_target(&mut self) {
+        let fun_stencil = self.function_stencil_builder.current_mut();
+        fun_stencil.set_function_has_new_target_binding();
+    }
 }
 
 pub struct ScopeDataMapAndScriptStencilList {

--- a/crates/scope/src/pass.rs
+++ b/crates/scope/src/pass.rs
@@ -366,4 +366,8 @@ impl<'alloc> Pass<'alloc> for ScopePass<'alloc> {
     ) {
         self.builder.on_switch();
     }
+
+    fn visit_enum_expression_variant_new_target_expression(&mut self) {
+        self.builder.on_new_target();
+    }
 }

--- a/crates/stencil/src/script.rs
+++ b/crates/stencil/src/script.rs
@@ -449,6 +449,12 @@ impl ScriptStencil {
             .set(ImmutableScriptFlagsEnum::HasMappedArgsObj);
     }
 
+    pub fn set_function_has_new_target_binding(&mut self) {
+        debug_assert!(self.is_lazy_function());
+        self.immutable_flags
+            .set(ImmutableScriptFlagsEnum::FunctionHasNewTargetBinding);
+    }
+
     pub fn is_arrow_function(&self) -> bool {
         self.is_function() && self.fun_flags.is_arrow()
     }


### PR DESCRIPTION
`ImmutableScriptFlagsEnum::FunctionHasNewTargetBinding` must be set for lazy function if it contains `new.target`.

jsparagus doesn't support `new.target`, but the fallback happens only when delazifying, and the compilation of the enclosing script finishes successfully, and not-setting the flag causes wrong delazification.