### PR TITLE
Update opcode for bug 1781061

### DIFF
--- a/crates/emitter/src/emitter.rs
+++ b/crates/emitter/src/emitter.rs
@@ -804,6 +804,11 @@ impl InstructionWriter {
         self.write_u16(argc);
     }
 
+    pub fn call_content_iter(&mut self, argc: u16) {
+        self.emit_argc_op(Opcode::CallContentIter, argc);
+        self.write_u16(argc);
+    }
+
     pub fn call_ignores_rv(&mut self, argc: u16) {
         self.emit_argc_op(Opcode::CallIgnoresRv, argc);
         self.write_u16(argc);

--- a/crates/stencil/src/copy/Opcodes.h
+++ b/crates/stencil/src/copy/Opcodes.h
@@ -1752,6 +1752,9 @@
      * iterable") rather than `JSMSG_NOT_FUNCTION` ("x[Symbol.iterator] is not
      * a function"). The `argc` operand must be 0 for this variation.
      *
+     * `JSOp::CallContentIter` is `JSOp::CallContent` variant of
+     * `JSOp::CallIter`.
+     *
      * `JSOp::CallIgnoresRv` hints to the VM that the return value is ignored.
      * This allows alternate faster implementations to be used that avoid
      * unnecesary allocations.
@@ -1768,6 +1771,7 @@
     MACRO(Call, call, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_IC) \
     MACRO(CallContent, call_content, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_IC) \
     MACRO(CallIter, call_iter, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_IC) \
+    MACRO(CallContentIter, call_content_iter, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_IC) \
     MACRO(CallIgnoresRv, call_ignores_rv, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_IC) \
     /*
      * Like `JSOp::Call`, but the arguments are provided in an array rather than
@@ -3527,14 +3531,13 @@
  * a power of two.  Use this macro to do so.
  */
 #define FOR_EACH_TRAILING_UNUSED_OPCODE(MACRO) \
-  IF_RECORD_TUPLE(/* empty */, MACRO(226))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(227))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(228))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(229))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(230))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(231))     \
   IF_RECORD_TUPLE(/* empty */, MACRO(232))     \
-  MACRO(233)                                   \
+  IF_RECORD_TUPLE(/* empty */, MACRO(233))     \
   MACRO(234)                                   \
   MACRO(235)                                   \
   MACRO(236)                                   \

--- a/crates/stencil/src/opcode.rs
+++ b/crates/stencil/src/opcode.rs
@@ -124,6 +124,7 @@ macro_rules! using_opcode_database {
                 (Call, call, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_IC),
                 (CallContent, call_content, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_IC),
                 (CallIter, call_iter, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_IC),
+                (CallContentIter, call_content_iter, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_IC),
                 (CallIgnoresRv, call_ignores_rv, NULL, 3, -1, 1, JOF_ARGC|JOF_INVOKE|JOF_IC),
                 (SpreadCall, spread_call, NULL, 1, 3, 1, JOF_BYTE|JOF_INVOKE|JOF_SPREAD|JOF_IC),
                 (OptimizeSpreadCall, optimize_spread_call, NULL, 1, 1, 1, JOF_BYTE|JOF_IC),


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1781061 added `JSOp::CallContentIter`.
It's mix of `JSOp::CallContent` and `JSOp::CallIter`, and it's used only in self-hosted JS,
and jsparagus doesn't use it.